### PR TITLE
fix: harden attendance and token handling

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -283,6 +283,8 @@ pub async fn mfa_disable(
         ));
     }
 
+    revoke_active_tokens_for_user(&pool, &user.id).await?;
+
     Ok(Json(json!({"message": "MFA disabled"})))
 }
 
@@ -334,6 +336,7 @@ pub async fn change_password(
     }
 
     revoke_tokens_for_user(&pool, &user.id, "Failed to revoke refresh tokens").await?;
+    revoke_active_tokens_for_user(&pool, &user.id).await?;
 
     Ok(Json(json!({"message": "Password updated successfully"})))
 }


### PR DESCRIPTION
## Summary\n- revoke active tokens on password/MFA changes\n- block clock-out when breaks are still open\n- make admin attendance upsert atomic and validate export dates\n\n## Testing\n- cargo test backend