### PR TITLE
fix: refresh token retry on 401

### DIFF
--- a/frontend/src/api/attendance.rs
+++ b/frontend/src/api/attendance.rs
@@ -17,7 +17,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .post(&format!("{}/attendance/clock-in", base_url))
+                    .post(format!("{}/attendance/clock-in", base_url))
                     .headers(headers)
                     .json(&json!({})))
             })
@@ -46,7 +46,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .post(&format!("{}/attendance/clock-out", base_url))
+                    .post(format!("{}/attendance/clock-out", base_url))
                     .headers(headers)
                     .json(&json!({})))
             })
@@ -119,7 +119,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .post(&format!("{}/attendance/break-start", base_url))
+                    .post(format!("{}/attendance/break-start", base_url))
                     .headers(headers)
                     .json(&json!({ "attendance_id": attendance_id })))
             })
@@ -147,7 +147,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .post(&format!("{}/attendance/break-end", base_url))
+                    .post(format!("{}/attendance/break-end", base_url))
                     .headers(headers)
                     .json(&json!({ "break_record_id": break_record_id })))
             })
@@ -281,7 +281,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .put(&format!("{}/admin/attendance", base_url))
+                    .put(format!("{}/admin/attendance", base_url))
                     .headers(headers)
                     .json(&payload))
             })
@@ -312,7 +312,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .put(&format!("{}/admin/breaks/{}/force-end", base_url, break_id))
+                    .put(format!("{}/admin/breaks/{}/force-end", base_url, break_id))
                     .headers(headers))
             })
             .await?;
@@ -399,7 +399,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 let mut request = self
                     .http_client()
-                    .get(&format!("{}/attendance/export", base_url))
+                    .get(format!("{}/attendance/export", base_url))
                     .headers(headers);
                 if !params.is_empty() {
                     request = request.query(&params);

--- a/frontend/src/api/auth.rs
+++ b/frontend/src/api/auth.rs
@@ -15,7 +15,7 @@ impl ApiClient {
         let base_url = self.resolved_base_url().await;
         let response = self
             .http_client()
-            .post(&format!("{}/auth/login", base_url))
+            .post(format!("{}/auth/login", base_url))
             .json(&request)
             .send()
             .await
@@ -60,7 +60,7 @@ impl ApiClient {
 
         let response = self
             .http_client()
-            .post(&format!("{}/auth/refresh", base_url))
+            .post(format!("{}/auth/refresh", base_url))
             .json(&payload)
             .send()
             .await
@@ -105,7 +105,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .post(&format!("{}/auth/logout", base_url))
+                    .post(format!("{}/auth/logout", base_url))
                     .headers(headers)
                     .json(&body))
             })
@@ -129,7 +129,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .get(&format!("{}/auth/mfa", base_url))
+                    .get(format!("{}/auth/mfa", base_url))
                     .headers(headers))
             })
             .await?;
@@ -157,7 +157,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .post(&format!("{}/auth/mfa/register", base_url))
+                    .post(format!("{}/auth/mfa/register", base_url))
                     .headers(headers)
                     .json(&json!({})))
             })
@@ -186,7 +186,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .post(&format!("{}/auth/mfa/activate", base_url))
+                    .post(format!("{}/auth/mfa/activate", base_url))
                     .headers(headers)
                     .json(&json!({ "code": code })))
             })

--- a/frontend/src/api/client.rs
+++ b/frontend/src/api/client.rs
@@ -121,7 +121,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .get(&format!("{}/admin/users", base_url))
+                    .get(format!("{}/admin/users", base_url))
                     .headers(headers))
             })
             .await?;
@@ -149,7 +149,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .post(&format!("{}/admin/users", base_url))
+                    .post(format!("{}/admin/users", base_url))
                     .headers(headers)
                     .json(&request))
             })
@@ -178,7 +178,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .post(&format!("{}/admin/mfa/reset", base_url))
+                    .post(format!("{}/admin/mfa/reset", base_url))
                     .headers(headers)
                     .json(&json!({ "user_id": user_id })))
             })
@@ -203,7 +203,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .get(&format!("{}/holidays", base_url))
+                    .get(format!("{}/holidays", base_url))
                     .headers(headers))
             })
             .await?;
