### PR TITLE
Refactor holiday service calendar loading

### DIFF
--- a/backend/src/services/holiday.rs
+++ b/backend/src/services/holiday.rs
@@ -1,5 +1,7 @@
-use chrono::{Datelike, NaiveDate};
-use sqlx::PgPool;
+use std::collections::{BTreeSet, HashMap};
+
+use chrono::{Datelike, Duration, NaiveDate};
+use sqlx::{PgPool, Row};
 
 #[derive(Clone)]
 pub struct HolidayService {
@@ -16,72 +18,11 @@ impl HolidayService {
         date: NaiveDate,
         user_id: Option<&str>,
     ) -> sqlx::Result<HolidayDecision> {
-        if let Some(user_id) = user_id {
-            if let Some(exception) = sqlx::query!(
-                r#"
-                SELECT override
-                FROM holiday_exceptions
-                WHERE user_id = $1 AND exception_date = $2
-                "#,
-                user_id,
-                date
-            )
-            .fetch_optional(&self.pool)
-            .await?
-            {
-                return Ok(HolidayDecision {
-                    is_holiday: exception.r#override,
-                    reason: HolidayReason::ExceptionOverride,
-                });
-            }
-        }
-
-        let public = sqlx::query_scalar!(
-            r#"
-            SELECT 1 as value
-            FROM holidays
-            WHERE holiday_date = $1
-            LIMIT 1
-            "#,
-            date
-        )
-        .fetch_optional(&self.pool)
-        .await?;
-
-        if public.is_some() {
-            return Ok(HolidayDecision {
-                is_holiday: true,
-                reason: HolidayReason::PublicHoliday,
-            });
-        }
-
-        let weekday = date.weekday().num_days_from_monday() as i16;
-        let weekly = sqlx::query_scalar!(
-            r#"
-            SELECT 1 as value
-            FROM weekly_holidays
-            WHERE weekday = $1
-              AND enforced_from <= $2
-              AND (enforced_to IS NULL OR enforced_to >= $2)
-            LIMIT 1
-            "#,
-            weekday,
-            date
-        )
-        .fetch_optional(&self.pool)
-        .await?;
-
-        if weekly.is_some() {
-            return Ok(HolidayDecision {
-                is_holiday: true,
-                reason: HolidayReason::WeeklyHoliday,
-            });
-        }
-
-        Ok(HolidayDecision {
-            is_holiday: false,
-            reason: HolidayReason::None,
-        })
+        let end = date
+            .succ_opt()
+            .ok_or_else(|| sqlx::Error::Protocol("date overflow".into()))?;
+        let sources = self.load_sources(date, end, user_id).await?;
+        Ok(sources.decision_for(date))
     }
 
     pub async fn list_month(
@@ -90,34 +31,112 @@ impl HolidayService {
         month: u32,
         user_id: Option<&str>,
     ) -> sqlx::Result<Vec<HolidayCalendarEntry>> {
-        let start = NaiveDate::from_ymd_opt(year, month, 1).ok_or_else(|| {
-            sqlx::Error::Protocol(format!("invalid year/month: {}/{}", year, month))
-        })?;
+        let (window_start, window_end) = month_bounds(year, month)?;
+        let sources = self.load_sources(window_start, window_end, user_id).await?;
 
-        let mut cursor = start;
+        let mut cursor = window_start;
         let mut entries = Vec::new();
-
-        loop {
-            if cursor.month() != month {
-                break;
+        while cursor < window_end {
+            if let Some(entry) = sources.entry_for(cursor) {
+                entries.push(entry);
             }
-
-            let decision = self.is_holiday(cursor, user_id).await?;
-            if decision.is_holiday {
-                entries.push(HolidayCalendarEntry {
-                    date: cursor,
-                    is_holiday: true,
-                    reason: decision.reason,
-                });
-            }
-
-            cursor = match cursor.succ_opt() {
-                Some(next) => next,
-                None => break,
-            };
+            cursor = cursor
+                .succ_opt()
+                .ok_or_else(|| sqlx::Error::Protocol("date overflow".into()))?;
         }
 
         Ok(entries)
+    }
+
+    async fn load_sources(
+        &self,
+        window_start: NaiveDate,
+        window_end: NaiveDate,
+        user_id: Option<&str>,
+    ) -> sqlx::Result<HolidaySources> {
+        if window_start >= window_end {
+            return Err(sqlx::Error::Protocol(
+                "invalid calendar window: start must be before end".into(),
+            ));
+        }
+
+        let mut sources = HolidaySources::default();
+        let last_inclusive = window_end
+            .pred_opt()
+            .ok_or_else(|| sqlx::Error::Protocol("invalid calendar window".into()))?;
+
+        let public_rows = sqlx::query(
+            r#"
+            SELECT holiday_date
+            FROM holidays
+            WHERE holiday_date >= $1
+              AND holiday_date <= $2
+            ORDER BY holiday_date
+            "#,
+        )
+        .bind(window_start)
+        .bind(last_inclusive)
+        .fetch_all(&self.pool)
+        .await?;
+
+        for row in public_rows {
+            let date: NaiveDate = row.try_get("holiday_date")?;
+            sources.public_holidays.insert(date);
+        }
+
+        let weekly_rows = sqlx::query(
+            r#"
+            SELECT weekday, enforced_from, enforced_to
+            FROM weekly_holidays
+            WHERE enforced_from <= $1
+              AND (enforced_to IS NULL OR enforced_to >= $2)
+            "#,
+        )
+        .bind(last_inclusive)
+        .bind(window_start)
+        .fetch_all(&self.pool)
+        .await?;
+
+        for row in weekly_rows {
+            let weekday: i16 = row.try_get("weekday")?;
+            let enforced_from: NaiveDate = row.try_get("enforced_from")?;
+            let enforced_to: Option<NaiveDate> = row.try_get("enforced_to")?;
+            let dates = expand_weekly_dates(
+                weekday,
+                enforced_from,
+                enforced_to,
+                window_start,
+                window_end,
+            );
+            sources.weekly_holidays.extend(dates);
+        }
+
+        if let Some(user_id) = user_id {
+            let exception_rows = sqlx::query(
+                r#"
+                SELECT exception_date, override
+                FROM holiday_exceptions
+                WHERE user_id = $1
+                  AND exception_date >= $2
+                  AND exception_date <= $3
+                "#,
+            )
+            .bind(user_id)
+            .bind(window_start)
+            .bind(last_inclusive)
+            .fetch_all(&self.pool)
+            .await?;
+
+            for row in exception_rows {
+                let exception_date: NaiveDate = row.try_get("exception_date")?;
+                let override_value: bool = row.try_get("override")?;
+                sources
+                    .exception_overrides
+                    .insert(exception_date, override_value);
+            }
+        }
+
+        Ok(sources)
     }
 }
 
@@ -151,4 +170,116 @@ pub struct HolidayCalendarEntry {
     pub date: NaiveDate,
     pub is_holiday: bool,
     pub reason: HolidayReason,
+}
+
+#[derive(Default)]
+struct HolidaySources {
+    public_holidays: BTreeSet<NaiveDate>,
+    weekly_holidays: BTreeSet<NaiveDate>,
+    exception_overrides: HashMap<NaiveDate, bool>,
+}
+
+impl HolidaySources {
+    fn decision_for(&self, date: NaiveDate) -> HolidayDecision {
+        if let Some(&flag) = self.exception_overrides.get(&date) {
+            return HolidayDecision {
+                is_holiday: flag,
+                reason: HolidayReason::ExceptionOverride,
+            };
+        }
+
+        if self.public_holidays.contains(&date) {
+            return HolidayDecision {
+                is_holiday: true,
+                reason: HolidayReason::PublicHoliday,
+            };
+        }
+
+        if self.weekly_holidays.contains(&date) {
+            return HolidayDecision {
+                is_holiday: true,
+                reason: HolidayReason::WeeklyHoliday,
+            };
+        }
+
+        HolidayDecision {
+            is_holiday: false,
+            reason: HolidayReason::None,
+        }
+    }
+
+    fn entry_for(&self, date: NaiveDate) -> Option<HolidayCalendarEntry> {
+        let decision = self.decision_for(date);
+        decision.is_holiday.then_some(HolidayCalendarEntry {
+            date,
+            is_holiday: true,
+            reason: decision.reason,
+        })
+    }
+}
+
+fn month_bounds(year: i32, month: u32) -> sqlx::Result<(NaiveDate, NaiveDate)> {
+    let start = NaiveDate::from_ymd_opt(year, month, 1)
+        .ok_or_else(|| sqlx::Error::Protocol(format!("invalid year/month: {}/{}", year, month)))?;
+
+    let (next_year, next_month) = if month == 12 {
+        (year + 1, 1)
+    } else {
+        (year, month + 1)
+    };
+
+    let end = NaiveDate::from_ymd_opt(next_year, next_month, 1).ok_or_else(|| {
+        sqlx::Error::Protocol(format!("invalid year/month: {}/{}", next_year, next_month))
+    })?;
+
+    Ok((start, end))
+}
+
+fn expand_weekly_dates(
+    weekday: i16,
+    enforced_from: NaiveDate,
+    enforced_to: Option<NaiveDate>,
+    window_start: NaiveDate,
+    window_end: NaiveDate,
+) -> Vec<NaiveDate> {
+    let mut result = Vec::new();
+    if window_start >= window_end {
+        return result;
+    }
+
+    let target_weekday = (weekday.rem_euclid(7)) as u32;
+    let mut effective_start = enforced_from.max(window_start);
+    let last_inclusive = match enforced_to {
+        Some(limit) => limit.min(
+            window_end
+                .pred_opt()
+                .expect("window_end must be greater than start"),
+        ),
+        None => window_end
+            .pred_opt()
+            .expect("window_end must be greater than start"),
+    };
+
+    if effective_start > last_inclusive {
+        return result;
+    }
+
+    effective_start = align_weekday_on_or_after(effective_start, target_weekday);
+    if effective_start > last_inclusive {
+        return result;
+    }
+
+    let mut cursor = effective_start;
+    while cursor <= last_inclusive {
+        result.push(cursor);
+        cursor += Duration::days(7);
+    }
+
+    result
+}
+
+fn align_weekday_on_or_after(date: NaiveDate, weekday: u32) -> NaiveDate {
+    let current = date.weekday().num_days_from_monday();
+    let diff = (weekday + 7 - current) % 7;
+    date + Duration::days(diff as i64)
 }

--- a/backend/tests/holiday_service.rs
+++ b/backend/tests/holiday_service.rs
@@ -3,6 +3,23 @@ use sqlx::PgPool;
 use timekeeper_backend::services::holiday::{HolidayReason, HolidayService};
 use uuid::Uuid;
 
+async fn seed_test_user(pool: &PgPool) -> sqlx::Result<String> {
+    let user_id = Uuid::new_v4().to_string();
+    let username_prefix: String = user_id.chars().take(8).collect();
+
+    sqlx::query(
+        "INSERT INTO users (id, username, password_hash, full_name, role, is_system_admin, \
+         mfa_secret, mfa_enabled_at, created_at, updated_at) \
+         VALUES ($1, $2, 'hash', 'User', 'employee', FALSE, NULL, NULL, NOW(), NOW())",
+    )
+    .bind(&user_id)
+    .bind(format!("user_{}", username_prefix))
+    .execute(pool)
+    .await?;
+
+    Ok(user_id)
+}
+
 #[sqlx::test(migrations = "./migrations")]
 async fn detects_public_holiday(pool: PgPool) -> sqlx::Result<()> {
     let date = NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
@@ -48,19 +65,7 @@ async fn detects_weekly_holiday(pool: PgPool) -> sqlx::Result<()> {
 #[sqlx::test(migrations = "./migrations")]
 async fn exception_can_override_weekly_holiday(pool: PgPool) -> sqlx::Result<()> {
     let wed = NaiveDate::from_ymd_opt(2025, 1, 8).unwrap();
-    let user_id = Uuid::new_v4().to_string();
-
-    let username_prefix: String = user_id.chars().take(8).collect();
-
-    sqlx::query(
-        "INSERT INTO users (id, username, password_hash, full_name, role, is_system_admin, \
-         mfa_secret, mfa_enabled_at, created_at, updated_at) \
-         VALUES ($1, $2, 'hash', 'User', 'employee', FALSE, NULL, NULL, NOW(), NOW())",
-    )
-    .bind(&user_id)
-    .bind(format!("user_{}", username_prefix))
-    .execute(&pool)
-    .await?;
+    let user_id = seed_test_user(&pool).await?;
 
     sqlx::query(
         "INSERT INTO weekly_holidays \
@@ -123,6 +128,65 @@ async fn monthly_listing_combines_sources(pool: PgPool) -> sqlx::Result<()> {
     assert!(entries
         .iter()
         .any(|entry| entry.date == wed && entry.reason == HolidayReason::WeeklyHoliday));
+
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn monthly_listing_includes_exception_overrides(pool: PgPool) -> sqlx::Result<()> {
+    let target = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();
+    let user_id = seed_test_user(&pool).await?;
+
+    sqlx::query(
+        "INSERT INTO holiday_exceptions \
+            (id, user_id, exception_date, override, reason, created_by, created_at) \
+         VALUES ($1, $2, $3, TRUE, 'Personal leave', 'system', NOW())",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(&user_id)
+    .bind(target)
+    .execute(&pool)
+    .await?;
+
+    let service = HolidayService::new(pool.clone());
+    let entries = service.list_month(2025, 1, Some(&user_id)).await?;
+
+    assert!(entries
+        .iter()
+        .any(|entry| { entry.date == target && entry.reason == HolidayReason::ExceptionOverride }));
+
+    Ok(())
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn monthly_listing_respects_weekly_effective_range(pool: PgPool) -> sqlx::Result<()> {
+    let enforced_from = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();
+    let enforced_to = NaiveDate::from_ymd_opt(2025, 1, 20).unwrap();
+
+    sqlx::query(
+        "INSERT INTO weekly_holidays \
+            (id, weekday, starts_on, ends_on, enforced_from, enforced_to, created_by, created_at, updated_at) \
+         VALUES ($1, 4, $2, $3, $2, $3, 'system', NOW(), NOW())",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(enforced_from)
+    .bind(enforced_to)
+    .execute(&pool)
+    .await?;
+
+    let service = HolidayService::new(pool.clone());
+    let entries = service.list_month(2025, 1, None).await?;
+
+    let weekly_dates: Vec<_> = entries
+        .iter()
+        .filter(|entry| entry.reason == HolidayReason::WeeklyHoliday)
+        .map(|entry| entry.date)
+        .collect();
+
+    assert_eq!(
+        weekly_dates,
+        vec![enforced_from, enforced_from + Duration::days(7)]
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- share a reusable data loader inside `HolidayService` so both `is_holiday` and `list_month` operate on pre-fetched monthly slices and reduce duplicated queries
- introduce helpers and additional unit tests that exercise exception overrides and weekly holiday effective ranges for the monthly calendar

## Testing
- `cargo test -p timekeeper-backend --test holiday_service` *(fails: `sqlx::test` could not connect to the configured Postgres instance in this environment and timed out)*
- `cargo clippy --all-targets -- -D warnings` *(fails: repository already contains numerous pre-existing lint violations; see log for full list)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919bbaeb3a88320bb4969d3cb39d79c)