### PR TITLE
fix: wait for env.js before frontend init

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,13 +10,23 @@
 <body>
     <div id="app"></div>
     <script type="module">
-        // Optional runtime env overrides (if present). Ignored if 404.
-        const envScript = document.createElement('script');
-        envScript.src = './env.js';
-        document.head.appendChild(envScript);
+        // env.js での上書きを待ってから WASM を起動する
+        const loadEnv = new Promise((resolve) => {
+            const envScript = document.createElement('script');
+            envScript.src = './env.js';
+            envScript.async = false;
+            envScript.onload = () => resolve(true);
+            envScript.onerror = () => resolve(false); // env.js が無くても続行
+            document.head.appendChild(envScript);
+        });
 
-        import init from './pkg/timekeeper_frontend.js';
-        init();
+        async function bootstrap() {
+            await loadEnv;
+            const { default: init } = await import('./pkg/timekeeper_frontend.js');
+            await init();
+        }
+
+        bootstrap();
     </script>
 </body>
 </html>

--- a/frontend/src/config.rs
+++ b/frontend/src/config.rs
@@ -307,3 +307,26 @@ mod tests {
         assert_eq!(refreshed.time_zone.as_deref(), Some("Asia/Tokyo"));
     }
 }
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod wasm_tests {
+    use super::*;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test(async)]
+    async fn reads_api_base_url_from_window_env() {
+        let window = web_sys::window().expect("window available");
+        let env = js_sys::Object::new();
+        let _ = js_sys::Reflect::set(
+            &env,
+            &"API_BASE_URL".into(),
+            &wasm_bindgen::JsValue::from_str("https://example.test/api"),
+        );
+        let _ = js_sys::Reflect::set(&window, &"__TIMEKEEPER_ENV".into(), &env);
+
+        let resolved = await_api_base_url().await;
+        assert_eq!(resolved, "https://example.test/api");
+    }
+}


### PR DESCRIPTION
## Summary
- wait for env.js load before bootstrapping WASM to avoid config race
- add wasm-bindgen test to ensure __TIMEKEEPER_ENV.API_BASE_URL is used

## Issue
- Closes #54

## Testing
- Not run (not requested)