### PR TITLE
fix: render mfa qr via data url

### DIFF
--- a/frontend/src/pages/mfa/components/verify.rs
+++ b/frontend/src/pages/mfa/components/verify.rs
@@ -1,4 +1,5 @@
 use crate::api::MfaSetupResponse;
+use crate::pages::mfa::utils::svg_to_data_url;
 use leptos::{ev::SubmitEvent, Callback, *};
 use qrcode::{render::svg, QrCode};
 use web_sys::HtmlInputElement;
@@ -19,6 +20,7 @@ pub fn VerificationSection(
                         let qr_svg = QrCode::new(info.otpauth_url.as_bytes())
                             .map(|code| code.render::<svg::Color>().build())
                             .unwrap_or_default();
+                        let qr_svg_data_url = svg_to_data_url(&qr_svg);
 
                         view! {
                             <div class="bg-white shadow rounded-lg p-6 space-y-4">
@@ -26,7 +28,7 @@ pub fn VerificationSection(
                                     {"認証アプリで QR をスキャン"}
                                 </h2>
                                 <div class="border rounded p-4 bg-gray-50">
-                                    <div inner_html=qr_svg />
+                                    <img src=qr_svg_data_url alt="認証アプリのQRコード" />
                                 </div>
                                 <p class="text-sm text-gray-600 break-all">
                                     {info.otpauth_url.clone()}

--- a/frontend/src/pages/mfa/utils.rs
+++ b/frontend/src/pages/mfa/utils.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine as _};
 use leptos::*;
 
 #[derive(Clone, Copy, Default)]
@@ -32,6 +33,11 @@ pub fn validate_totp_code(code: &str) -> Result<String, String> {
     }
 }
 
+pub fn svg_to_data_url(svg: &str) -> String {
+    let encoded = general_purpose::STANDARD.encode(svg.as_bytes());
+    format!("data:image/svg+xml;base64,{}", encoded)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -47,5 +53,17 @@ mod tests {
     fn validate_totp_code_trims_and_accepts() {
         let result = validate_totp_code(" 987654 ");
         assert_eq!(result.unwrap(), "987654");
+    }
+
+    #[wasm_bindgen_test]
+    fn svg_to_data_url_encodes_svg() {
+        let result = svg_to_data_url("<svg></svg>");
+        assert_eq!(result, "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=");
+    }
+
+    #[wasm_bindgen_test]
+    fn svg_to_data_url_handles_empty_input() {
+        let result = svg_to_data_url("");
+        assert_eq!(result, "data:image/svg+xml;base64,");
     }
 }


### PR DESCRIPTION
## Summary
- render MFA QR via data URL <img> instead of inner_html
- add svg_to_data_url helper + tests

## Issue
- Fixes #82

## Impact
- Frontend only

## Env
- None

## Testing
- wasm-pack test --headless --firefox