### PR TITLE
docs: add refactor/backend merge request outline

### DIFF
--- a/documents/backend-refactor-plan.md
+++ b/documents/backend-refactor-plan.md
@@ -96,3 +96,4 @@
 2. ブランチごとに小さな plan（目的、手順、テスト）を `documents/` 配下に追加し、`refactor/backend-attendance` と同様の粒度で進行ログを残す。  
 3. 各 PR で repository/helper が追加されたら、API ハンドラが細くなったことをレビュー観点に含める。  
 4. backend の整理後は frontend 側（特に `AdminPage`）の ViewModel 化と合わせて e2e (`backend/tests`, Playwright) を回し、リグレッションを防止する。
+5. `documents/refactor-backend-merge-request.md` を用いて `refactor/backend` ブランチへのマージ依頼内容を整理し、レビュアーと共有する。

--- a/documents/refactor-backend-merge-request.md
+++ b/documents/refactor-backend-merge-request.md
@@ -1,0 +1,31 @@
+# refactor/backend マージ依頼
+
+## 目的
+`refactor/backend` ブランチは、バックエンド全体のハンドラ/サービス/モデルを読みやすく再構成する横串リファクタ用の統合ブランチです。本書は同ブランチをチームに共有し、作業の背景と進捗、残タスク、リスク、およびテスト結果を整理したうえでマージを依頼するためのものです。
+
+## 実施内容サマリ
+- `refactor/backend-attendance`: 出退勤系ハンドラの共通化、エラーレスポンス/日付処理ヘルパーの導入。
+- `refactor/backend-requests`: 休暇/残業リクエストの repository 化とバリデーション整理。
+- ドキュメント整備: `documents/backend-refactor-plan.md`, `documents/backend-review-plan.md` で横断的なリファクタ手順とレビュー観点を明文化。
+
+これらの変更により、バックエンドの主要ハンドラが小さな責務単位に分割され、後続の `admin` / `holidays` / `models` リファクタに着手しやすい状態になっています。
+
+## 残タスク
+- `refactor/backend-admin`: 管理 API のモジュール分割と認可/レスポンス共通化。
+- `refactor/backend-holidays`: `HolidayService` および祝日ハンドラの再構成。
+- `refactor/backend-models`: Enum 変換ヘルパーとモデル impl の統合。
+
+上記は個別サブブランチで進行予定ですが、既存の共通ヘルパーとドキュメントを共有するため、一旦 `refactor/backend` にマージして作業土台を固めたい意図です。
+
+## レビュー観点
+1. 既存 API 仕様（リクエスト/レスポンス JSON）の互換性を保てているか。
+2. 共通ヘルパー導入によるエラー/レスポンス shape の一貫性。
+3. `documents/backend-refactor-plan.md` に記載したステップと差分がないか。
+
+## テスト
+- `cd backend && cargo test -p timekeeper-backend`
+
+上記テストにより、リファクタ後も既存機能が回帰していないことを確認しています。
+
+## マージ依頼
+`refactor/backend` ブランチを最新の `work`（または `main` 相当）にマージし、今後の `admin`/`holidays`/`models` サブブランチのベースとして共有したいです。レビューのうえ問題なければ、CI 通過後にマージをお願いします。


### PR DESCRIPTION
## Summary
- add a dedicated `documents/refactor-backend-merge-request.md` file that summarizes the horizontal refactor status and requests a merge into `refactor/backend`
- extend the backend refactor plan with a step that points reviewers to the new merge-request document

## Testing
- `cd backend && cargo test -p timekeeper-backend`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919cad81ea08320bca7c80aa344a5cd)