### PR TITLE
fix: guard admin export user filter

### DIFF
--- a/frontend/src/pages/admin/components/user_select.rs
+++ b/frontend/src/pages/admin/components/user_select.rs
@@ -20,6 +20,7 @@ pub fn AdminUserSelect(
     #[prop(optional_no_strip)] label: Option<String>,
     #[prop(default = "ユーザーを選択".to_string())] placeholder: String,
     #[prop(default = UserSelectValue::Id)] value_kind: UserSelectValue,
+    #[prop(into, default = MaybeSignal::Static(false))] disabled: MaybeSignal<bool>,
 ) -> impl IntoView {
     let fetch_error = create_rw_signal(None::<String>);
     let loading = users.loading();
@@ -63,8 +64,9 @@ pub fn AdminUserSelect(
                 .into_view();
         }
         match users.get() {
-            None => view! { <option value="" disabled>{"ユーザーを読み込み中..."}</option> }
-                .into_view(),
+            None => {
+                view! { <option value="" disabled>{"ユーザーを読み込み中..."}</option> }.into_view()
+            }
             Some(Err(_)) => {
                 view! { <option value="" disabled>{"ユーザーの取得に失敗しました"}</option> }
                     .into_view()
@@ -101,6 +103,7 @@ pub fn AdminUserSelect(
                 class="w-full border rounded px-2 py-1 bg-white disabled:opacity-50"
                 on:change=on_change
                 prop:value=selected
+                disabled=disabled
             >
                 <option value="">{placeholder.clone()}</option>
                 {move || options_view()}

--- a/frontend/src/pages/admin_export.rs
+++ b/frontend/src/pages/admin_export.rs
@@ -179,6 +179,11 @@ fn AdminExportPanel() -> impl IntoView {
                 from_date: from_date.get_untracked(),
                 to_date: to_date.get_untracked(),
             };
+            if use_specific_user.get_untracked() && filters.username_param().is_none() {
+                error.set(Some("指定ユーザーを選択してください。".into()));
+                preview.set(None);
+                return;
+            }
             if let Err(msg) = filters.validate() {
                 error.set(Some(msg));
                 preview.set(None);
@@ -225,27 +230,27 @@ fn AdminExportPanel() -> impl IntoView {
                                     {"指定ユーザー"}
                                 </label>
                             </div>
-                            <Show when=move || use_specific_user.get()>
-                                <Show when=move || users_error.get().is_some()>
-                                    <div class="space-y-1">
-                                        <input
-                                            class="w-full border rounded px-2 py-1"
-                                            placeholder="username を直接入力"
-                                            prop:value={move || username.get()}
-                                            on:input=move |ev| username.set(event_target_value(&ev))
-                                        />
-                                        <ErrorMessage message={users_error.get().unwrap_or_default()} />
-                                    </div>
-                                </Show>
-                                <Show when=move || users_error.get().is_none()>
-                                    <AdminUserSelect
-                                        users=users_resource.clone()
-                                        selected=username
-                                        label=None
-                                        placeholder="ユーザーを選択してください".into()
-                                        value_kind=UserSelectValue::Username
+                            <Show when=move || users_error.get().is_some()>
+                                <div class="space-y-1">
+                                    <input
+                                        class="w-full border rounded px-2 py-1 disabled:opacity-50"
+                                        placeholder="username を直接入力"
+                                        prop:value={move || username.get()}
+                                        on:input=move |ev| username.set(event_target_value(&ev))
+                                        disabled={move || !use_specific_user.get()}
                                     />
-                                </Show>
+                                    <ErrorMessage message={users_error.get().unwrap_or_default()} />
+                                </div>
+                            </Show>
+                            <Show when=move || users_error.get().is_none()>
+                                <AdminUserSelect
+                                    users=users_resource.clone()
+                                    selected=username
+                                    label=None
+                                    placeholder="ユーザーを選択してください".into()
+                                    value_kind=UserSelectValue::Username
+                                    disabled=move || !use_specific_user.get()
+                                />
                             </Show>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- disable username inputs when '指定ユーザー' is off
- require a user to be chosen before export when filtering by user

## Testing
- not run (not requested)