### PR TITLE
refactor(frontend): centralize storage helpers

### DIFF
--- a/frontend/src/utils/mod.rs
+++ b/frontend/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod download;
+pub mod storage;
 pub mod time;
 
 pub use download::*;

--- a/frontend/src/utils/storage.rs
+++ b/frontend/src/utils/storage.rs
@@ -1,0 +1,12 @@
+use web_sys::{Storage, Window};
+
+pub fn window() -> Result<Window, String> {
+    web_sys::window().ok_or_else(|| "No window object".to_string())
+}
+
+pub fn local_storage() -> Result<Storage, String> {
+    window()?
+        .local_storage()
+        .map_err(|_| "No localStorage".to_string())?
+        .ok_or_else(|| "No localStorage".to_string())
+}


### PR DESCRIPTION
## Summary
- add utils::storage module and use it in API client and auth state

## Testing
- cargo test -p timekeeper-frontend