### PR TITLE
Remove Swagger UI stub override configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /frontend/build/
 /frontend/.wasm-pack/
 /frontend/wasm-pack.log
+backend/tests/support/swagger-ui.zip
 
 # Environment & secrets
 .env

--- a/backend/tests/holiday_service.rs
+++ b/backend/tests/holiday_service.rs
@@ -1,19 +1,43 @@
 use chrono::NaiveDate;
-use timekeeper_backend::handlers::admin::AdminHolidayKind;
+use timekeeper_backend::services::holiday::{HolidayReason, HolidayServiceStub};
 
 #[test]
-fn prioritizes_override_holiday_without_db() {
-    let base = AdminHolidayKind::Public;
-    let override_kind = AdminHolidayKind::Exception;
-    let date = NaiveDate::from_ymd_opt(2025, 4, 1).unwrap();
+fn exception_override_beats_public_and_weekly_flags() {
+    let public = NaiveDate::from_ymd_opt(2025, 4, 1).unwrap();
+    let weekly = NaiveDate::from_ymd_opt(2025, 4, 2).unwrap();
+    let override_date = public;
 
-    // Simulate that an override wins over a base kind when both exist.
-    let chosen = if override_kind == AdminHolidayKind::Exception {
-        override_kind
-    } else {
-        base
-    };
+    let service = HolidayServiceStub::new([public], [weekly], [(override_date, false)]);
 
-    assert_eq!(chosen, AdminHolidayKind::Exception);
-    assert_eq!(date, NaiveDate::from_ymd_opt(2025, 4, 1).unwrap());
+    let decision = service.is_holiday(override_date);
+
+    assert!(!decision.is_holiday);
+    assert_eq!(decision.reason, HolidayReason::ExceptionOverride);
+}
+
+#[test]
+fn list_month_applies_service_logic_over_mixed_sources() {
+    let public = NaiveDate::from_ymd_opt(2025, 4, 1).unwrap();
+    let weekly_first = NaiveDate::from_ymd_opt(2025, 4, 4).unwrap();
+    let weekly_second = NaiveDate::from_ymd_opt(2025, 4, 11).unwrap();
+    let forced_holiday = NaiveDate::from_ymd_opt(2025, 4, 15).unwrap();
+
+    let service = HolidayServiceStub::new(
+        [public],
+        [weekly_first, weekly_second],
+        [(forced_holiday, true)],
+    );
+
+    let entries = service.list_month(2025, 4).expect("list monthly holidays");
+    let dates: Vec<_> = entries.iter().map(|entry| entry.date).collect();
+
+    assert_eq!(dates, vec![public, weekly_first, weekly_second, forced_holiday]);
+    assert!(entries
+        .iter()
+        .all(|entry| matches!(
+            entry.reason,
+            HolidayReason::PublicHoliday
+                | HolidayReason::WeeklyHoliday
+                | HolidayReason::ExceptionOverride
+        )));
 }

--- a/backend/tests/support/swagger-ui-dist/README.md
+++ b/backend/tests/support/swagger-ui-dist/README.md
@@ -1,0 +1,10 @@
+# Swagger UIスタブのローカルテスト方法
+
+デフォルトでは`utoipa-swagger-ui`のビルド時にSwagger UIの配布物をインターネットから取得します。ネットワークに接続できない環境でビルドやテストを行う場合は、次の手順でローカルスタブのZIPを生成し、環境変数経由で参照してください。
+
+1. `cd backend`
+2. `cd tests/support/swagger-ui-dist && zip -r ../swagger-ui.zip swagger-ui-stub`
+3. `cd ../..`
+4. `SWAGGER_UI_DOWNLOAD_URL="file://$(pwd)/tests/support/swagger-ui.zip" cargo test`
+
+上記のZIPは追跡対象外にしているため、必要に応じて各開発者の環境で作成してください。

--- a/backend/tests/support/swagger-ui-dist/swagger-ui-stub/dist/swagger-initializer.js
+++ b/backend/tests/support/swagger-ui-dist/swagger-ui-stub/dist/swagger-initializer.js
@@ -1,0 +1,8 @@
+// Minimal stub for tests
+window.onload = () => {
+  window.ui = SwaggerUIBundle({
+    url: "http://example.com",
+    deep: true,
+    dom_id: '#swagger-ui',
+  });
+};


### PR DESCRIPTION
## Summary
- remove the Cargo configuration that forced Swagger UI downloads to a local stub archive
- document how to create and use a local Swagger UI stub archive for offline testing and ignore the generated ZIP

## Testing
- SWAGGER_UI_DOWNLOAD_URL="file://$(pwd)/tests/support/swagger-ui.zip" cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692141d641e4832085316ee32ac27c71)