### PR TITLE
feat: share attendance context across dashboard

### DIFF
--- a/frontend/src/pages/dashboard.rs
+++ b/frontend/src/pages/dashboard.rs
@@ -1,22 +1,12 @@
 use crate::{
     components::{cards::*, forms::*, layout::*},
-    state::attendance::{refresh_today_context, use_attendance},
+    state::attendance::use_attendance,
 };
 use leptos::*;
-use log::error;
 
 #[component]
 pub fn DashboardPage() -> impl IntoView {
     let (attendance_state, set_attendance_state) = use_attendance();
-
-    create_effect(move |_| {
-        let set_state = set_attendance_state.clone();
-        spawn_local(async move {
-            if let Err(err) = refresh_today_context(set_state).await {
-                error!("Failed to refresh attendance context: {}", err);
-            }
-        });
-    });
 
     view! {
         <Layout>
@@ -27,10 +17,7 @@ pub fn DashboardPage() -> impl IntoView {
                 </div>
 
                 <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-                    <AttendanceCard
-                        attendance_state=attendance_state
-                        set_attendance_state=set_attendance_state
-                    />
+                    <AttendanceCard/>
                     <SummaryCard/>
                 </div>
 


### PR DESCRIPTION
## Summary
- have `use_attendance` reuse a provided context so multiple components can safely share the same reactive attendance state
- let `AttendanceCard` resolve the shared state internally and update the user-facing copy to match the Japanese wording from PR #16 without needing props
- simplify `DashboardPage` now that the card manages its own refresh flow and add a regression test ensuring the context reuse works

## Testing
- `cargo test`
- `wasm-pack test --headless --firefox` *(fails: `wasm-pack` is unavailable and its installation was blocked by a 403 from crates.io)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919feb363248320a36ec38bda204f6f)