### PR TITLE
feat: add mobile cards for admin users

### DIFF
--- a/frontend/src/pages/admin_users/components/list.rs
+++ b/frontend/src/pages/admin_users/components/list.rs
@@ -39,66 +39,123 @@ pub fn UserList(
                 </p>
             </Show>
             <Show when=move || !users.get().is_empty()>
-                <div class="overflow-x-auto">
-                    <table class="min-w-full divide-y divide-gray-200">
-                        <thead>
-                            <tr>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    {"ユーザー名"}
-                                </th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    {"氏名"}
-                                </th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    {"権限"}
-                                </th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    {"システム管理者"}
-                                </th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    {"MFA"}
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody class="bg-white divide-y divide-gray-200">
-                            <For
-                                each=move || users.get()
-                                key=|user| user.id.clone()
-                                children=move |user: UserResponse| {
+                <>
+                    <div class="space-y-3 md:hidden">
+                        <For
+                            each=move || users.get()
+                            key=|user| user.id.clone()
+                            children=move |user: UserResponse| {
+                                let on_select = on_select.clone();
+                                let row_user = user.clone();
+                                let click_handler = {
                                     let on_select = on_select.clone();
-                                    let row_user = user.clone();
-                                    let click_handler = {
-                                        let on_select = on_select.clone();
-                                        let selected = row_user.clone();
-                                        move |_| on_select.call(selected.clone())
-                                    };
-                                    view! {
-                                        <tr
-                                            class="hover:bg-gray-50 cursor-pointer"
-                                            on:click=click_handler
-                                        >
-                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                                {row_user.username.clone()}
-                                            </td>
-                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                                {row_user.full_name.clone()}
-                                            </td>
-                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                                {row_user.role.clone()}
-                                            </td>
-                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                                {if row_user.is_system_admin { "Yes" } else { "No" }}
-                                            </td>
-                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                                {if row_user.mfa_enabled { "Enabled" } else { "Disabled" }}
-                                            </td>
-                                        </tr>
-                                    }
+                                    let selected = row_user.clone();
+                                    move |_| on_select.call(selected.clone())
+                                };
+                                view! {
+                                    <button
+                                        class="w-full text-left border border-gray-200 rounded-lg p-4 shadow-sm hover:bg-gray-50"
+                                        on:click=click_handler
+                                        type="button"
+                                    >
+                                        <div class="flex items-start justify-between gap-3">
+                                            <div>
+                                                <p class="text-sm text-gray-500">{"ユーザー名"}</p>
+                                                <p class="text-base font-semibold text-gray-900">
+                                                    {row_user.username.clone()}
+                                                </p>
+                                            </div>
+                                            <div class="text-right">
+                                                <p class="text-sm text-gray-500">{"権限"}</p>
+                                                <p class="text-sm font-medium text-gray-900">
+                                                    {row_user.role.clone()}
+                                                </p>
+                                            </div>
+                                        </div>
+                                        <div class="mt-3 grid grid-cols-2 gap-3 text-sm">
+                                            <div>
+                                                <p class="text-gray-500">{"氏名"}</p>
+                                                <p class="text-gray-900">{row_user.full_name.clone()}</p>
+                                            </div>
+                                            <div>
+                                                <p class="text-gray-500">{"システム管理者"}</p>
+                                                <p class="text-gray-900">
+                                                    {if row_user.is_system_admin { "Yes" } else { "No" }}
+                                                </p>
+                                            </div>
+                                            <div>
+                                                <p class="text-gray-500">{"MFA"}</p>
+                                                <p class="text-gray-900">
+                                                    {if row_user.mfa_enabled { "Enabled" } else { "Disabled" }}
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </button>
                                 }
-                            />
-                        </tbody>
-                    </table>
-                </div>
+                            }
+                        />
+                    </div>
+                    <div class="hidden md:block overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead>
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                        {"ユーザー名"}
+                                    </th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                        {"氏名"}
+                                    </th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                        {"権限"}
+                                    </th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                        {"システム管理者"}
+                                    </th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                        {"MFA"}
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                <For
+                                    each=move || users.get()
+                                    key=|user| user.id.clone()
+                                    children=move |user: UserResponse| {
+                                        let on_select = on_select.clone();
+                                        let row_user = user.clone();
+                                        let click_handler = {
+                                            let on_select = on_select.clone();
+                                            let selected = row_user.clone();
+                                            move |_| on_select.call(selected.clone())
+                                        };
+                                        view! {
+                                            <tr
+                                                class="hover:bg-gray-50 cursor-pointer"
+                                                on:click=click_handler
+                                            >
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                    {row_user.username.clone()}
+                                                </td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                    {row_user.full_name.clone()}
+                                                </td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                    {row_user.role.clone()}
+                                                </td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                    {if row_user.is_system_admin { "Yes" } else { "No" }}
+                                                </td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                    {if row_user.mfa_enabled { "Enabled" } else { "Disabled" }}
+                                                </td>
+                                            </tr>
+                                        }
+                                    }
+                                />
+                            </tbody>
+                        </table>
+                    </div>
+                </>
             </Show>
         </div>
     }


### PR DESCRIPTION
## Summary
- add a mobile card layout for the admin users list
- keep the existing table on `md` and above
- make each card clickable to open the user detail drawer

## Related
- #65

## Testing
- TMPDIR=/tmp TMP=/tmp TEMP=/tmp cargo test -p timekeeper-frontend
- TMPDIR=/tmp TMP=/tmp TEMP=/tmp cargo clippy --all-targets -- -D warnings (fails due to existing warnings tracked in #68)
