### PR TITLE
chore: add test compose and screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ docker-compose.yml
 /e2e/test-results/
 /e2e/playwright-report/
 /e2e/.cache/
+/e2e/screenshots/
 
 # Logs
 *.log

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,50 @@
+version: "3.8"
+
+services:
+  backend-test:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    container_name: timekeeper-backend-test
+    ports:
+      - "3001:3000"
+    environment:
+      - DATABASE_URL=postgres://timekeeper:timekeeper@backend-test-db:5432/timekeeper
+      - RUST_LOG=debug
+      - APP_TIMEZONE=${APP_TIMEZONE:-Asia/Tokyo}
+      - JWT_SECRET=Extrude,Malformed,Neurosis,Music,Smile,Ambush,Uncorrupt,Hatching,Platform,Posture
+    depends_on:
+      backend-test-db:
+        condition: service_healthy
+    networks:
+      - timekeeper_test_net
+
+  frontend-test:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    container_name: timekeeper-frontend-test
+    ports:
+      - "8081:80"
+    depends_on:
+      - backend-test
+    networks:
+      - timekeeper_test_net
+
+  backend-test-db:
+    image: postgres:16
+    environment:
+      - POSTGRES_DB=timekeeper
+      - POSTGRES_USER=timekeeper
+      - POSTGRES_PASSWORD=timekeeper
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "timekeeper"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - timekeeper_test_net
+
+networks:
+  timekeeper_test_net:
+    driver: bridge

--- a/e2e/screenshots.mjs
+++ b/e2e/screenshots.mjs
@@ -1,0 +1,157 @@
+import { chromium } from "playwright";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const base = process.env.FRONTEND_BASE_URL || "http://localhost:8080";
+const adminUsername = process.env.E2E_ADMIN_USER || "admin";
+const adminPassword = process.env.E2E_ADMIN_PASS || "admin123";
+const adminTotpCode = process.env.E2E_TOTP_CODE || "";
+const nonAdminUsername = process.env.E2E_NON_ADMIN_USER || "";
+const nonAdminPassword = process.env.E2E_NON_ADMIN_PASS || "";
+const nonAdminTotpCode = process.env.E2E_NON_ADMIN_TOTP_CODE || "";
+
+const viewports = [
+  { name: "desktop", width: 1280, height: 720 },
+  { name: "mobile", width: 768, height: 1024 },
+];
+
+const pages = [
+  {
+    name: "home",
+    path: "/",
+    waitFor: "text=少人数向けの勤怠管理システム",
+    requiresAuth: false,
+  },
+  { name: "login", path: "/login", waitFor: "#username", requiresAuth: false },
+  { name: "dashboard", path: "/dashboard", waitFor: "text=ダッシュボード", requiresAuth: true },
+  { name: "attendance", path: "/attendance", waitFor: "text=勤怠管理", requiresAuth: true },
+  { name: "requests", path: "/requests", waitFor: "text=申請管理", requiresAuth: true },
+  { name: "mfa", path: "/mfa/register", waitFor: "text=MFA 設定", requiresAuth: true },
+  { name: "admin", path: "/admin", waitFor: "text=管理者ツール", requiresAuth: true },
+  { name: "admin-users", path: "/admin/users", waitFor: "text=ユーザー管理", requiresAuth: true },
+  {
+    name: "admin-export-empty",
+    path: "/admin/export",
+    waitFor: "text=データエクスポート",
+    requiresAuth: true,
+    expectAbsentSelector: "text=プレビュー (先頭2KB)",
+  },
+];
+
+const unauthorizedPages = [
+  {
+    name: "admin-unauthorized",
+    path: "/admin",
+    waitFor: "text=このページは管理者以上の権限が必要です。",
+  },
+];
+
+const log = (message) => console.log(`[screenshots] ${message}`);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const outputDir = process.env.SCREENSHOT_DIR || path.join(__dirname, "screenshots");
+
+fs.mkdirSync(outputDir, { recursive: true });
+
+async function login(page, { username, password, totp }) {
+  log("ログイン開始");
+  await page.goto(`${base}/login`, { waitUntil: "domcontentloaded" });
+  await page.fill("#username", username);
+  await page.fill("#password", password);
+  if (totp) {
+    await page.fill("#totp_code", totp);
+  }
+  await page.click('button[type="submit"]');
+  await page.waitForURL("**/dashboard", { timeout: 20000 });
+  log("ログイン成功");
+}
+
+async function capturePage(page, viewportName, pageDef) {
+  const url = `${base}${pageDef.path}`;
+  log(`${viewportName} ${pageDef.name} を取得中: ${url}`);
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector(pageDef.waitFor, { timeout: 20000 });
+  if (pageDef.expectAbsentSelector) {
+    const count = await page.locator(pageDef.expectAbsentSelector).count();
+    if (count > 0) {
+      throw new Error(
+        `Expected ${pageDef.expectAbsentSelector} to be absent on ${pageDef.name}.`
+      );
+    }
+  }
+  const filename = `${pageDef.name}-${viewportName}.png`;
+  const filePath = path.join(outputDir, filename);
+  await page.screenshot({ path: filePath, fullPage: true });
+  log(`保存: ${filePath}`);
+}
+
+const browser = await chromium.launch({ headless: true });
+const hasNonAdminCredentials = Boolean(nonAdminUsername && nonAdminPassword);
+
+try {
+  if (!hasNonAdminCredentials) {
+    log("非管理者ユーザーが未設定のため未許可画面をスキップします。");
+    log("E2E_NON_ADMIN_USER と E2E_NON_ADMIN_PASS を設定してください。");
+  }
+
+  for (const viewport of viewports) {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+    });
+    const page = await context.newPage();
+    page.setDefaultTimeout(20000);
+
+    for (const pageDef of pages) {
+      if (pageDef.requiresAuth) {
+        break;
+      }
+      await capturePage(page, viewport.name, pageDef);
+    }
+
+    await login(page, {
+      username: adminUsername,
+      password: adminPassword,
+      totp: adminTotpCode,
+    });
+
+    for (const pageDef of pages.filter((p) => p.requiresAuth)) {
+      await capturePage(page, viewport.name, pageDef);
+    }
+
+    await context.close();
+
+    if (hasNonAdminCredentials) {
+      const nonAdminContext = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+      });
+      const nonAdminPage = await nonAdminContext.newPage();
+      nonAdminPage.setDefaultTimeout(20000);
+
+      await login(nonAdminPage, {
+        username: nonAdminUsername,
+        password: nonAdminPassword,
+        totp: nonAdminTotpCode,
+      });
+
+      for (const pageDef of unauthorizedPages) {
+        await capturePage(nonAdminPage, viewport.name, pageDef);
+      }
+
+      await nonAdminContext.close();
+    }
+  }
+
+  await browser.close();
+  log("スクリーンショット取得完了");
+  process.exit(0);
+} catch (error) {
+  console.error("[screenshots] 失敗:", error);
+  try {
+    await browser.close();
+  } catch {
+    // ignore
+  }
+  process.exit(1);
+}


