### PR TITLE
fix: align request queries with DB schema

### DIFF
--- a/backend/migrations/015_update_overtime_planned_hours.sql
+++ b/backend/migrations/015_update_overtime_planned_hours.sql
@@ -1,0 +1,4 @@
+-- Ensure overtime planned_hours matches backend f64 expectations.
+ALTER TABLE overtime_requests
+    ALTER COLUMN planned_hours TYPE DOUBLE PRECISION
+    USING planned_hours::DOUBLE PRECISION;

--- a/backend/src/handlers/admin.rs
+++ b/backend/src/handlers/admin.rs
@@ -360,7 +360,8 @@ pub async fn list_requests(
             .build_query_as::<crate::models::leave_request::LeaveRequest>()
             .fetch_all(&pool)
             .await
-            .map_err(|_| {
+            .map_err(|err| {
+                tracing::error!(error = %err, "failed to list leave requests");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(json!({"error":"Database error"})),
@@ -385,7 +386,8 @@ pub async fn list_requests(
             .build_query_as::<crate::models::overtime_request::OvertimeRequest>()
             .fetch_all(&pool)
             .await
-            .map_err(|_| {
+            .map_err(|err| {
+                tracing::error!(error = %err, "failed to list overtime requests");
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(json!({"error":"Database error"})),

--- a/backend/src/handlers/requests.rs
+++ b/backend/src/handlers/requests.rs
@@ -149,7 +149,12 @@ pub async fn get_my_requests(
     .bind(&user_id)
     .fetch_all(&pool)
     .await
-    .map_err(|_| {
+    .map_err(|err| {
+        tracing::error!(
+            error = %err,
+            user_id = %user_id,
+            "failed to fetch leave_requests in get_my_requests"
+        );
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": "Database error"})),
@@ -163,7 +168,12 @@ pub async fn get_my_requests(
     .bind(&user_id)
     .fetch_all(&pool)
     .await
-    .map_err(|_| {
+    .map_err(|err| {
+        tracing::error!(
+            error = %err,
+            user_id = %user_id,
+            "failed to fetch overtime_requests in get_my_requests"
+        );
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({"error": "Database error"})),

--- a/backend/tests/requests_api.rs
+++ b/backend/tests/requests_api.rs
@@ -1,0 +1,91 @@
+use axum::{
+    extract::{Query, State},
+    Extension,
+};
+use chrono::NaiveDate;
+use serde_json::Value;
+use sqlx::PgPool;
+use timekeeper_backend::{
+    handlers::{
+        admin::{list_requests, RequestListQuery},
+        requests::get_my_requests,
+    },
+    models::{
+        leave_request::LeaveType,
+        user::UserRole,
+    },
+};
+
+mod support;
+use support::{
+    seed_leave_request, seed_overtime_request, seed_user, test_config,
+};
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt::try_init();
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn get_my_requests_returns_leave_and_overtime(pool: PgPool) {
+    init_tracing();
+    let config = test_config();
+    let user = seed_user(&pool, UserRole::Employee, false).await;
+    let date = NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+    seed_leave_request(&pool, &user.id, LeaveType::Annual, date, date).await;
+    seed_overtime_request(&pool, &user.id, date, 1.5).await;
+
+    let response =
+        get_my_requests(State((pool.clone(), config)), Extension(user.clone())).await;
+
+    let payload: Value = response.expect("get_my_requests ok").0;
+    let leave = payload
+        .get("leave_requests")
+        .and_then(|v| v.as_array())
+        .expect("leave list");
+    let overtime = payload
+        .get("overtime_requests")
+        .and_then(|v| v.as_array())
+        .expect("overtime list");
+    assert_eq!(leave.len(), 1);
+    assert_eq!(overtime.len(), 1);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn admin_list_requests_includes_seeded_records(pool: PgPool) {
+    init_tracing();
+    let config = test_config();
+    let admin = seed_user(&pool, UserRole::Admin, false).await;
+    let employee = seed_user(&pool, UserRole::Employee, false).await;
+    let date = NaiveDate::from_ymd_opt(2025, 2, 1).unwrap();
+    seed_leave_request(&pool, &employee.id, LeaveType::Sick, date, date).await;
+    seed_overtime_request(&pool, &employee.id, date, 2.0).await;
+
+    let query = RequestListQuery {
+        status: None,
+        r#type: None,
+        user_id: None,
+        from: None,
+        to: None,
+        page: Some(1),
+        per_page: Some(20),
+    };
+
+    let response = list_requests(
+        State((pool.clone(), config)),
+        Extension(admin.clone()),
+        Query(query),
+    )
+    .await;
+
+    let payload: Value = response.expect("list_requests ok").0;
+    let leave = payload
+        .get("leave_requests")
+        .and_then(|v| v.as_array())
+        .expect("leave array");
+    let overtime = payload
+        .get("overtime_requests")
+        .and_then(|v| v.as_array())
+        .expect("overtime array");
+    assert!(!leave.is_empty());
+    assert!(!overtime.is_empty());
+}


### PR DESCRIPTION
- ログ強化: `/api/requests/me` と `/api/admin/requests` のクエリ失敗時に `tracing::error!` へ詳細を出力し、`500 {"error":"Database error"}` の発生要因を即時に把握できるようにした。
- スキーマ修正: `overtime_requests.planned_hours` を `REAL` から `DOUBLE PRECISION` に変更するマイグレーション `015_update_overtime_planned_hours.sql` を追加し、Rust 側 `f64` との型不一致を解消。
- テスト追加: leave / overtime のデータをシードできるテスト helper を整備し、`GET /api/requests/me` と `GET /api/admin/requests` が正常に 200 を返す統合テスト `backend/tests/requests_api.rs` を追加。

## Testing
```bash
cargo test -p timekeeper-backend
```

Notes for Reviewers
- 新マイグレーション適用 (sqlx migrate run) が必要です。
- 500 エラー再発時にはバックエンドログに failed to fetch ... が出力されるので、実環境でも RUST_LOG=timekeeper_backend=debug,sqlx=error などで確認できます。