@@ -248,7 +248,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .get(&format!("{}/admin/holidays", base_url))
+                    .get(format!("{}/admin/holidays", base_url))
                     .headers(headers)
                     .query(&params))
             })
@@ -280,7 +280,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .post(&format!("{}/admin/holidays", base_url))
+                    .post(format!("{}/admin/holidays", base_url))
                     .headers(headers)
                     .json(payload))
             })
@@ -309,7 +309,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .delete(&format!("{}/admin/holidays/{}", base_url, id))
+                    .delete(format!("{}/admin/holidays/{}", base_url, id))
                     .headers(headers))
             })
             .await?;
@@ -337,7 +337,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .get(&format!("{}/holidays/check", base_url))
+                    .get(format!("{}/holidays/check", base_url))
                     .query(&[("date", date.format("%Y-%m-%d").to_string())])
                     .headers(headers))
             })
@@ -370,7 +370,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .get(&format!("{}/holidays/month", base_url))
+                    .get(format!("{}/holidays/month", base_url))
                     .query(&[("year", year.to_string()), ("month", month.to_string())])
                     .headers(headers))
             })
@@ -399,7 +399,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .get(&format!("{}/admin/holidays/weekly", base_url))
+                    .get(format!("{}/admin/holidays/weekly", base_url))
                     .headers(headers))
             })
             .await?;
@@ -430,7 +430,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .post(&format!("{}/admin/holidays/weekly", base_url))
+                    .post(format!("{}/admin/holidays/weekly", base_url))
                     .headers(headers)
                     .json(payload))
             })
@@ -491,7 +491,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .client
-                    .get(&format!("{}/admin/export", base_url))
+                    .get(format!("{}/admin/export", base_url))
                     .headers(headers))
             })
             .await?;
@@ -541,7 +541,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 let mut request = self
                     .client
-                    .get(&format!("{}/admin/export", base_url))
+                    .get(format!("{}/admin/export", base_url))
                     .headers(headers);
                 if !params.is_empty() {
                     request = request.query(&params);

--- a/frontend/src/api/requests.rs
+++ b/frontend/src/api/requests.rs
@@ -51,7 +51,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .get(&format!("{}/admin/requests/{}", base_url, id))
+                    .get(format!("{}/admin/requests/{}", base_url, id))
                     .headers(headers))
             })
             .await?;
@@ -78,7 +78,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .put(&format!("{}/admin/requests/{}/{}", base_url, id, action))
+                    .put(format!("{}/admin/requests/{}/{}", base_url, id, action))
                     .headers(headers)
                     .json(&json!({ "comment": comment })))
             })
@@ -93,7 +93,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .put(&format!("{}/requests/{}", base_url, id))
+                    .put(format!("{}/requests/{}", base_url, id))
                     .headers(headers)
                     .json(&payload))
             })
@@ -108,7 +108,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .delete(&format!("{}/requests/{}", base_url, id))
+                    .delete(format!("{}/requests/{}", base_url, id))
                     .headers(headers))
             })
             .await?;
@@ -140,7 +140,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .post(&format!("{}/requests/{}", base_url, kind))
+                    .post(format!("{}/requests/{}", base_url, kind))
                     .headers(headers)
                     .json(&payload))
             })
@@ -169,7 +169,7 @@ impl ApiClient {
                 let headers = self.get_auth_headers()?;
                 Ok(self
                     .http_client()
-                    .get(&format!("{}/requests/me", base_url))
+                    .get(format!("{}/requests/me", base_url))
                     .headers(headers))
             })
             .await?;


### PR DESCRIPTION
## Summary
- add API request retry flow that refreshes tokens on 401 and retries the original request
- remove needless borrows in API request URL formatting introduced with the retry helpers
- keep existing unauthorized handling behavior after retry attempts

## Related
- #55

## Testing
- TMPDIR=/tmp TMP=/tmp TEMP=/tmp cargo test -p timekeeper-frontend
- TMPDIR=/tmp TMP=/tmp TEMP=/tmp cargo clippy --all-targets -- -D warnings (fails due to existing warnings tracked in #68)
