### PR TITLE
fix: reuse dashboard summary for alerts generation

### DIFF
--- a/frontend/src/pages/dashboard/components/alerts.rs
+++ b/frontend/src/pages/dashboard/components/alerts.rs
@@ -1,12 +1,12 @@
 use crate::{
     components::layout::{ErrorMessage, LoadingSpinner},
-    pages::dashboard::repository::{DashboardAlert, DashboardAlertLevel},
+    pages::dashboard::repository::{DashboardAlert, DashboardAlertLevel, DashboardSummary},
 };
 use leptos::*;
 
 #[component]
 pub fn AlertsSection(
-    alerts: Resource<(), Result<Vec<DashboardAlert>, String>>,
+    alerts: Resource<Option<Result<DashboardSummary, String>>, Result<Vec<DashboardAlert>, String>>,
     on_reload: Callback<()>,
 ) -> impl IntoView {
     view! {

--- a/frontend/src/pages/dashboard/repository.rs
+++ b/frontend/src/pages/dashboard/repository.rs
@@ -42,8 +42,7 @@ pub async fn fetch_summary() -> Result<DashboardSummary, String> {
     })
 }
 
-pub async fn fetch_alerts() -> Result<Vec<DashboardAlert>, String> {
-    let summary = fetch_summary().await?;
+pub fn build_alerts(summary: &DashboardSummary) -> Vec<DashboardAlert> {
     let mut alerts = Vec::new();
 
     if summary.total_work_days.unwrap_or_default() == 0 {
@@ -60,7 +59,7 @@ pub async fn fetch_alerts() -> Result<Vec<DashboardAlert>, String> {
         });
     }
 
-    Ok(alerts)
+    alerts
 }
 
 pub async fn fetch_recent_activities() -> Result<Vec<DashboardActivity>, String> {


### PR DESCRIPTION
## Summary
- AlertsResource を summary_resource に従属させ、サマリー API の二重呼び出しを解消
- サマリー結果を元に同期生成する `build_alerts` を追加し、リロード時は summary を再取得

## Impact
- Frontend のリソース構成のみ変更、Backend 影響なし
- Env vars: 変更なし

## Testing
- [x] cargo fmt --all
- [x] cargo test -p timekeeper-frontend --lib
- [ ] wasm-pack test --headless --firefox frontend
- [ ] node e2e/run.mjs