### PR DESCRIPTION
# PR概要
- 変更サマリー: テスト環境用の docker-compose と Playwright のスクリーンショット取得スクリプトを追加
- 関連Issue / Linear: なし
- 対象: フロントエンド / インフラ

# 変更内容
- docker-compose（テスト環境）追加: `docker-compose.test.yml`
  - backend/frontend のコンテナ名・ポートを本番+1に変更
  - DBは永続ボリュームなし（内部通信のみ）
- Playwright スクリーンショット取得スクリプト追加: `e2e/screenshots.mjs`
  - 1280/768 の2サイズでフルページ撮影
  - 主要ページ + 管理画面 + 未許可画面を撮影
- 生成物除外: `.gitignore` に `/e2e/screenshots/` 追加

# 影響範囲
- バックエンドへの影響: なし（テスト用 compose 追加のみ）
- フロントエンドへの影響: なし（撮影スクリプト追加のみ）
- 破壊的変更: なし

# 環境変数の差分
- 追加:
  - `FRONTEND_BASE_URL`
  - `E2E_ADMIN_USER`
  - `E2E_ADMIN_PASS`
  - `E2E_TOTP_CODE`（任意）
  - `E2E_NON_ADMIN_USER`（未許可画面取得時）
  - `E2E_NON_ADMIN_PASS`（未許可画面取得時）
  - `E2E_NON_ADMIN_TOTP_CODE`（任意）
  - `SCREENSHOT_DIR`（任意）
- 変更: なし
- 削除: なし

# テストエビデンス
- `cargo test`: 未実行
- `cargo clippy --all-targets -- -D warnings`: 未実行
- `wasm-pack test --headless --firefox`: 未実行
- `node e2e/run.mjs`: 未実行
- `node e2e/screenshots.mjs`: 未実行

# スクリーンショット / 出力
- 取得方法:
  - `node e2e/screenshots.mjs`
- 保存先:
  - `e2e/screenshots/`
- 添付:
  - 未取得

# 補足
- 非管理者の未許可画面は `E2E_NON_ADMIN_USER` / `E2E_NON_ADMIN_PASS` 未設定時はスキップされます。
