### PR TITLE
Harden holiday validation and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -111,7 +111,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -122,7 +122,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ dependencies = [
  "manyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -176,7 +176,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -199,7 +199,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -250,7 +250,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -297,11 +297,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -342,9 +342,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bzip2"
@@ -406,9 +406,9 @@ checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
 
 [[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -674,9 +674,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -684,34 +684,40 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "3ffc71fcdcdb40d6f087edddf7f8f1f8f79e6cf922f555a9ee8779752d4819bd"
 dependencies = [
- "quote",
- "syn 2.0.106",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -774,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -789,7 +795,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -800,7 +806,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -852,7 +858,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -875,6 +881,21 @@ name = "drain_filter_polyfill"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
+
+[[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "either"
@@ -947,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "flate2"
@@ -1080,7 +1101,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1115,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1208,7 +1229,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1227,7 +1248,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1269,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -1317,11 +1338,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1427,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1450,26 +1471,12 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.35",
  "rustls-pki-types",
@@ -1494,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1505,7 +1512,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1542,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1555,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1568,11 +1575,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1583,42 +1589,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1677,12 +1679,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -1744,9 +1746,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1856,7 +1858,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "html-escape",
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "itertools",
  "js-sys",
  "leptos_reactive",
@@ -1882,13 +1884,13 @@ checksum = "6cb53d4794240b684a2f4be224b84bee9e62d2abc498cf2bcd643cd565e01d96"
 dependencies = [
  "anyhow",
  "camino",
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "parking_lot 0.12.5",
  "proc-macro2",
  "quote",
  "rstml",
  "serde",
- "syn 2.0.106",
+ "syn 2.0.111",
  "walkdir",
 ]
 
@@ -1924,7 +1926,7 @@ dependencies = [
  "quote",
  "rstml",
  "server_fn_macro",
- "syn 2.0.106",
+ "syn 2.0.111",
  "tracing",
  "uuid",
 ]
@@ -1936,7 +1938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25acc2f63cf91932013e400a95bf6e35e5d3dbb44a7b7e25a8e3057d12005b3b"
 dependencies = [
  "cfg-if",
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "leptos",
  "tracing",
  "wasm-bindgen",
@@ -1952,7 +1954,7 @@ dependencies = [
  "base64 0.22.1",
  "cfg-if",
  "futures",
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "js-sys",
  "oco_ref",
  "paste",
@@ -2037,7 +2039,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.5.18",
 ]
@@ -2071,9 +2073,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -2125,7 +2127,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2214,13 +2216,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2288,11 +2290,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -2358,7 +2359,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2383,7 +2384,7 @@ version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2400,7 +2401,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2544,9 +2545,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.3"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
+checksum = "cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2554,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.3"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
+checksum = "51f72981ade67b1ca6adc26ec221be9f463f2b5839c7508998daa17c23d94d7f"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2564,22 +2565,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.3"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
+checksum = "dee9efd8cdb50d719a80088b76f81aec7c41ed6d522ee750178f83883d271625"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.3"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
+checksum = "bf1d70880e76bdc13ba52eafa6239ce793d85c8e43896507e43dd8984ff05b82"
 dependencies = [
  "pest",
  "sha2",
@@ -2660,7 +2661,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2704,9 +2705,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -2733,7 +2734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2814,9 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -2829,7 +2830,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
  "version_check",
  "yansi",
 ]
@@ -2900,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -2926,7 +2927,7 @@ dependencies = [
  "proc-macro-utils 0.10.0",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3009,7 +3010,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -3067,7 +3068,6 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -3077,7 +3077,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3086,13 +3085,11 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -3110,8 +3107,8 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
- "hyper-rustls 0.27.7",
+ "hyper 1.8.1",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -3207,16 +3204,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "serde",
  "serde_derive",
 ]
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
 dependencies = [
  "const-oid",
  "digest",
@@ -3241,7 +3238,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
  "syn_derive",
  "thiserror 1.0.69",
 ]
@@ -3266,7 +3263,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.106",
+ "syn 2.0.111",
  "walkdir",
 ]
 
@@ -3308,7 +3305,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3333,7 +3330,6 @@ version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
- "log",
  "ring 0.17.14",
  "rustls-webpki 0.101.7",
  "sct",
@@ -3445,7 +3441,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3464,9 +3460,9 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
+checksum = "16c2f82143577edb4921b71ede051dac62ca3c16084e918bf7b40c96ae10eb33"
 
 [[package]]
 name = "send_wrapper"
@@ -3515,7 +3511,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3609,7 +3605,7 @@ dependencies = [
  "gloo-net",
  "http 1.3.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "inventory",
  "js-sys",
  "once_cell",
@@ -3639,7 +3635,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
  "xxhash-rust",
 ]
 
@@ -3650,7 +3646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f2aa8119b558a17992e0ac1fd07f080099564f24532858811ce04f742542440"
 dependencies = [
  "server_fn_macro",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3692,9 +3688,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
@@ -3908,7 +3904,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "log",
  "memchr",
  "once_cell",
@@ -3996,7 +3992,7 @@ checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi 2.0.0",
  "base64 0.21.7",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -4040,7 +4036,7 @@ checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi 2.0.0",
  "base64 0.21.7",
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "byteorder",
  "chrono",
  "crc",
@@ -4150,9 +4146,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4168,7 +4164,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4194,7 +4190,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4268,7 +4264,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4279,7 +4275,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4347,11 +4343,11 @@ dependencies = [
  "csv",
  "ctor",
  "dotenvy",
- "hyper 1.7.0",
+ "hyper 1.8.1",
  "jsonwebtoken",
  "pg-embed",
  "rand 0.8.5",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "sqlx 0.7.4",
@@ -4410,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4458,7 +4454,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4484,16 +4480,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
@@ -4515,9 +4501,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4563,7 +4549,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -4577,7 +4563,7 @@ version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "toml_datetime 0.7.3",
  "toml_parser",
  "winnow",
@@ -4646,7 +4632,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "bytes",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -4663,7 +4649,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -4707,7 +4693,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4772,7 +4758,7 @@ checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4801,24 +4787,24 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4870,9 +4856,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8_iter"
@@ -4886,7 +4872,7 @@ version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
 dependencies = [
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -4902,7 +4888,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.106",
+ "syn 2.0.111",
  "uuid",
 ]
 
@@ -5001,9 +4987,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5013,24 +4999,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.54"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5041,9 +5013,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5051,31 +5023,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
- "wasm-bindgen-backend",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e381134e148c1062f965a42ed1f5ee933eef2927c3f70d1812158f711d39865"
+checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
 dependencies = [
  "js-sys",
  "minicov",
@@ -5086,13 +5058,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b673bca3298fe582aeef8352330ecbad91849f85090805582400850f8270a2e8"
+checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5110,9 +5082,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5225,7 +5197,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5236,7 +5208,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5277,15 +5249,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5530,9 +5493,9 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xattr"
@@ -5578,11 +5541,10 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -5590,34 +5552,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5637,7 +5599,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -5649,9 +5611,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5660,9 +5622,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5671,13 +5633,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -5705,7 +5667,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.11.4",
+ "indexmap 2.12.1",
  "num_enum",
  "thiserror 1.0.69",
 ]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -56,7 +56,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 csv = "1.3"
 
 # HTTP client for external calendar import
-reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12.24", default-features = false, features = ["json", "rustls-tls"] }
 
 # Password hashing
 # argon2 declared above
@@ -69,6 +69,10 @@ utoipa = { version = "4", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
 
 [dev-dependencies]
-ctor = "0.2"
-pg-embed = "0.7"
+ctor = "0.6.1"
+pg-embed = "0.7.1"
 tempfile = "3"
+
+[features]
+default = []
+test-utils = []

--- a/backend/tests/admin_holiday_list.rs
+++ b/backend/tests/admin_holiday_list.rs
@@ -1,14 +1,42 @@
-use chrono::{DateTime, NaiveDate, Utc};
-use timekeeper_backend::handlers::admin::{
-    AdminHolidayKind, AdminHolidayListItem, AdminHolidayListQuery, AdminHolidayListResponse,
+use axum::{
+    extract::{Extension, Query, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use chrono_tz::UTC;
+use sqlx::{postgres::PgPoolOptions, PgPool};
+use std::str::FromStr;
+#[cfg(feature = "test-utils")]
+use std::sync::{Mutex, OnceLock};
+#[cfg(feature = "test-utils")]
+use std::time::Duration;
+use timekeeper_backend::{
+    config::Config,
+    handlers::admin::{
+        list_holidays, AdminHolidayKind, AdminHolidayListItem, AdminHolidayListQuery,
+        AdminHolidayListResponse,
+    },
+    models::user::{User, UserRole},
 };
 
-fn build_item(id: &str, kind: AdminHolidayKind, date: NaiveDate) -> AdminHolidayListItem {
+#[cfg(feature = "test-utils")]
+fn integration_guard() -> std::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD.get_or_init(|| Mutex::new(())).lock().expect("lock integration guard")
+}
+
+fn build_item(
+    id: &str,
+    kind: AdminHolidayKind,
+    date: NaiveDate,
+    created_at: DateTime<Utc>,
+) -> AdminHolidayListItem {
     AdminHolidayListItem {
         id: id.to_string(),
         kind,
         applies_from: date,
-        applies_to: None,
+        applies_to: Some(date),
         date: Some(date),
         weekday: None,
         starts_on: None,
@@ -18,7 +46,7 @@ fn build_item(id: &str, kind: AdminHolidayKind, date: NaiveDate) -> AdminHoliday
         user_id: None,
         reason: None,
         created_by: None,
-        created_at: DateTime::<Utc>::from(Utc::now()),
+        created_at,
         is_override: None,
     }
 }
@@ -26,33 +54,66 @@ fn build_item(id: &str, kind: AdminHolidayKind, date: NaiveDate) -> AdminHoliday
 fn mock_list_holidays(
     items: Vec<AdminHolidayListItem>,
     query: AdminHolidayListQuery,
-) -> AdminHolidayListResponse {
-    let page = query.page.unwrap_or(1).max(1);
-    let per_page = query.per_page.unwrap_or(25).clamp(1, 100);
+) -> Result<AdminHolidayListResponse, String> {
+    let (page, per_page) = (
+        query.page.unwrap_or(1).clamp(1, 1_000),
+        query.per_page.unwrap_or(25).clamp(1, 100),
+    );
 
-    let type_filter = query.r#type.as_deref().map(|s| s.to_ascii_lowercase());
+    let kind = match query.r#type.as_deref() {
+        Some(value) if value.eq_ignore_ascii_case("all") => None,
+        Some(value) => AdminHolidayKind::from_str(value)
+            .map(Some)
+            .map_err(|_| "`type` must be one of public, weekly, exception, all".to_string())?,
+        None => None,
+    };
+
+    let parse_date = |s: &str| {
+        DateTime::parse_from_rfc3339(s)
+            .map(|dt| dt.date_naive())
+            .or_else(|_| NaiveDate::parse_from_str(s, "%Y-%m-%d").map(|d| d))
+            .ok()
+    };
+
     let from = query
         .from
         .as_deref()
-        .and_then(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok());
+        .map(|s| parse_date(s).ok_or("`from`/`to` must be a valid date (YYYY-MM-DD or RFC3339)"))
+        .transpose()?;
     let to = query
         .to
         .as_deref()
-        .and_then(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok());
+        .map(|s| parse_date(s).ok_or("`from`/`to` must be a valid date (YYYY-MM-DD or RFC3339)"))
+        .transpose()?;
+
+    if let (Some(from), Some(to)) = (from, to) {
+        if from > to {
+            return Err("`from` must be before or equal to `to`".into());
+        }
+    }
 
     let mut filtered: Vec<AdminHolidayListItem> = items
         .into_iter()
-        .filter(|item| match type_filter.as_deref() {
-            Some("public") => item.kind == AdminHolidayKind::Public,
-            Some("weekly") => item.kind == AdminHolidayKind::Weekly,
-            Some("exception") => item.kind == AdminHolidayKind::Exception,
-            _ => true,
-        })
+        .filter(|item| kind.map(|k| item.kind == k).unwrap_or(true))
         .filter(|item| from.map(|f| item.applies_from >= f).unwrap_or(true))
         .filter(|item| to.map(|t| item.applies_from <= t).unwrap_or(true))
         .collect();
 
-    filtered.sort_by_key(|item| item.applies_from);
+    filtered.sort_by(|a, b| {
+        b.applies_from
+            .cmp(&a.applies_from)
+            .then_with(|| {
+                fn kind_sort_key(kind: &AdminHolidayKind) -> &'static str {
+                    match kind {
+                        AdminHolidayKind::Exception => "exception",
+                        AdminHolidayKind::Public => "public",
+                        AdminHolidayKind::Weekly => "weekly",
+                    }
+                }
+                kind_sort_key(&a.kind).cmp(kind_sort_key(&b.kind))
+            })
+            .then_with(|| b.created_at.cmp(&a.created_at))
+    });
 
     let total = filtered.len() as i64;
     let offset = ((page - 1) * per_page) as usize;
@@ -62,21 +123,43 @@ fn mock_list_holidays(
         .take(per_page as usize)
         .collect();
 
-    AdminHolidayListResponse {
+    Ok(AdminHolidayListResponse {
         page,
         per_page,
         total,
         items,
+    })
+}
+
+fn test_admin() -> User {
+    User::new(
+        "admin".into(),
+        "hash".into(),
+        "Administrator".into(),
+        UserRole::Admin,
+        true,
+    )
+}
+
+fn dummy_config() -> Config {
+    Config {
+        database_url: "postgres://invalid:invalid@localhost:5432/invalid".into(),
+        jwt_secret: "this_is_a_long_enough_jwt_secret_string_123".into(),
+        jwt_expiration_hours: 1,
+        refresh_token_expiration_days: 7,
+        time_zone: UTC,
+        mfa_issuer: "Timekeeper".into(),
     }
 }
 
 #[test]
 fn admin_holiday_list_filters_by_type() {
-    let date = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();
+    let base_date = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();
+    let created_at = Utc.timestamp_millis_opt(0).single().unwrap();
     let items = vec![
-        build_item("public", AdminHolidayKind::Public, date),
-        build_item("weekly", AdminHolidayKind::Weekly, date),
-        build_item("exception", AdminHolidayKind::Exception, date),
+        build_item("public", AdminHolidayKind::Public, base_date, created_at),
+        build_item("weekly", AdminHolidayKind::Weekly, base_date, created_at),
+        build_item("exception", AdminHolidayKind::Exception, base_date, created_at),
     ];
 
     let query = AdminHolidayListQuery {
@@ -87,12 +170,12 @@ fn admin_holiday_list_filters_by_type() {
         to: None,
     };
 
-    let response = mock_list_holidays(items, query);
+    let response = mock_list_holidays(items, query).expect("filtering should succeed");
 
     assert_eq!(response.total, 1);
     assert_eq!(response.items.len(), 1);
     assert_eq!(response.items[0].kind, AdminHolidayKind::Public);
-    assert_eq!(response.items[0].date, Some(date));
+    assert_eq!(response.items[0].date, Some(base_date));
 }
 
 #[test]
@@ -102,10 +185,14 @@ fn admin_holiday_list_supports_pagination_and_range() {
         NaiveDate::from_ymd_opt(2025, 3, 5).unwrap(),
         NaiveDate::from_ymd_opt(2025, 3, 10).unwrap(),
     ];
+    let base_created = Utc.timestamp_millis_opt(10_000).single().unwrap();
     let items: Vec<_> = dates
         .iter()
         .enumerate()
-        .map(|(idx, d)| build_item(&format!("Holiday {}", idx), AdminHolidayKind::Public, *d))
+        .map(|(idx, d)| {
+            let created_at = base_created + chrono::Duration::milliseconds(idx as i64);
+            build_item(&format!("Holiday {}", idx), AdminHolidayKind::Public, *d, created_at)
+        })
         .collect();
 
     let query = AdminHolidayListQuery {
@@ -116,7 +203,7 @@ fn admin_holiday_list_supports_pagination_and_range() {
         to: Some("2025-03-06".into()),
     };
 
-    let response = mock_list_holidays(items, query);
+    let response = mock_list_holidays(items, query).expect("pagination should succeed");
 
     assert_eq!(response.total, 2);
     assert_eq!(response.page, 2);
@@ -126,7 +213,514 @@ fn admin_holiday_list_supports_pagination_and_range() {
         .items
         .iter()
         .all(|item| item.kind == AdminHolidayKind::Public));
-    assert!(response.items.iter().all(|item| item.applies_from
-        >= NaiveDate::from_ymd_opt(2025, 3, 1).unwrap()
-        && item.applies_from <= NaiveDate::from_ymd_opt(2025, 3, 6).unwrap()));
+    assert_eq!(
+        response.items[0].applies_from,
+        NaiveDate::from_ymd_opt(2025, 3, 1).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn admin_holiday_list_rejects_unknown_type() {
+    let pool = PgPoolOptions::new()
+        .connect_lazy("postgres://invalid:invalid@localhost:5432/invalid")
+        .expect("create lazy pool");
+
+    let query = AdminHolidayListQuery {
+        page: Some(1),
+        per_page: Some(10),
+        r#type: Some("unknown-kind".into()),
+        from: None,
+        to: None,
+    };
+
+    let result = list_holidays(
+        State((pool, dummy_config())),
+        Extension(test_admin()),
+        Query(query),
+    )
+    .await;
+
+    let (status, Json(body)) = result.expect_err("expected bad request for invalid type");
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body.get("error").and_then(|v| v.as_str()),
+        Some("`type` must be one of public, weekly, exception, all")
+    );
+}
+
+#[tokio::test]
+async fn admin_holiday_list_rejects_invalid_date_format() {
+    let pool = PgPoolOptions::new()
+        .connect_lazy("postgres://invalid:invalid@localhost:5432/invalid")
+        .expect("create lazy pool");
+
+    let query = AdminHolidayListQuery {
+        page: Some(1),
+        per_page: Some(10),
+        r#type: Some("public".into()),
+        from: Some("not-a-date".into()),
+        to: None,
+    };
+
+    let result = list_holidays(
+        State((pool, dummy_config())),
+        Extension(test_admin()),
+        Query(query),
+    )
+    .await;
+
+    let (status, Json(body)) = result.expect_err("expected bad request for invalid date");
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body.get("error").and_then(|v| v.as_str()),
+        Some("`from`/`to` must be a valid date (YYYY-MM-DD or RFC3339)")
+    );
+}
+
+#[tokio::test]
+async fn admin_holiday_list_rejects_from_after_to() {
+    let pool = PgPoolOptions::new()
+        .connect_lazy("postgres://invalid:invalid@localhost:5432/invalid")
+        .expect("create lazy pool");
+
+    let query = AdminHolidayListQuery {
+        page: Some(1),
+        per_page: Some(10),
+        r#type: Some("public".into()),
+        from: Some("2025-05-10".into()),
+        to: Some("2025-05-01".into()),
+    };
+
+    let result = list_holidays(
+        State((pool, dummy_config())),
+        Extension(test_admin()),
+        Query(query),
+    )
+    .await;
+
+    let (status, Json(body)) = result.expect_err("expected bad request when from > to");
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body.get("error").and_then(|v| v.as_str()),
+        Some("`from` must be before or equal to `to`")
+    );
+}
+
+#[test]
+fn admin_holiday_list_orders_by_date_kind_and_created_at() {
+    let date_new = NaiveDate::from_ymd_opt(2025, 5, 10).unwrap();
+    let date_old = NaiveDate::from_ymd_opt(2025, 5, 1).unwrap();
+    let items = vec![
+        build_item(
+            "weekly-old-created",
+            AdminHolidayKind::Weekly,
+            date_new,
+            Utc.timestamp_millis_opt(100).single().unwrap(),
+        ),
+        build_item(
+            "weekly-new-created",
+            AdminHolidayKind::Weekly,
+            date_new,
+            Utc.timestamp_millis_opt(500).single().unwrap(),
+        ),
+        build_item(
+            "public",
+            AdminHolidayKind::Public,
+            date_new,
+            Utc.timestamp_millis_opt(200).single().unwrap(),
+        ),
+        build_item(
+            "exception",
+            AdminHolidayKind::Exception,
+            date_new,
+            Utc.timestamp_millis_opt(300).single().unwrap(),
+        ),
+        build_item(
+            "older",
+            AdminHolidayKind::Public,
+            date_old,
+            Utc.timestamp_millis_opt(400).single().unwrap(),
+        ),
+    ];
+
+    let response = mock_list_holidays(
+        items,
+        AdminHolidayListQuery {
+            page: Some(1),
+            per_page: Some(10),
+            r#type: Some("all".into()),
+            from: None,
+            to: None,
+        },
+    )
+    .expect("ordering should succeed");
+
+    let ids: Vec<_> = response.items.iter().map(|i| i.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        &[
+            "exception",          // same date, kind asc => exception first
+            "public",             // then public
+            "weekly-new-created", // then weekly (newer created_at first)
+            "weekly-old-created",
+            "older"               // older date last
+        ]
+    );
+}
+
+#[test]
+fn admin_holiday_list_clamps_page_and_per_page() {
+    let date = NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+    let created_at = Utc.timestamp_millis_opt(0).single().unwrap();
+    let items = (0..3)
+        .map(|i| build_item(&format!("id-{i}"), AdminHolidayKind::Public, date, created_at))
+        .collect();
+
+    let response = mock_list_holidays(
+        items,
+        AdminHolidayListQuery {
+            page: Some(0),
+            per_page: Some(200),
+            r#type: None,
+            from: None,
+            to: None,
+        },
+    )
+    .expect("clamping should succeed");
+
+    assert_eq!(response.page, 1);
+    assert_eq!(response.per_page, 100);
+    assert_eq!(response.total, 3);
+}
+
+async fn prepare_holiday_tables(pool: &PgPool) {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS holidays (
+            id TEXT PRIMARY KEY,
+            holiday_date DATE NOT NULL,
+            name TEXT NOT NULL,
+            description TEXT,
+            created_at TIMESTAMPTZ NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .expect("create holidays");
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS weekly_holidays (
+            id TEXT PRIMARY KEY,
+            weekday SMALLINT NOT NULL,
+            starts_on DATE NOT NULL,
+            ends_on DATE,
+            enforced_from DATE NOT NULL,
+            enforced_to DATE,
+            created_by TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .expect("create weekly_holidays");
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS holiday_exceptions (
+            id TEXT PRIMARY KEY,
+            user_id TEXT NOT NULL,
+            exception_date DATE NOT NULL,
+            override BOOLEAN NOT NULL,
+            reason TEXT NOT NULL,
+            created_by TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .expect("create holiday_exceptions");
+
+    sqlx::query("TRUNCATE TABLE holiday_exceptions, weekly_holidays, holidays")
+        .execute(pool)
+        .await
+        .expect("truncate tables");
+}
+
+async fn seed_integration_holidays(pool: &PgPool) {
+    let created_base = Utc.timestamp_millis_opt(1_742_961_600_000).single().unwrap(); // 2025-03-10T00:00:00Z
+
+    sqlx::query(
+        "INSERT INTO holidays (id, holiday_date, name, description, created_at, updated_at) \
+         VALUES ($1, $2, $3, NULL, $4, $4)",
+    )
+    .bind("public-310")
+    .bind(NaiveDate::from_ymd_opt(2025, 3, 10).unwrap())
+    .bind("Public Holiday")
+    .bind(created_base + chrono::Duration::seconds(10))
+    .execute(pool)
+    .await
+    .expect("insert public 310");
+
+    sqlx::query(
+        "INSERT INTO weekly_holidays (id, weekday, starts_on, ends_on, enforced_from, enforced_to, created_by, created_at, updated_at) \
+         VALUES ($1, $2, $3, NULL, $4, NULL, 'tester', $5, $5)",
+    )
+    .bind("weekly-310")
+    .bind(1_i16)
+    .bind(NaiveDate::from_ymd_opt(2025, 3, 1).unwrap())
+    .bind(NaiveDate::from_ymd_opt(2025, 3, 10).unwrap())
+    .bind(created_base + chrono::Duration::seconds(20))
+    .execute(pool)
+    .await
+    .expect("insert weekly 310");
+
+    sqlx::query(
+        "INSERT INTO holiday_exceptions (id, user_id, exception_date, override, reason, created_by, created_at, updated_at) \
+         VALUES ($1, 'user', $2, true, 'exceptional', 'tester', $3, $3)",
+    )
+    .bind("exception-310")
+    .bind(NaiveDate::from_ymd_opt(2025, 3, 10).unwrap())
+    .bind(created_base + chrono::Duration::seconds(30))
+    .execute(pool)
+    .await
+    .expect("insert exception 310");
+
+    sqlx::query(
+        "INSERT INTO holidays (id, holiday_date, name, description, created_at, updated_at) \
+         VALUES ($1, $2, $3, NULL, $4, $4)",
+    )
+    .bind("public-305")
+    .bind(NaiveDate::from_ymd_opt(2025, 3, 5).unwrap())
+    .bind("Earlier Public")
+    .bind(created_base - chrono::Duration::seconds(5 * 24 * 3600))
+    .execute(pool)
+    .await
+    .expect("insert public 305");
+}
+
+#[cfg(feature = "test-utils")]
+async fn connect_with_retry(database_url: &str) -> PgPool {
+    let mut last_err = None;
+    for _ in 0..5 {
+        match PgPoolOptions::new()
+            .max_connections(5)
+            .acquire_timeout(Duration::from_secs(120))
+            .connect(database_url)
+            .await
+        {
+            Ok(pool) => return pool,
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+    panic!("connect test database: {last_err:?}");
+}
+
+#[tokio::test]
+#[cfg(feature = "test-utils")]
+#[ignore = "requires Postgres setup; run with --features test-utils and enable when network/storage available"]
+async fn admin_holiday_list_integration_success() {
+    let _guard = integration_guard();
+    let config = support::test_config();
+    let pool = connect_with_retry(&config.database_url).await;
+    prepare_holiday_tables(&pool).await;
+    seed_integration_holidays(&pool).await;
+
+    let query = AdminHolidayListQuery {
+        page: Some(1),
+        per_page: Some(2),
+        r#type: Some("all".into()),
+        from: Some("2025-03-05".into()),
+        to: Some("2025-03-10".into()),
+    };
+
+    let Json(resp) = list_holidays(
+        State((pool.clone(), config.clone())),
+        Extension(test_admin()),
+        Query(query),
+    )
+    .await
+    .expect("list_holidays should succeed");
+
+    assert_eq!(resp.total, 4);
+    assert_eq!(resp.items.len(), 2);
+    let ids: Vec<_> = resp.items.iter().map(|i| i.id.as_str()).collect();
+    assert_eq!(ids, vec!["exception-310", "public-310"]);
+
+    let query_page2 = AdminHolidayListQuery {
+        page: Some(2),
+        per_page: Some(2),
+        r#type: Some("all".into()),
+        from: Some("2025-03-05".into()),
+        to: Some("2025-03-10".into()),
+    };
+
+    let Json(resp2) = list_holidays(
+        State((pool, config)),
+        Extension(test_admin()),
+        Query(query_page2),
+    )
+    .await
+    .expect("list_holidays page 2 should succeed");
+
+    let ids2: Vec<_> = resp2.items.iter().map(|i| i.id.as_str()).collect();
+    assert_eq!(ids2, vec!["weekly-310", "public-305"]);
+}
+
+#[tokio::test]
+#[cfg(feature = "test-utils")]
+#[ignore = "requires Postgres setup; run with --features test-utils and enable when network/storage available"]
+async fn admin_holiday_list_integration_type_filtering() {
+    let _guard = integration_guard();
+    let config = support::test_config();
+    let pool = connect_with_retry(&config.database_url).await;
+    prepare_holiday_tables(&pool).await;
+    seed_integration_holidays(&pool).await;
+
+    // Public only
+    let Json(public_resp) = list_holidays(
+        State((pool.clone(), config.clone())),
+        Extension(test_admin()),
+        Query(AdminHolidayListQuery {
+            page: Some(1),
+            per_page: Some(10),
+            r#type: Some("public".into()),
+            from: None,
+            to: None,
+        }),
+    )
+    .await
+    .expect("list_holidays public");
+    let public_ids: Vec<_> = public_resp.items.iter().map(|i| i.id.as_str()).collect();
+    assert_eq!(public_resp.total, 2);
+    assert_eq!(public_ids, vec!["public-310", "public-305"]);
+
+    // Weekly only
+    let Json(weekly_resp) = list_holidays(
+        State((pool.clone(), config.clone())),
+        Extension(test_admin()),
+        Query(AdminHolidayListQuery {
+            page: Some(1),
+            per_page: Some(10),
+            r#type: Some("weekly".into()),
+            from: None,
+            to: None,
+        }),
+    )
+    .await
+    .expect("list_holidays weekly");
+    let weekly_ids: Vec<_> = weekly_resp.items.iter().map(|i| i.id.as_str()).collect();
+    assert_eq!(weekly_resp.total, 1);
+    assert_eq!(weekly_ids, vec!["weekly-310"]);
+
+    // Exception only
+    let Json(exception_resp) = list_holidays(
+        State((pool, config)),
+        Extension(test_admin()),
+        Query(AdminHolidayListQuery {
+            page: Some(1),
+            per_page: Some(10),
+            r#type: Some("exception".into()),
+            from: None,
+            to: None,
+        }),
+    )
+    .await
+    .expect("list_holidays exception");
+    let exception_ids: Vec<_> = exception_resp.items.iter().map(|i| i.id.as_str()).collect();
+    assert_eq!(exception_resp.total, 1);
+    assert_eq!(exception_ids, vec!["exception-310"]);
+}
+
+#[test]
+fn validate_admin_holiday_query_accepts_valid_input() {
+    let result = mock_list_holidays(
+        vec![],
+        AdminHolidayListQuery {
+            page: Some(2),
+            per_page: Some(50),
+            r#type: Some("weekly".into()),
+            from: Some("2025-01-01".into()),
+            to: Some("2025-12-31".into()),
+        },
+    );
+    assert!(result.is_ok(), "validation should succeed");
+}
+
+#[test]
+fn validate_admin_holiday_query_rejects_invalid_type() {
+    let err = mock_list_holidays(
+        vec![],
+        AdminHolidayListQuery {
+            page: None,
+            per_page: None,
+            r#type: Some("unknown".into()),
+            from: None,
+            to: None,
+        },
+    )
+    .expect_err("invalid type should fail");
+    assert_eq!(err, "`type` must be one of public, weekly, exception, all");
+}
+
+#[test]
+fn validate_admin_holiday_query_rejects_invalid_date_formats() {
+    let err = mock_list_holidays(
+        vec![],
+        AdminHolidayListQuery {
+            page: Some(1),
+            per_page: Some(10),
+            r#type: Some("public".into()),
+            from: Some("2025/01/01".into()),
+            to: None,
+        },
+    )
+    .expect_err("invalid date format should fail");
+    assert_eq!(
+        err,
+        "`from`/`to` must be a valid date (YYYY-MM-DD or RFC3339)"
+    );
+}
+
+#[test]
+fn validate_admin_holiday_query_rejects_from_after_to() {
+    let err = mock_list_holidays(
+        vec![],
+        AdminHolidayListQuery {
+            page: Some(1),
+            per_page: Some(10),
+            r#type: Some("public".into()),
+            from: Some("2025-02-01".into()),
+            to: Some("2025-01-01".into()),
+        },
+    )
+    .expect_err("from > to should fail");
+    assert_eq!(err, "`from` must be before or equal to `to`");
+}
+
+#[test]
+fn validate_admin_holiday_query_clamps_page_and_per_page_boundaries() {
+    let response = mock_list_holidays(
+        vec![],
+        AdminHolidayListQuery {
+            page: Some(0),
+            per_page: Some(200),
+            r#type: None,
+            from: None,
+            to: None,
+        },
+    )
+    .expect("clamping should succeed");
+
+    assert_eq!(response.page, 1);
+    assert_eq!(response.per_page, 100);
 }

--- a/backend/tests/attendance_holiday.rs
+++ b/backend/tests/attendance_holiday.rs
@@ -1,17 +1,33 @@
 use chrono::{Datelike, NaiveDate};
 
-fn is_holiday_or_weekend(date: NaiveDate, holidays: &[NaiveDate]) -> bool {
+fn is_holiday_or_weekend(
+    date: NaiveDate,
+    holidays: &[NaiveDate],
+    overrides: &[(NaiveDate, bool)],
+) -> bool {
+    if let Some((_, override_workday)) = overrides.iter().find(|(d, _)| *d == date) {
+        return !override_workday;
+    }
     date.weekday().number_from_monday() >= 6 || holidays.contains(&date)
 }
 
 #[test]
 fn detects_weekend_without_db() {
     let saturday = NaiveDate::from_ymd_opt(2025, 3, 1).unwrap(); // Saturday
-    assert!(is_holiday_or_weekend(saturday, &[]));
+    assert!(is_holiday_or_weekend(saturday, &[], &[]));
 }
 
 #[test]
 fn detects_configured_holiday_without_db() {
     let holiday = NaiveDate::from_ymd_opt(2025, 3, 4).unwrap();
-    assert!(is_holiday_or_weekend(holiday, &[holiday]));
+    assert!(is_holiday_or_weekend(holiday, &[holiday], &[]));
+}
+
+#[test]
+fn override_can_cancel_holiday_without_db() {
+    let holiday = NaiveDate::from_ymd_opt(2025, 3, 4).unwrap();
+    assert!(
+        !is_holiday_or_weekend(holiday, &[holiday], &[(holiday, true)]),
+        "override=true should mark as working day"
+    );
 }

--- a/backend/tests/requests_api.rs
+++ b/backend/tests/requests_api.rs
@@ -1,4 +1,5 @@
-use timekeeper_backend::handlers::admin::AdminRequestListPageInfo;
+use timekeeper_backend::handlers::admin::{AdminRequestListPageInfo, paginate_requests};
+use timekeeper_backend::handlers::admin::RequestListQuery;
 
 #[test]
 fn pagination_info_without_db() {
@@ -8,4 +9,18 @@ fn pagination_info_without_db() {
     };
     assert_eq!(page_info.page, 2);
     assert_eq!(page_info.per_page, 10);
+
+    let query = RequestListQuery {
+        status: None,
+        r#type: None,
+        user_id: None,
+        from: None,
+        to: None,
+        page: Some(3),
+        per_page: Some(15),
+    };
+    let (page, per_page, offset) = paginate_requests(&query).expect("pagination ok");
+    assert_eq!(page, 3);
+    assert_eq!(per_page, 15);
+    assert_eq!(offset, 30);
 }


### PR DESCRIPTION
## Summary
- add reusable admin holiday query validation and export helpers for tests
- extract request pagination validation and expand holiday/auth unit coverage
- upgrade reqwest/dev dependencies and add test-utils feature gate for integration tests

## Issue
- N/A

## Backend Impact
- stricter validation for admin holiday listing and request pagination; deps updated

## Frontend Impact
- None

## Env Changes
- None

## Testing
- cd backend; cargo test