### PR TITLE
fix: clean up frontend warnings

### DIFF
--- a/frontend/src/api/attendance.rs
+++ b/frontend/src/api/attendance.rs
@@ -68,50 +68,6 @@ impl ApiClient {
         }
     }
 
-    pub async fn get_my_attendance(
-        &self,
-        year: Option<i32>,
-        month: Option<u32>,
-    ) -> Result<Vec<AttendanceResponse>, String> {
-        let base_url = self.resolved_base_url().await;
-        let mut url = format!("{}/attendance/me", base_url);
-        let mut query_params = Vec::new();
-
-        if let Some(year) = year {
-            query_params.push(format!("year={}", year));
-        }
-        if let Some(month) = month {
-            query_params.push(format!("month={}", month));
-        }
-
-        if !query_params.is_empty() {
-            url.push('?');
-            url.push_str(&query_params.join("&"));
-        }
-
-        let response = self
-            .send_with_refresh(|| {
-                let headers = self.get_auth_headers()?;
-                Ok(self.http_client().get(&url).headers(headers))
-            })
-            .await?;
-
-        let status = response.status();
-        Self::handle_unauthorized_status(status);
-        if status.is_success() {
-            response
-                .json()
-                .await
-                .map_err(|e| format!("Failed to parse response: {}", e))
-        } else {
-            let error: ApiError = response
-                .json()
-                .await
-                .map_err(|e| format!("Failed to parse error: {}", e))?;
-            Err(error.error)
-        }
-    }
-
     pub async fn break_start(&self, attendance_id: &str) -> Result<BreakRecordResponse, String> {
         let base_url = self.resolved_base_url().await;
         let response = self

--- a/frontend/src/api/client.rs
+++ b/frontend/src/api/client.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chrono::NaiveDate;
 use reqwest_wasm::{Client, StatusCode};
@@ -18,13 +17,6 @@ impl ApiClient {
         Self {
             client: Client::new(),
             base_url: None,
-        }
-    }
-
-    pub fn new_with_base_url(base_url: impl Into<String>) -> Self {
-        Self {
-            client: Client::new(),
-            base_url: Some(base_url.into()),
         }
     }
 
@@ -189,34 +181,6 @@ impl ApiClient {
             Ok(())
         } else {
             let error: ApiError = resp
-                .json()
-                .await
-                .map_err(|e| format!("Failed to parse error: {}", e))?;
-            Err(error.error)
-        }
-    }
-
-    pub async fn get_public_holidays(&self) -> Result<Vec<HolidayResponse>, String> {
-        let base_url = self.resolved_base_url().await;
-        let response = self
-            .send_with_refresh(|| {
-                let headers = self.get_auth_headers()?;
-                Ok(self
-                    .client
-                    .get(format!("{}/holidays", base_url))
-                    .headers(headers))
-            })
-            .await?;
-
-        let status = response.status();
-        Self::handle_unauthorized_status(status);
-        if status.is_success() {
-            response
-                .json()
-                .await
-                .map_err(|e| format!("Failed to parse response: {}", e))
-        } else {
-            let error: ApiError = response
                 .json()
                 .await
                 .map_err(|e| format!("Failed to parse error: {}", e))?;
@@ -465,34 +429,6 @@ impl ApiClient {
             .send_with_refresh(|| {
                 let headers = self.get_auth_headers()?;
                 Ok(self.client.get(&url).headers(headers))
-            })
-            .await?;
-
-        let status = response.status();
-        Self::handle_unauthorized_status(status);
-        if status.is_success() {
-            response
-                .json()
-                .await
-                .map_err(|e| format!("Failed to parse response: {}", e))
-        } else {
-            let error: ApiError = response
-                .json()
-                .await
-                .map_err(|e| format!("Failed to parse error: {}", e))?;
-            Err(error.error)
-        }
-    }
-
-    pub async fn export_data(&self) -> Result<serde_json::Value, String> {
-        let base_url = self.resolved_base_url().await;
-        let response = self
-            .send_with_refresh(|| {
-                let headers = self.get_auth_headers()?;
-                Ok(self
-                    .client
-                    .get(format!("{}/admin/export", base_url))
-                    .headers(headers))
             })
             .await?;
 

--- a/frontend/src/api/requests.rs
+++ b/frontend/src/api/requests.rs
@@ -44,20 +44,6 @@ impl ApiClient {
         self.map_json_response(response).await
     }
 
-    pub async fn admin_get_request_detail(&self, id: &str) -> Result<Value, String> {
-        let base_url = self.resolved_base_url().await;
-        let response = self
-            .send_with_refresh(|| {
-                let headers = self.get_auth_headers()?;
-                Ok(self
-                    .http_client()
-                    .get(format!("{}/admin/requests/{}", base_url, id))
-                    .headers(headers))
-            })
-            .await?;
-        self.map_json_response(response).await
-    }
-
     pub async fn admin_approve_request(&self, id: &str, comment: &str) -> Result<Value, String> {
         self.admin_mutate_request(id, "approve", comment).await
     }

--- a/frontend/src/api/types.rs
+++ b/frontend/src/api/types.rs
@@ -37,11 +37,6 @@ pub struct MfaSetupResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MfaCodeRequest {
-    pub code: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MfaStatusResponse {
     pub enabled: bool,
     pub pending: bool,

--- a/frontend/src/components/forms.rs
+++ b/frontend/src/components/forms.rs
@@ -94,17 +94,16 @@ pub fn AttendanceActionButtons(
     let last_event = create_rw_signal(None::<ClockEventKind>);
 
     let clock_action = {
-        let set_attendance_state = set_attendance_state.clone();
         create_action(move |payload: &ClockEventPayload| {
-            let set_attendance_state = set_attendance_state.clone();
+            let set_attendance_state = set_attendance_state;
             let payload = payload.clone();
             async move {
                 match payload.kind {
                     ClockEventKind::ClockIn => {
-                        attendance_state::clock_in(set_attendance_state.clone()).await?
+                        attendance_state::clock_in(set_attendance_state).await?
                     }
                     ClockEventKind::ClockOut => {
-                        attendance_state::clock_out(set_attendance_state.clone()).await?
+                        attendance_state::clock_out(set_attendance_state).await?
                     }
                     ClockEventKind::BreakStart => {
                         let attendance_id = payload
@@ -127,9 +126,6 @@ pub fn AttendanceActionButtons(
     };
     let action_pending = clock_action.pending();
     {
-        let clock_action = clock_action.clone();
-        let set_message = set_message.clone();
-        let last_event = last_event.clone();
         create_effect(move |_| {
             if let Some(result) = clock_action.value().get() {
                 match result {
@@ -150,10 +146,6 @@ pub fn AttendanceActionButtons(
     }
 
     let handle_clock_in = {
-        let clock_action = clock_action.clone();
-        let action_pending = action_pending;
-        let set_message = set_message.clone();
-        let last_event = last_event.clone();
         move |_| {
             if action_pending.get() {
                 return;
@@ -165,10 +157,6 @@ pub fn AttendanceActionButtons(
     };
 
     let handle_clock_out = {
-        let clock_action = clock_action.clone();
-        let action_pending = action_pending;
-        let set_message = set_message.clone();
-        let last_event = last_event.clone();
         move |_| {
             if action_pending.get() {
                 return;
@@ -180,11 +168,6 @@ pub fn AttendanceActionButtons(
     };
 
     let handle_break_start = {
-        let attendance_state = attendance_state.clone();
-        let set_message = set_message.clone();
-        let clock_action = clock_action.clone();
-        let action_pending = action_pending;
-        let last_event = last_event.clone();
         move |_| {
             if action_pending.get() {
                 return;
@@ -208,11 +191,6 @@ pub fn AttendanceActionButtons(
     };
 
     let handle_break_end = {
-        let attendance_state = attendance_state.clone();
-        let set_message = set_message.clone();
-        let clock_action = clock_action.clone();
-        let action_pending = action_pending;
-        let last_event = last_event.clone();
         move |_| {
             if action_pending.get() {
                 return;

--- a/frontend/src/components/guard.rs
+++ b/frontend/src/components/guard.rs
@@ -22,7 +22,7 @@ pub fn RequireAuth(children: ChildrenFn) -> impl IntoView {
                 if is_loading.get() {
                     view! { <LoadingSpinner /> }.into_view()
                 } else {
-                    view! { <></> }.into_view()
+                    ().into_view()
                 }
             }
         >

--- a/frontend/src/components/layout.rs
+++ b/frontend/src/components/layout.rs
@@ -26,7 +26,6 @@ pub fn Header() -> impl IntoView {
     let logout_action = auth::use_logout_action();
     let logout_pending = logout_action.pending();
     {
-        let logout_action = logout_action.clone();
         create_effect(move |_| {
             if logout_action.value().get().is_some() {
                 if let Some(win) = web_sys::window() {
@@ -36,9 +35,6 @@ pub fn Header() -> impl IntoView {
         });
     }
     let on_logout = {
-        let logout_action = logout_action.clone();
-        let logout_pending = logout_pending.clone();
-        let set_menu_open = set_menu_open.clone();
         move |_| {
             if logout_pending.get_untracked() {
                 return;
@@ -47,10 +43,7 @@ pub fn Header() -> impl IntoView {
             logout_action.dispatch(false);
         }
     };
-    let toggle_menu = {
-        let set_menu_open = set_menu_open.clone();
-        move |_| set_menu_open.update(|open| *open = !*open)
-    };
+    let toggle_menu = { move |_| set_menu_open.update(|open| *open = !*open) };
     view! {
         <header class="bg-white shadow-sm border-b">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -226,7 +219,6 @@ pub fn TimeZoneWarningBanner() -> impl IntoView {
     let (refreshing, set_refreshing) = create_signal(false);
 
     {
-        let set_status = set_status.clone();
         spawn_local(async move {
             config::await_time_zone().await;
             set_status.set(config::time_zone_status());
@@ -239,8 +231,6 @@ pub fn TimeZoneWarningBanner() -> impl IntoView {
         }
         set_refreshing.set(true);
         set_status.update(|state| state.loading = true);
-        let set_status = set_status.clone();
-        let set_refreshing = set_refreshing.clone();
         spawn_local(async move {
             let new_status = config::refresh_time_zone().await;
             if new_status.last_error.is_some() {

--- a/frontend/src/pages/admin/components/attendance.rs
+++ b/frontend/src/pages/admin/components/attendance.rs
@@ -33,7 +33,6 @@ pub fn AdminAttendanceToolsSection(
     let error = create_rw_signal(None::<String>);
 
     let add_break = {
-        let breaks = breaks.clone();
         move |_| {
             breaks.update(|list| list.push((String::new(), String::new())));
         }
@@ -56,8 +55,6 @@ pub fn AdminAttendanceToolsSection(
     let force_pending = force_break_action.pending();
 
     {
-        let message = message.clone();
-        let error = error.clone();
         create_effect(move |_| {
             if let Some(result) = attendance_action.value().get() {
                 match result {
@@ -74,8 +71,6 @@ pub fn AdminAttendanceToolsSection(
         });
     }
     {
-        let message = message.clone();
-        let error = error.clone();
         create_effect(move |_| {
             if let Some(result) = force_break_action.value().get() {
                 match result {
@@ -93,14 +88,6 @@ pub fn AdminAttendanceToolsSection(
     }
 
     let on_submit_attendance = {
-        let att_user = att_user.clone();
-        let att_date = att_date.clone();
-        let att_in = att_in.clone();
-        let att_out = att_out.clone();
-        let breaks = breaks.clone();
-        let attendance_action = attendance_action.clone();
-        let message = message.clone();
-        let error = error.clone();
         move |ev: ev::SubmitEvent| {
             ev.prevent_default();
             if !system_admin_allowed.get_untracked() {
@@ -163,10 +150,6 @@ pub fn AdminAttendanceToolsSection(
     };
 
     let on_force_end = {
-        let break_force_id = break_force_id.clone();
-        let force_break_action = force_break_action.clone();
-        let error = error.clone();
-        let message = message.clone();
         move |_| {
             if !system_admin_allowed.get_untracked() {
                 return;

--- a/frontend/src/pages/admin/components/holidays.rs
+++ b/frontend/src/pages/admin/components/holidays.rs
@@ -112,7 +112,6 @@ pub fn HolidayManagementSection(
         })
     });
     let on_prev_page = {
-        let holiday_query = holiday_query.clone();
         move |_| {
             holiday_query.update(|query| {
                 if query.page > 1 {
@@ -122,8 +121,6 @@ pub fn HolidayManagementSection(
         }
     };
     let on_next_page = {
-        let holiday_query = holiday_query.clone();
-        let can_go_next = can_go_next.clone();
         move |_| {
             if can_go_next.get_untracked() {
                 holiday_query.update(|query| query.page += 1);
@@ -131,7 +128,6 @@ pub fn HolidayManagementSection(
         }
     };
     let on_per_page_change = {
-        let holiday_query = holiday_query.clone();
         move |ev: ev::Event| {
             if let Ok(value) = event_target_value(&ev).parse::<i64>() {
                 holiday_query.update(|query| {
@@ -142,11 +138,6 @@ pub fn HolidayManagementSection(
         }
     };
     let on_apply_filters = {
-        let filter_from_input = filter_from_input.clone();
-        let filter_to_input = filter_to_input.clone();
-        let holiday_error = holiday_error.clone();
-        let holiday_message = holiday_message.clone();
-        let holiday_query = holiday_query.clone();
         move |_| {
             let from_raw = filter_from_input.get();
             let to_raw = filter_to_input.get();
@@ -189,11 +180,6 @@ pub fn HolidayManagementSection(
         }
     };
     let on_clear_filters = {
-        let filter_from_input = filter_from_input.clone();
-        let filter_to_input = filter_to_input.clone();
-        let holiday_error = holiday_error.clone();
-        let holiday_message = holiday_message.clone();
-        let holiday_query = holiday_query.clone();
         move |_| {
             filter_from_input.set(String::new());
             filter_to_input.set(String::new());
@@ -207,12 +193,6 @@ pub fn HolidayManagementSection(
         }
     };
     let on_apply_calendar_range = {
-        let calendar_month_input = calendar_month_input.clone();
-        let filter_from_input = filter_from_input.clone();
-        let filter_to_input = filter_to_input.clone();
-        let holiday_error = holiday_error.clone();
-        let holiday_message = holiday_message.clone();
-        let holiday_query = holiday_query.clone();
         move |_| {
             let month_raw = calendar_month_input.get();
             let trimmed = month_raw.trim();
@@ -255,12 +235,6 @@ pub fn HolidayManagementSection(
     });
     let create_pending = create_holiday_action.pending();
     {
-        let holiday_message = holiday_message.clone();
-        let holiday_error = holiday_error.clone();
-        let holidays_reload = holidays_reload.clone();
-        let holiday_date_input = holiday_date_input.clone();
-        let holiday_name_input = holiday_name_input.clone();
-        let holiday_desc_input = holiday_desc_input.clone();
         create_effect(move |_| {
             if let Some(result) = create_holiday_action.value().get() {
                 match result {
@@ -292,10 +266,6 @@ pub fn HolidayManagementSection(
         async move { repo.delete_holiday(&id).await }
     });
     {
-        let deleting_id = deleting_id.clone();
-        let holidays_reload = holidays_reload.clone();
-        let holiday_message = holiday_message.clone();
-        let holiday_error = holiday_error.clone();
         create_effect(move |_| {
             if let Some(result) = delete_holiday_action.value().get() {
                 match result {
@@ -326,8 +296,6 @@ pub fn HolidayManagementSection(
     });
     let google_loading = fetch_google_action.pending();
     {
-        let google_holidays = google_holidays.clone();
-        let google_error = google_error.clone();
         create_effect(move |_| {
             if let Some(result) = fetch_google_action.value().get() {
                 match result {
@@ -358,9 +326,6 @@ pub fn HolidayManagementSection(
         }
     });
     {
-        let holiday_message = holiday_message.clone();
-        let holiday_error = holiday_error.clone();
-        let holidays_reload = holidays_reload.clone();
         create_effect(move |_| {
             if let Some(result) = import_action.value().get() {
                 match result {
@@ -384,8 +349,6 @@ pub fn HolidayManagementSection(
     }
 
     let on_fetch_google = {
-        let google_year_input = google_year_input.clone();
-        let fetch_google_action = fetch_google_action.clone();
         move |_| {
             let parsed_year = google_year_input.get().trim().parse::<i32>().ok();
             fetch_google_action.dispatch(parsed_year);
@@ -393,12 +356,6 @@ pub fn HolidayManagementSection(
     };
 
     let on_create_holiday = {
-        let holiday_date_input = holiday_date_input.clone();
-        let holiday_name_input = holiday_name_input.clone();
-        let holiday_desc_input = holiday_desc_input.clone();
-        let holiday_error = holiday_error.clone();
-        let holiday_message = holiday_message.clone();
-        let create_holiday_action = create_holiday_action.clone();
         move |ev: ev::SubmitEvent| {
             ev.prevent_default();
             let date_raw = holiday_date_input.get();
@@ -433,8 +390,6 @@ pub fn HolidayManagementSection(
     };
 
     let on_delete_holiday = {
-        let delete_holiday_action = delete_holiday_action.clone();
-        let deleting_id = deleting_id.clone();
         move |id: String| {
             deleting_id.set(Some(id.clone()));
             delete_holiday_action.dispatch(id);
@@ -442,11 +397,6 @@ pub fn HolidayManagementSection(
     };
 
     let on_import_google = {
-        let google_holidays = google_holidays.clone();
-        let holidays_data = holidays_data.clone();
-        let import_action = import_action.clone();
-        let holiday_error = holiday_error.clone();
-        let holiday_message = holiday_message.clone();
         move |_| {
             let existing: HashSet<NaiveDate> = holidays_data
                 .get()

--- a/frontend/src/pages/admin/components/requests.rs
+++ b/frontend/src/pages/admin/components/requests.rs
@@ -77,9 +77,6 @@ pub fn AdminRequestsSection(
     });
     let action_pending = request_action.pending();
     {
-        let modal_open = modal_open.clone();
-        let action_error = action_error.clone();
-        let reload = reload.clone();
         create_effect(move |_| {
             if let Some(result) = request_action.value().get() {
                 match result {
@@ -94,14 +91,10 @@ pub fn AdminRequestsSection(
         });
     }
 
-    let trigger_reload = {
-        let reload = reload.clone();
-        move || reload.update(|value| *value = value.wrapping_add(1))
-    };
+    let trigger_reload = { move || reload.update(|value| *value = value.wrapping_add(1)) };
 
     let on_status_change = {
         let filter_state = filter_state.clone();
-        let trigger_reload = trigger_reload.clone();
         move |value: String| {
             filter_state.status_signal().set(value);
             filter_state.reset_page();
@@ -111,7 +104,6 @@ pub fn AdminRequestsSection(
 
     let on_search = {
         let filter_state = filter_state.clone();
-        let trigger_reload = trigger_reload.clone();
         move |_| {
             filter_state.reset_page();
             trigger_reload();
@@ -119,9 +111,6 @@ pub fn AdminRequestsSection(
     };
 
     let open_modal = {
-        let modal_open = modal_open.clone();
-        let modal_data = modal_data.clone();
-        let modal_comment = modal_comment.clone();
         move |data: Value| {
             modal_data.set(data);
             modal_comment.set(String::new());
@@ -130,9 +119,6 @@ pub fn AdminRequestsSection(
     };
 
     let on_action = {
-        let modal_data = modal_data.clone();
-        let modal_comment = modal_comment.clone();
-        let request_action = request_action.clone();
         move |approve: bool| {
             let id = modal_data
                 .get()

--- a/frontend/src/pages/admin/components/system_tools.rs
+++ b/frontend/src/pages/admin/components/system_tools.rs
@@ -30,8 +30,6 @@ pub fn AdminMfaResetSection(
     });
     let pending = reset_action.pending();
     {
-        let error = error.clone();
-        let success = success.clone();
         create_effect(move |_| {
             if let Some(result) = reset_action.value().get() {
                 match result {
@@ -49,10 +47,6 @@ pub fn AdminMfaResetSection(
     }
 
     let on_reset = {
-        let user_id = user_id.clone();
-        let error = error.clone();
-        let success = success.clone();
-        let reset_action = reset_action.clone();
         move |_| {
             if !system_admin_allowed.get_untracked() {
                 return;

--- a/frontend/src/pages/admin/components/user_select.rs
+++ b/frontend/src/pages/admin/components/user_select.rs
@@ -26,7 +26,6 @@ pub fn AdminUserSelect(
     let loading = users.loading();
 
     {
-        let fetch_error = fetch_error.clone();
         create_effect(move |_| {
             if let Some(result) = users.get() {
                 match result {
@@ -40,7 +39,6 @@ pub fn AdminUserSelect(
     }
 
     let on_change = {
-        let selected = selected.clone();
         move |ev: ev::Event| {
             selected.set(event_target_value(&ev));
         }
@@ -48,13 +46,11 @@ pub fn AdminUserSelect(
 
     let has_label = label.as_ref().map(|l| !l.is_empty()).unwrap_or(false);
     let label_value = label.unwrap_or_default();
-    let users_resource = users.clone();
 
     let on_retry = {
-        let fetch_error = fetch_error.clone();
         move |_| {
             fetch_error.set(None);
-            users_resource.refetch();
+            users.refetch();
         }
     };
 

--- a/frontend/src/pages/admin/components/weekly_holidays.rs
+++ b/frontend/src/pages/admin/components/weekly_holidays.rs
@@ -60,9 +60,6 @@ pub fn WeeklyHolidaySection(
     });
     let create_pending = create_action.pending();
     {
-        let message = message.clone();
-        let form_error = form_error.clone();
-        let reload = reload.clone();
         let form_state = form_state.clone();
         create_effect(move |_| {
             if let Some(result) = create_action.value().get() {
@@ -86,10 +83,6 @@ pub fn WeeklyHolidaySection(
 
     let on_submit = {
         let form_state = form_state.clone();
-        let form_error = form_error.clone();
-        let message = message.clone();
-        let create_action = create_action.clone();
-        let system_admin_allowed = system_admin_allowed.clone();
         move |ev: ev::SubmitEvent| {
             ev.prevent_default();
             if !admin_allowed.get_untracked() {
@@ -108,10 +101,7 @@ pub fn WeeklyHolidaySection(
         }
     };
 
-    let on_refresh = {
-        let reload = reload.clone();
-        move |_| reload.update(|value| *value = value.wrapping_add(1))
-    };
+    let on_refresh = { move |_| reload.update(|value| *value = value.wrapping_add(1)) };
 
     view! {
         <div class="bg-white shadow rounded-lg p-6 space-y-4">

--- a/frontend/src/pages/admin/panel.rs
+++ b/frontend/src/pages/admin/panel.rs
@@ -13,19 +13,15 @@ use leptos::*;
 #[component]
 pub fn AdminPanel() -> impl IntoView {
     let (auth, _set_auth) = use_auth();
-    let auth_for_admin = auth.clone();
     let admin_allowed = create_memo(move |_| {
-        auth_for_admin
-            .get()
+        auth.get()
             .user
             .as_ref()
             .map(|user| user.is_system_admin || user.role.eq_ignore_ascii_case("admin"))
             .unwrap_or(false)
     });
-    let auth_for_system = auth.clone();
     let system_admin_allowed = create_memo(move |_| {
-        auth_for_system
-            .get()
+        auth.get()
             .user
             .as_ref()
             .map(|user| user.is_system_admin)
@@ -33,9 +29,8 @@ pub fn AdminPanel() -> impl IntoView {
     });
     let repository = store_value(AdminRepository::new());
     let users_repository = repository.get_value();
-    let users_allowed = admin_allowed.clone();
     let users_resource = create_resource(
-        move || users_allowed.get(),
+        move || admin_allowed.get(),
         move |allowed| {
             let repo = users_repository.clone();
             async move {
@@ -49,32 +44,32 @@ pub fn AdminPanel() -> impl IntoView {
     );
 
     view! {
-        <layout::AdminDashboardScaffold admin_allowed=admin_allowed.clone()>
+        <layout::AdminDashboardScaffold admin_allowed=admin_allowed>
             <WeeklyHolidaySection
                 repository=repository.get_value()
-                admin_allowed=admin_allowed.clone()
-                system_admin_allowed=system_admin_allowed.clone()
+                admin_allowed=admin_allowed
+                system_admin_allowed=system_admin_allowed
             />
             <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
                 <AdminRequestsSection
                     repository=repository.get_value()
-                    admin_allowed=admin_allowed.clone()
-                    users=users_resource.clone()
+                    admin_allowed=admin_allowed
+                    users=users_resource
                 />
                 <AdminAttendanceToolsSection
                     repository=repository.get_value()
-                    system_admin_allowed=system_admin_allowed.clone()
-                    users=users_resource.clone()
+                    system_admin_allowed=system_admin_allowed
+                    users=users_resource
                 />
                 <AdminMfaResetSection
                     repository=repository.get_value()
-                    system_admin_allowed=system_admin_allowed.clone()
-                    users=users_resource.clone()
+                    system_admin_allowed=system_admin_allowed
+                    users=users_resource
                 />
             </div>
             <HolidayManagementSection
                 repository=repository.get_value()
-                admin_allowed=admin_allowed.clone()
+                admin_allowed=admin_allowed
             />
         </layout::AdminDashboardScaffold>
     }

--- a/frontend/src/pages/admin/repository.rs
+++ b/frontend/src/pages/admin/repository.rs
@@ -63,12 +63,6 @@ impl AdminRepository {
         }
     }
 
-    pub fn with_client(client: ApiClient) -> Self {
-        Self {
-            client: Rc::new(client),
-        }
-    }
-
     pub async fn list_weekly_holidays(&self) -> Result<Vec<WeeklyHolidayResponse>, String> {
         self.client.admin_list_weekly_holidays().await
     }
@@ -190,7 +184,7 @@ fn convert_admin_holiday_item(item: AdminHolidayListItem) -> Option<HolidayRespo
         ..
     } = item;
 
-    let mut fallback_reason = reason.clone();
+    let fallback_reason = reason.clone();
     let holiday_name = name
         .or_else(|| fallback_reason.clone())
         .unwrap_or_else(|| "Holiday".to_string());

--- a/frontend/src/pages/admin_users/components/detail.rs
+++ b/frontend/src/pages/admin_users/components/detail.rs
@@ -13,8 +13,6 @@ pub fn UserDetailDrawer(
 ) -> impl IntoView {
     let pending = reset_mfa_action.pending();
     {
-        let messages = messages.clone();
-        let reset_mfa_action = reset_mfa_action.clone();
         create_effect(move |_| {
             if let Some(result) = reset_mfa_action.value().get() {
                 match result {
@@ -43,24 +41,18 @@ pub fn UserDetailDrawer(
                     .get()
                     .map(|user| {
                         let overlay_close = {
-                            let selected_user = selected_user.clone();
-                            let messages = messages.clone();
                             move |_| {
                                 messages.update(MessageState::clear);
                                 selected_user.set(None);
                             }
                         };
                         let button_close = {
-                            let selected_user = selected_user.clone();
-                            let messages = messages.clone();
                             move |_| {
                                 messages.update(MessageState::clear);
                                 selected_user.set(None);
                             }
                         };
                         let reset_click = {
-                            let selected_user = selected_user.clone();
-                            let messages = messages.clone();
                             move |_| {
                                 if let Some(current) = selected_user.get_untracked() {
                                     messages.update(MessageState::clear);

--- a/frontend/src/pages/admin_users/components/invite_form.rs
+++ b/frontend/src/pages/admin_users/components/invite_form.rs
@@ -15,8 +15,6 @@ pub fn InviteForm(
 ) -> impl IntoView {
     let pending = invite_action.pending();
     let on_submit = {
-        let form_state = form_state.clone();
-        let messages = messages.clone();
         move |ev: ev::SubmitEvent| {
             ev.prevent_default();
             messages.update(MessageState::clear);

--- a/frontend/src/pages/admin_users/components/list.rs
+++ b/frontend/src/pages/admin_users/components/list.rs
@@ -45,10 +45,8 @@ pub fn UserList(
                             each=move || users.get()
                             key=|user| user.id.clone()
                             children=move |user: UserResponse| {
-                                let on_select = on_select.clone();
                                 let row_user = user.clone();
                                 let click_handler = {
-                                    let on_select = on_select.clone();
                                     let selected = row_user.clone();
                                     move |_| on_select.call(selected.clone())
                                 };
@@ -121,10 +119,8 @@ pub fn UserList(
                                     each=move || users.get()
                                     key=|user| user.id.clone()
                                     children=move |user: UserResponse| {
-                                        let on_select = on_select.clone();
                                         let row_user = user.clone();
                                         let click_handler = {
-                                            let on_select = on_select.clone();
                                             let selected = row_user.clone();
                                             move |_| on_select.call(selected.clone())
                                         };

--- a/frontend/src/pages/admin_users/panel.rs
+++ b/frontend/src/pages/admin_users/panel.rs
@@ -16,10 +16,8 @@ use super::{
 pub fn AdminUsersPage() -> impl IntoView {
     let repository = AdminUsersRepository::new();
     let (auth, _set_auth) = use_auth();
-    let auth_for_guard = auth.clone();
     let is_system_admin = create_memo(move |_| {
-        auth_for_guard
-            .get()
+        auth.get()
             .user
             .as_ref()
             .map(|user| user.is_system_admin)
@@ -63,10 +61,6 @@ pub fn AdminUsersPage() -> impl IntoView {
     });
 
     {
-        let invite_action = invite_action.clone();
-        let invite_messages = invite_messages.clone();
-        let invite_form = invite_form.clone();
-        let users_reload = users_reload.clone();
         create_effect(move |_| {
             if let Some(result) = invite_action.value().get() {
                 match result {
@@ -89,8 +83,6 @@ pub fn AdminUsersPage() -> impl IntoView {
     }
 
     let select_user = Callback::new({
-        let selected_user = selected_user.clone();
-        let drawer_messages = drawer_messages.clone();
         move |user: UserResponse| {
             drawer_messages.set(MessageState::default());
             selected_user.set(Some(user));

--- a/frontend/src/pages/admin_users/repository.rs
+++ b/frontend/src/pages/admin_users/repository.rs
@@ -19,12 +19,6 @@ impl AdminUsersRepository {
         }
     }
 
-    pub fn with_client(client: ApiClient) -> Self {
-        Self {
-            client: Rc::new(client),
-        }
-    }
-
     pub async fn fetch_users(&self) -> Result<Vec<UserResponse>, String> {
         self.client.get_users().await
     }

--- a/frontend/src/pages/attendance/components/history.rs
+++ b/frontend/src/pages/attendance/components/history.rs
@@ -57,14 +57,11 @@ fn HistoryRow(
     });
 
     let toggle = {
-        let expanded = expanded.clone();
-        let breaks = breaks.clone();
         let attendance_id = item.id.clone();
         move |_| {
             let now_expanded = !expanded.get();
             expanded.set(now_expanded);
             if now_expanded {
-                let breaks = breaks.clone();
                 let attendance_id = attendance_id.clone();
                 spawn_local(async move {
                     match repository::fetch_breaks_by_attendance(&attendance_id).await {

--- a/frontend/src/pages/attendance/utils.rs
+++ b/frontend/src/pages/attendance/utils.rs
@@ -15,23 +15,17 @@ impl AttendanceFormState {
         }
     }
 
-    pub fn from_signal(&self) -> RwSignal<String> {
+    pub fn start_date_signal(&self) -> RwSignal<String> {
         self.from
     }
 
-    pub fn to_signal(&self) -> RwSignal<String> {
+    pub fn end_date_signal(&self) -> RwSignal<String> {
         self.to
     }
 
     pub fn set_range(&self, from: NaiveDate, to: NaiveDate) {
         self.from.set(from.format("%Y-%m-%d").to_string());
         self.to.set(to.format("%Y-%m-%d").to_string());
-    }
-
-    #[allow(dead_code)]
-    pub fn reset(&self) {
-        self.from.set(String::new());
-        self.to.set(String::new());
     }
 
     pub fn to_payload(&self) -> Result<(Option<NaiveDate>, Option<NaiveDate>), String> {
@@ -83,8 +77,8 @@ mod tests {
     #[wasm_bindgen_test]
     fn form_state_validates_order() {
         let state = AttendanceFormState::new();
-        state.from_signal().set("2025-02-10".into());
-        state.to_signal().set("2025-02-01".into());
+        state.start_date_signal().set("2025-02-10".into());
+        state.end_date_signal().set("2025-02-01".into());
         assert!(state.to_payload().is_err());
     }
 

--- a/frontend/src/pages/dashboard/components/alerts.rs
+++ b/frontend/src/pages/dashboard/components/alerts.rs
@@ -4,10 +4,11 @@ use crate::{
 };
 use leptos::*;
 
+type AlertsResource =
+    Resource<Option<Result<DashboardSummary, String>>, Result<Vec<DashboardAlert>, String>>;
+
 #[component]
-pub fn AlertsSection(
-    alerts: Resource<Option<Result<DashboardSummary, String>>, Result<Vec<DashboardAlert>, String>>,
-) -> impl IntoView {
+pub fn AlertsSection(alerts: AlertsResource) -> impl IntoView {
     view! {
         <div class="bg-white shadow rounded-lg p-6 space-y-4">
             <div class="flex flex-col gap-2">

--- a/frontend/src/pages/dashboard/panel.rs
+++ b/frontend/src/pages/dashboard/panel.rs
@@ -20,9 +20,8 @@ pub fn DashboardPage() -> impl IntoView {
     let activity_filter = create_rw_signal(ActivityStatusFilter::All);
 
     create_effect(move |_| {
-        let set_state = set_attendance_state.clone();
         spawn_local(async move {
-            let _ = refresh_today_context(set_state).await;
+            let _ = refresh_today_context(set_attendance_state).await;
         });
     });
 

--- a/frontend/src/pages/dashboard/repository.rs
+++ b/frontend/src/pages/dashboard/repository.rs
@@ -67,11 +67,6 @@ pub fn build_alerts(summary: &DashboardSummary) -> Vec<DashboardAlert> {
     alerts
 }
 
-pub async fn fetch_alerts() -> Result<Vec<DashboardAlert>, String> {
-    let summary = fetch_summary().await?;
-    Ok(build_alerts(&summary))
-}
-
 pub async fn fetch_recent_activities(
     filter: ActivityStatusFilter,
 ) -> Result<Vec<DashboardActivity>, String> {

--- a/frontend/src/pages/dashboard/utils.rs
+++ b/frontend/src/pages/dashboard/utils.rs
@@ -33,14 +33,6 @@ impl ActivityStatusFilter {
         }
     }
 
-    pub fn label(self) -> &'static str {
-        match self {
-            ActivityStatusFilter::All => "すべて",
-            ActivityStatusFilter::PendingOnly => "承認待ちのみ",
-            ActivityStatusFilter::ApprovedOnly => "承認済みのみ",
-        }
-    }
-
     pub fn as_value(self) -> &'static str {
         match self {
             ActivityStatusFilter::All => "all",

--- a/frontend/src/pages/login/panel.rs
+++ b/frontend/src/pages/login/panel.rs
@@ -16,9 +16,6 @@ pub fn LoginPanel() -> impl IntoView {
     let pending = login_action.pending();
 
     {
-        let login_action = login_action.clone();
-        let set_error = set_error.clone();
-        let set_totp_code = set_totp_code.clone();
         create_effect(move |_| {
             if let Some(result) = login_action.value().get() {
                 match result {
@@ -36,12 +33,6 @@ pub fn LoginPanel() -> impl IntoView {
     }
 
     let handle_submit = {
-        let pending = pending.clone();
-        let username = username.clone();
-        let password = password.clone();
-        let totp_code = totp_code.clone();
-        let set_error = set_error.clone();
-        let login_action = login_action.clone();
         Callback::new(move |ev: SubmitEvent| {
             ev.prevent_default();
             if pending.get_untracked() {

--- a/frontend/src/pages/requests/components/detail_modal.rs
+++ b/frontend/src/pages/requests/components/detail_modal.rs
@@ -3,10 +3,7 @@ use leptos::*;
 
 #[component]
 pub fn RequestDetailModal(selected: RwSignal<Option<RequestSummary>>) -> impl IntoView {
-    let on_close = {
-        let selected = selected.clone();
-        move |_| selected.set(None)
-    };
+    let on_close = { move |_| selected.set(None) };
     view! {
         <Show when=move || selected.get().is_some()>
             {move || {
@@ -15,7 +12,7 @@ pub fn RequestDetailModal(selected: RwSignal<Option<RequestSummary>>) -> impl In
                     .map(|summary| {
                         view! {
                             <div class="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
-                                <div class="fixed inset-0 bg-black/40" on:click=on_close.clone()></div>
+                                <div class="fixed inset-0 bg-black/40" on:click=on_close></div>
                                 <div class="relative bg-white rounded-lg shadow-xl w-full max-w-md mx-4 p-6 space-y-4">
                                     <div class="flex items-center justify-between">
                                         <div>
@@ -27,7 +24,7 @@ pub fn RequestDetailModal(selected: RwSignal<Option<RequestSummary>>) -> impl In
                                                 }}
                                             </p>
                                         </div>
-                                        <button class="text-gray-500 hover:text-gray-700" on:click=on_close.clone()>
+                                        <button class="text-gray-500 hover:text-gray-700" on:click=on_close>
                                             {"✕"}
                                         </button>
                                     </div>
@@ -54,7 +51,7 @@ pub fn RequestDetailModal(selected: RwSignal<Option<RequestSummary>>) -> impl In
                                         </div>
                                     </div>
                                     <div class="flex justify-end">
-                                        <button class="px-4 py-2 rounded bg-gray-200 text-gray-700 hover:bg-gray-300" on:click=on_close.clone()>
+                                        <button class="px-4 py-2 rounded bg-gray-200 text-gray-700 hover:bg-gray-300" on:click=on_close>
                                             {"閉じる"}
                                         </button>
                                     </div>

--- a/frontend/src/pages/requests/components/leave_form.rs
+++ b/frontend/src/pages/requests/components/leave_form.rs
@@ -20,10 +20,6 @@ pub fn LeaveRequestForm(
 
     let on_submit = {
         let state = state.clone();
-        let message = message.clone();
-        let action = action.clone();
-        let update_action = update_action.clone();
-        let editing = editing.clone();
         move |ev: ev::SubmitEvent| {
             ev.prevent_default();
             match state.to_payload() {

--- a/frontend/src/pages/requests/components/list.rs
+++ b/frontend/src/pages/requests/components/list.rs
@@ -61,7 +61,6 @@ pub fn RequestsList(
                                 each=move || summaries.get()
                                 key=|summary| summary.id.clone()
                                 children=move |summary: RequestSummary| {
-                                    let on_select = on_select.clone();
                                     let summary = store_value(summary);
                                     let summary_value = summary.get_value();
                                     let status = summary_value.status.clone();

--- a/frontend/src/pages/requests/components/overtime_form.rs
+++ b/frontend/src/pages/requests/components/overtime_form.rs
@@ -20,10 +20,6 @@ pub fn OvertimeRequestForm(
 
     let on_submit = {
         let state = state.clone();
-        let message = message.clone();
-        let action = action.clone();
-        let update_action = update_action.clone();
-        let editing = editing.clone();
         move |ev: ev::SubmitEvent| {
             ev.prevent_default();
             match state.to_payload() {

--- a/frontend/src/pages/requests/panel.rs
+++ b/frontend/src/pages/requests/panel.rs
@@ -77,8 +77,6 @@ pub fn RequestsPage() -> impl IntoView {
     });
 
     {
-        let reload = reload.clone();
-        let editing_request = editing_request.clone();
         let leave_state = leave_state.clone();
         let overtime_state = overtime_state.clone();
         create_effect(move |_| {
@@ -97,9 +95,6 @@ pub fn RequestsPage() -> impl IntoView {
         });
     }
     {
-        let cancel_action = cancel_action.clone();
-        let list_message = list_message.clone();
-        let reload = reload.clone();
         create_effect(move |_| {
             if let Some(result) = cancel_action.value().get() {
                 match result {
@@ -114,11 +109,8 @@ pub fn RequestsPage() -> impl IntoView {
     }
 
     let on_edit = Callback::new({
-        let editing_request = editing_request.clone();
-        let list_message = list_message.clone();
         let leave_state = leave_state.clone();
         let overtime_state = overtime_state.clone();
-        let set_active_form = set_active_form.clone();
         move |summary: RequestSummary| {
             list_message.update(|msg| msg.clear());
             let target = EditTarget {
@@ -139,8 +131,6 @@ pub fn RequestsPage() -> impl IntoView {
         }
     });
     let on_cancel_request = Callback::new({
-        let cancel_action = cancel_action.clone();
-        let editing_request = editing_request.clone();
         let leave_state = leave_state.clone();
         let overtime_state = overtime_state.clone();
         move |summary: RequestSummary| {
@@ -151,8 +141,6 @@ pub fn RequestsPage() -> impl IntoView {
         }
     });
     {
-        let reload = reload.clone();
-        let leave_message = leave_message.clone();
         create_effect(move |_| {
             if let Some(result) = leave_action.value().get() {
                 match result {
@@ -166,8 +154,6 @@ pub fn RequestsPage() -> impl IntoView {
         });
     }
     {
-        let reload = reload.clone();
-        let overtime_message = overtime_message.clone();
         create_effect(move |_| {
             if let Some(result) = overtime_action.value().get() {
                 match result {
@@ -182,7 +168,6 @@ pub fn RequestsPage() -> impl IntoView {
     }
 
     let on_select = Callback::new({
-        let selected_request = selected_request.clone();
         move |summary: RequestSummary| {
             selected_request.set(Some(summary));
         }
@@ -232,8 +217,6 @@ pub fn RequestsPage() -> impl IntoView {
                             update_action=update_action
                             editing=editing_request
                             on_cancel_edit=Callback::new({
-                                let editing_request = editing_request.clone();
-                                let list_message = list_message.clone();
                                 let leave_state = leave_state_mobile.clone();
                                 move |_| {
                                     editing_request.set(None);
@@ -251,8 +234,6 @@ pub fn RequestsPage() -> impl IntoView {
                             update_action=update_action
                             editing=editing_request
                             on_cancel_edit=Callback::new({
-                                let editing_request = editing_request.clone();
-                                let list_message = list_message.clone();
                                 let overtime_state = overtime_state_mobile.clone();
                                 move |_| {
                                     editing_request.set(None);
@@ -271,8 +252,6 @@ pub fn RequestsPage() -> impl IntoView {
                         update_action=update_action
                         editing=editing_request
                         on_cancel_edit=Callback::new({
-                            let editing_request = editing_request.clone();
-                            let list_message = list_message.clone();
                             let leave_state = leave_state_desktop.clone();
                             move |_| {
                                 editing_request.set(None);
@@ -288,8 +267,6 @@ pub fn RequestsPage() -> impl IntoView {
                         update_action=update_action
                         editing=editing_request
                         on_cancel_edit=Callback::new({
-                            let editing_request = editing_request.clone();
-                            let list_message = list_message.clone();
                             let overtime_state = overtime_state_desktop.clone();
                             move |_| {
                                 editing_request.set(None);

--- a/frontend/src/pages/requests/repository.rs
+++ b/frontend/src/pages/requests/repository.rs
@@ -25,12 +25,6 @@ impl RequestsRepository {
         }
     }
 
-    pub fn with_client(client: ApiClient) -> Self {
-        Self {
-            client: Rc::new(client),
-        }
-    }
-
     pub async fn submit_leave(
         &self,
         payload: CreateLeaveRequest,

--- a/frontend/src/router.rs
+++ b/frontend/src/router.rs
@@ -35,7 +35,7 @@ pub const PROTECTED_ROUTE_PATHS: &[&str] = &[
 pub const PUBLIC_ROUTE_PATHS: &[&str] = &["/", "/login", "/mfa/register"];
 
 pub fn mount_app() {
-    mount_to_body(|| app_root());
+    mount_to_body(app_root);
 }
 
 pub fn app_root() -> impl IntoView {
@@ -116,5 +116,4 @@ mod tests {
         let unique: HashSet<&str> = ROUTE_PATHS.iter().copied().collect();
         assert_eq!(unique.len(), ROUTE_PATHS.len());
     }
-
 }

--- a/frontend/src/state/auth.rs
+++ b/frontend/src/state/auth.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use crate::{
     api::{ApiClient, LoginRequest, MfaSetupResponse, MfaStatusResponse, UserResponse},
     pages::login::repository as login_repository,
@@ -8,21 +7,11 @@ use leptos::*;
 
 type AuthContext = (ReadSignal<AuthState>, WriteSignal<AuthState>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AuthState {
     pub user: Option<UserResponse>,
     pub is_authenticated: bool,
     pub loading: bool,
-}
-
-impl Default for AuthState {
-    fn default() -> Self {
-        Self {
-            user: None,
-            is_authenticated: false,
-            loading: false,
-        }
-    }
 }
 
 fn create_auth_context() -> AuthContext {
@@ -87,21 +76,6 @@ async fn refresh_session(api_client: &ApiClient) -> Result<UserResponse, String>
     Ok(response.user)
 }
 
-pub async fn login(
-    username: String,
-    password: String,
-    totp_code: Option<String>,
-    set_auth_state: WriteSignal<AuthState>,
-) -> Result<(), String> {
-    let request = LoginRequest {
-        username,
-        password,
-        totp_code,
-        device_label: None,
-    };
-    login_request(request, set_auth_state).await
-}
-
 pub async fn login_request(
     request: LoginRequest,
     set_auth_state: WriteSignal<AuthState>,
@@ -147,28 +121,6 @@ pub async fn logout(
     result
 }
 
-pub async fn refresh_auth(set_auth_state: WriteSignal<AuthState>) -> Result<(), String> {
-    let api_client = ApiClient::new();
-    match refresh_session(&api_client).await {
-        Ok(user) => {
-            set_auth_state.update(|state| {
-                state.user = Some(user);
-                state.is_authenticated = true;
-                state.loading = false;
-            });
-            Ok(())
-        }
-        Err(err) => {
-            set_auth_state.update(|state| {
-                state.user = None;
-                state.is_authenticated = false;
-                state.loading = false;
-            });
-            Err(err)
-        }
-    }
-}
-
 pub async fn fetch_mfa_status() -> Result<MfaStatusResponse, String> {
     ApiClient::new().get_mfa_status().await
 }
@@ -211,7 +163,6 @@ pub fn use_login_action() -> Action<LoginRequest, Result<(), String>> {
     let (_auth, set_auth) = use_auth();
     create_action(move |request: &LoginRequest| {
         let payload = request.clone();
-        let set_auth = set_auth.clone();
         async move { login_request(payload, set_auth).await }
     })
 }
@@ -219,16 +170,7 @@ pub fn use_login_action() -> Action<LoginRequest, Result<(), String>> {
 pub fn use_logout_action() -> Action<bool, Result<(), String>> {
     let (_auth, set_auth) = use_auth();
     create_action(move |all: &bool| {
-        let set_auth = set_auth.clone();
         let flag = *all;
         async move { logout(flag, set_auth).await }
-    })
-}
-
-pub fn use_refresh_action() -> Action<(), Result<(), String>> {
-    let (_auth, set_auth) = use_auth();
-    create_action(move |_| {
-        let set_auth = set_auth.clone();
-        async move { refresh_auth(set_auth).await }
     })
 }

--- a/frontend/src/utils/download.rs
+++ b/frontend/src/utils/download.rs
@@ -27,7 +27,7 @@ pub fn trigger_csv_download(filename: &str, csv_data: &str) -> Result<(), String
         .append_child(&a)
         .map_err(|_| "Append failed".to_string())?;
     a.click();
-    let _ = a.remove();
+    a.remove();
     let _ = web_sys::Url::revoke_object_url(&url);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- remove unused frontend auth/helpers and API endpoints that were only kept for dead_code
- simplify frontend signals/actions to avoid Copy clones and clean up state helpers
- align naming in attendance/export helpers and trim unused utilities

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `TMPDIR=/tmp TEMP=/tmp TMP=/tmp cargo test -p timekeeper-frontend`
