### PR TITLE
fix: sanitize csv exports

### DIFF
--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -15,7 +15,7 @@ use crate::{
         break_record::BreakRecordResponse,
         user::{CreateUser, UpdateUser, User, UserResponse},
     },
-    utils::{password::hash_password, time},
+    utils::{csv::append_csv_row, password::hash_password, time},
 };
 
 pub async fn get_users(
@@ -662,29 +662,53 @@ pub async fn export_data(
 
     // Convert to CSV format
     let mut csv_data = String::new();
-    csv_data.push_str("Username,Full Name,Date,Clock In,Clock Out,Total Hours,Status\n");
+    append_csv_row(
+        &mut csv_data,
+        &[
+            "Username".to_string(),
+            "Full Name".to_string(),
+            "Date".to_string(),
+            "Clock In".to_string(),
+            "Clock Out".to_string(),
+            "Total Hours".to_string(),
+            "Status".to_string(),
+        ],
+    );
 
     for record in data {
-        csv_data.push_str(&format!(
-            "{},{},{},{},{},{},{}\n",
-            record.try_get::<String, _>("username").unwrap_or_default(),
-            record.try_get::<String, _>("full_name").unwrap_or_default(),
-            record.try_get::<String, _>("date").unwrap_or_default(),
-            record
-                .try_get::<Option<chrono::NaiveDateTime>, _>("clock_in_time")
-                .ok()
-                .flatten()
-                .map(|t| t.format("%H:%M:%S").to_string())
-                .unwrap_or_default(),
-            record
-                .try_get::<Option<chrono::NaiveDateTime>, _>("clock_out_time")
-                .ok()
-                .flatten()
-                .map(|t| t.format("%H:%M:%S").to_string())
-                .unwrap_or_default(),
-            record.try_get::<f64, _>("total_work_hours").unwrap_or(0.0),
-            record.try_get::<String, _>("status").unwrap_or_default(),
-        ));
+        let username = record.try_get::<String, _>("username").unwrap_or_default();
+        let full_name = record.try_get::<String, _>("full_name").unwrap_or_default();
+        let date = record.try_get::<String, _>("date").unwrap_or_default();
+        let clock_in = record
+            .try_get::<Option<chrono::NaiveDateTime>, _>("clock_in_time")
+            .ok()
+            .flatten()
+            .map(|t| t.format("%H:%M:%S").to_string())
+            .unwrap_or_default();
+        let clock_out = record
+            .try_get::<Option<chrono::NaiveDateTime>, _>("clock_out_time")
+            .ok()
+            .flatten()
+            .map(|t| t.format("%H:%M:%S").to_string())
+            .unwrap_or_default();
+        let total_hours = record
+            .try_get::<f64, _>("total_work_hours")
+            .map(|h| format!("{:.2}", h))
+            .unwrap_or_else(|_| "0.00".to_string());
+        let status = record.try_get::<String, _>("status").unwrap_or_default();
+
+        append_csv_row(
+            &mut csv_data,
+            &[
+                username,
+                full_name,
+                date,
+                clock_in,
+                clock_out,
+                total_hours,
+                status,
+            ],
+        );
     }
 
     Ok(Json(json!({

--- a/backend/src/handlers/attendance.rs
+++ b/backend/src/handlers/attendance.rs
@@ -18,7 +18,7 @@ use crate::{
         break_record::{BreakRecord, BreakRecordResponse},
         user::User,
     },
-    utils::time,
+    utils::{csv::append_csv_row, time},
 };
 
 #[derive(Debug, Deserialize)]
@@ -668,8 +668,19 @@ pub async fn export_my_attendance(
         )
     })?;
 
-    let mut csv_data =
-        String::from("Username,Full Name,Date,Clock In,Clock Out,Total Hours,Status\n");
+    let mut csv_data = String::new();
+    append_csv_row(
+        &mut csv_data,
+        &[
+            "Username".to_string(),
+            "Full Name".to_string(),
+            "Date".to_string(),
+            "Clock In".to_string(),
+            "Clock Out".to_string(),
+            "Total Hours".to_string(),
+            "Status".to_string(),
+        ],
+    );
     for row in rows {
         let username = row.try_get::<String, _>("username").unwrap_or_default();
         let full_name = row.try_get::<String, _>("full_name").unwrap_or_default();
@@ -689,13 +700,24 @@ pub async fn export_my_attendance(
             .flatten()
             .map(|t| t.format("%H:%M:%S").to_string())
             .unwrap_or_default();
-        let total_hours = row.try_get::<f64, _>("total_work_hours").unwrap_or(0.0);
+        let total_hours = row
+            .try_get::<f64, _>("total_work_hours")
+            .map(|h| format!("{:.2}", h))
+            .unwrap_or_else(|_| "0.00".to_string());
         let status = row.try_get::<String, _>("status").unwrap_or_default();
 
-        csv_data.push_str(&format!(
-            "{},{},{},{},{},{:.2},{}\n",
-            username, full_name, date, clock_in, clock_out, total_hours, status
-        ));
+        append_csv_row(
+            &mut csv_data,
+            &[
+                username,
+                full_name,
+                date,
+                clock_in,
+                clock_out,
+                total_hours,
+                status,
+            ],
+        );
     }
 
     Ok(Json(json!({

--- a/backend/src/utils/csv.rs
+++ b/backend/src/utils/csv.rs
@@ -1,0 +1,21 @@
+fn needs_formula_guard(value: &str) -> bool {
+    matches!(value.chars().next(), Some('=' | '+' | '-' | '@'))
+}
+
+fn escape_cell(value: &str) -> String {
+    let mut sanitized = value.replace('"', "\"\"");
+    if needs_formula_guard(&sanitized) {
+        sanitized.insert(0, '\'');
+    }
+    format!("\"{}\"", sanitized)
+}
+
+pub fn append_csv_row(buffer: &mut String, fields: &[String]) {
+    for (idx, field) in fields.iter().enumerate() {
+        if idx > 0 {
+            buffer.push(',');
+        }
+        buffer.push_str(&escape_cell(field));
+    }
+    buffer.push('\n');
+}

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -1,7 +1,9 @@
+pub mod csv;
 pub mod jwt;
 pub mod password;
 pub mod time;
 
+pub use csv::*;
 pub use jwt::*;
 pub use password::*;
 pub use time::*;


### PR DESCRIPTION
## Summary
- add a shared CSV writer that quotes cells, escapes quotes, and prefixes formula characters
- update admin and self-service exports to use the safer helper

## Testing
- cd backend; cargo test