### PR TITLE
fix: enforce strong jwt secret

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -20,7 +20,13 @@ impl Config {
             env::var("DATABASE_URL").unwrap_or_else(|_| "sqlite:./timekeeper.db".to_string());
 
         let jwt_secret = env::var("JWT_SECRET")
-            .unwrap_or_else(|_| "your-secret-key-change-this-in-production".to_string());
+            .map_err(|_| anyhow!("JWT_SECRET must be set and at least 32 characters long"))?;
+        if jwt_secret.len() < 32 {
+            return Err(anyhow!(
+                "JWT_SECRET must be at least 32 characters long (current length: {})",
+                jwt_secret.len()
+            ));
+        }
 
         let jwt_expiration_hours = env::var("JWT_EXPIRATION_HOURS")
             .unwrap_or_else(|_| "1".to_string())

--- a/env.example
+++ b/env.example
@@ -1,5 +1,5 @@
 DATABASE_URL=postgres://timekeeper:timekeeper@localhost:5432/timekeeper
-JWT_SECRET=your-secret-key-change-this-in-production
+JWT_SECRET=please-generate-a-32-char-minimum-secret-value
 JWT_EXPIRATION_HOURS=1
 REFRESH_TOKEN_EXPIRATION_DAYS=7
 APP_TIMEZONE=Asia/Tokyo


### PR DESCRIPTION
## Summary
- require JWT_SECRET to be set and at least 32 characters long during config load
- update env.example to document the stronger secret requirement

## Testing
- cd backend; cargo test