### PR TITLE
Stabilize backend integration tests

### DIFF
--- a/backend/tests/admin_holiday_list.rs
+++ b/backend/tests/admin_holiday_list.rs
@@ -34,7 +34,7 @@ async fn admin_holiday_list_filters_by_type() {
     };
 
     let response = list_holidays(
-        axum::extract::State((pool.clone(), config)),
+        axum::extract::State((pool.clone_pool(), config)),
         Extension(admin),
         Query(query),
     )
@@ -77,7 +77,7 @@ async fn admin_holiday_list_supports_pagination_and_range() {
     };
 
     let response = list_holidays(
-        axum::extract::State((pool.clone(), config)),
+        axum::extract::State((pool.clone_pool(), config)),
         Extension(admin),
         Query(query),
     )

--- a/backend/tests/attendance_holiday.rs
+++ b/backend/tests/attendance_holiday.rs
@@ -23,10 +23,10 @@ async fn clock_in_blocked_on_weekly_holiday() {
     seed_weekly_holiday(&pool, date).await;
 
     let config = test_config();
-    let holiday_service = Arc::new(HolidayService::new(pool.clone()));
+    let holiday_service = Arc::new(HolidayService::new(pool.clone_pool()));
 
     let result = attendance::clock_in(
-        State((pool.clone(), config.clone())),
+        State((pool.clone_pool(), config.clone())),
         Extension(user.clone()),
         Extension(holiday_service.clone()),
         Json(ClockInRequest { date: Some(date) }),
@@ -64,15 +64,15 @@ async fn clock_in_allowed_with_exception() {
     .bind(Uuid::new_v4().to_string())
     .bind(&user.id)
     .bind(date)
-    .execute(&pool)
+    .execute(pool.as_ref())
     .await
     .expect("insert exception");
 
     let config = test_config();
-    let holiday_service = Arc::new(HolidayService::new(pool.clone()));
+    let holiday_service = Arc::new(HolidayService::new(pool.clone_pool()));
 
     let result = attendance::clock_in(
-        State((pool.clone(), config.clone())),
+        State((pool.clone_pool(), config.clone())),
         Extension(user.clone()),
         Extension(holiday_service.clone()),
         Json(ClockInRequest { date: Some(date) }),

--- a/backend/tests/config_api.rs
+++ b/backend/tests/config_api.rs
@@ -12,6 +12,6 @@ async fn timezone_endpoint_returns_configured_value() {
     };
     let cfg = test_config();
 
-    let response = config::get_time_zone(State((pool, cfg.clone()))).await;
+    let response = config::get_time_zone(State((pool.clone_pool(), cfg.clone()))).await;
     assert_eq!(response.0.time_zone, cfg.time_zone.to_string());
 }

--- a/backend/tests/holiday_api.rs
+++ b/backend/tests/holiday_api.rs
@@ -32,7 +32,7 @@ async fn regular_admin_cannot_backdate_weekly_holiday() {
     };
 
     let result = admin::create_weekly_holiday(
-        State((pool.clone(), config.clone())),
+        State((pool.clone_pool(), config.clone())),
         Extension(admin_user.clone()),
         Json(payload),
     )
@@ -59,7 +59,7 @@ async fn system_admin_can_backdate_weekly_holiday() {
     };
 
     let response = admin::create_weekly_holiday(
-        State((pool.clone(), config.clone())),
+        State((pool.clone_pool(), config.clone())),
         Extension(admin_user.clone()),
         Json(payload),
     )
@@ -80,7 +80,7 @@ async fn holiday_check_endpoint_detects_weekly_rule() {
     let target_date = NaiveDate::from_ymd_opt(2025, 1, 8).unwrap();
     seed_weekly_holiday(&pool, target_date).await;
 
-    let holiday_service = Arc::new(HolidayService::new(pool.clone()));
+    let holiday_service = Arc::new(HolidayService::new(pool.clone_pool()));
 
     let response = holidays::check_holiday(
         Extension(user.clone()),

--- a/backend/tests/holiday_service.rs
+++ b/backend/tests/holiday_service.rs
@@ -18,10 +18,10 @@ async fn detects_public_holiday() -> sqlx::Result<()> {
     )
     .bind(Uuid::new_v4().to_string())
     .bind(date)
-    .execute(&pool)
+    .execute(pool.as_ref())
     .await?;
 
-    let service = HolidayService::new(pool.clone());
+    let service = HolidayService::new(pool.clone_pool());
     let decision = service.is_holiday(date, None).await?;
 
     assert!(decision.is_holiday);
@@ -44,10 +44,10 @@ async fn detects_weekly_holiday() -> sqlx::Result<()> {
     )
     .bind(Uuid::new_v4().to_string())
     .bind(wed - Duration::days(7))
-    .execute(&pool)
+    .execute(pool.as_ref())
     .await?;
 
-    let service = HolidayService::new(pool.clone());
+    let service = HolidayService::new(pool.clone_pool());
     let decision = service.is_holiday(wed, None).await?;
 
     assert!(decision.is_holiday);
@@ -73,7 +73,7 @@ async fn exception_can_override_weekly_holiday() -> sqlx::Result<()> {
     )
     .bind(&user_id)
     .bind(format!("user_{}", username_prefix))
-    .execute(&pool)
+    .execute(pool.as_ref())
     .await?;
 
     sqlx::query(
@@ -83,7 +83,7 @@ async fn exception_can_override_weekly_holiday() -> sqlx::Result<()> {
     )
     .bind(Uuid::new_v4().to_string())
     .bind(wed - Duration::days(7))
-    .execute(&pool)
+    .execute(pool.as_ref())
     .await?;
 
     sqlx::query(
@@ -94,10 +94,10 @@ async fn exception_can_override_weekly_holiday() -> sqlx::Result<()> {
     .bind(Uuid::new_v4().to_string())
     .bind(&user_id)
     .bind(wed)
-    .execute(&pool)
+    .execute(pool.as_ref())
     .await?;
 
-    let service = HolidayService::new(pool.clone());
+    let service = HolidayService::new(pool.clone_pool());
     let decision = service.is_holiday(wed, Some(&user_id)).await?;
 
     assert!(!decision.is_holiday);
@@ -118,7 +118,7 @@ async fn monthly_listing_combines_sources() -> sqlx::Result<()> {
     )
     .bind(Uuid::new_v4().to_string())
     .bind(jan1)
-    .execute(&pool)
+    .execute(pool.as_ref())
     .await?;
 
     let wed = NaiveDate::from_ymd_opt(2025, 1, 8).unwrap();
@@ -129,10 +129,10 @@ async fn monthly_listing_combines_sources() -> sqlx::Result<()> {
     )
     .bind(Uuid::new_v4().to_string())
     .bind(wed - Duration::days(7))
-    .execute(&pool)
+    .execute(pool.as_ref())
     .await?;
 
-    let service = HolidayService::new(pool.clone());
+    let service = HolidayService::new(pool.clone_pool());
     let entries = service.list_month(2025, 1, None).await?;
 
     assert!(entries

--- a/backend/tests/requests_api.rs
+++ b/backend/tests/requests_api.rs
@@ -32,7 +32,8 @@ async fn get_my_requests_returns_leave_and_overtime() {
     seed_leave_request(&pool, &user.id, LeaveType::Annual, date, date).await;
     seed_overtime_request(&pool, &user.id, date, 1.5).await;
 
-    let response = get_my_requests(State((pool.clone(), config)), Extension(user.clone())).await;
+    let response =
+        get_my_requests(State((pool.clone_pool(), config)), Extension(user.clone())).await;
 
     let payload: Value = response.expect("get_my_requests ok").0;
     let leave = payload
@@ -72,7 +73,7 @@ async fn admin_list_requests_includes_seeded_records() {
     };
 
     let response = list_requests(
-        State((pool.clone(), config)),
+        State((pool.clone_pool(), config)),
         Extension(admin.clone()),
         Query(query),
     )


### PR DESCRIPTION
## Summary
- update the shared test helpers so they honor `DATABASE_URL`, offer a reusable pool bootstrapper, and add regression tests for the new behavior
- switch all backend integration tests to the helper so they can skip cleanly when no database is running while still preparing a clean schema when one is available

## Testing
- `cd backend && cargo test`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b9a111888320a64dec061ec95116)