### PR TITLE
feat: audit log schema and repo

### DIFF
--- a/backend/migrations/018_create_audit_logs.sql
+++ b/backend/migrations/018_create_audit_logs.sql
@@ -1,0 +1,24 @@
+-- Replace legacy audit logs table with the expanded audit log schema.
+ALTER TABLE IF EXISTS audit_logs RENAME TO audit_logs_legacy;
+
+CREATE TABLE audit_logs (
+    id TEXT PRIMARY KEY,
+    occurred_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    actor_id TEXT,
+    actor_type TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    target_type TEXT,
+    target_id TEXT,
+    result TEXT NOT NULL,
+    error_code TEXT,
+    metadata JSONB,
+    ip TEXT,
+    user_agent TEXT,
+    request_id TEXT
+);
+
+CREATE INDEX idx_audit_logs_occurred_at ON audit_logs(occurred_at);
+CREATE INDEX idx_audit_logs_actor_id ON audit_logs(actor_id);
+CREATE INDEX idx_audit_logs_event_type ON audit_logs(event_type);
+CREATE INDEX idx_audit_logs_target_id ON audit_logs(target_id);
+CREATE INDEX idx_audit_logs_request_id ON audit_logs(request_id);

--- a/backend/src/handlers/audit_log_repo.rs
+++ b/backend/src/handlers/audit_log_repo.rs
@@ -1,0 +1,41 @@
+use sqlx::PgPool;
+
+use crate::models::audit_log::AuditLog;
+
+#[allow(dead_code)]
+pub async fn insert_audit_log(pool: &PgPool, log: &AuditLog) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO audit_logs \
+         (id, occurred_at, actor_id, actor_type, event_type, target_type, target_id, result, \
+         error_code, metadata, ip, user_agent, request_id) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+    )
+    .bind(&log.id)
+    .bind(log.occurred_at)
+    .bind(&log.actor_id)
+    .bind(&log.actor_type)
+    .bind(&log.event_type)
+    .bind(&log.target_type)
+    .bind(&log.target_id)
+    .bind(&log.result)
+    .bind(&log.error_code)
+    .bind(&log.metadata)
+    .bind(&log.ip)
+    .bind(&log.user_agent)
+    .bind(&log.request_id)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+#[allow(dead_code)]
+pub async fn fetch_audit_log(pool: &PgPool, id: &str) -> Result<Option<AuditLog>, sqlx::Error> {
+    sqlx::query_as::<_, AuditLog>(
+        "SELECT id, occurred_at, actor_id, actor_type, event_type, target_type, target_id, result, \
+         error_code, metadata, ip, user_agent, request_id \
+         FROM audit_logs WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+}

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod admin;
 pub mod attendance;
 pub mod attendance_utils;
+pub mod audit_log_repo;
 pub mod auth;
 pub mod auth_repo;
 pub mod config;

--- a/backend/src/models/audit_log.rs
+++ b/backend/src/models/audit_log.rs
@@ -1,0 +1,22 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::{types::Json, FromRow};
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct AuditLog {
+    pub id: String,
+    pub occurred_at: DateTime<Utc>,
+    pub actor_id: Option<String>,
+    pub actor_type: String,
+    pub event_type: String,
+    pub target_type: Option<String>,
+    pub target_id: Option<String>,
+    pub result: String,
+    pub error_code: Option<String>,
+    pub metadata: Option<Json<Value>>,
+    pub ip: Option<String>,
+    pub user_agent: Option<String>,
+    pub request_id: Option<String>,
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,6 +1,7 @@
 //! Data models shared across database access and API handlers.
 
 pub mod attendance;
+pub mod audit_log;
 pub mod break_record;
 pub mod holiday;
 pub mod holiday_exception;

--- a/backend/tests/audit_log_repo.rs
+++ b/backend/tests/audit_log_repo.rs
@@ -1,0 +1,67 @@
+use chrono::Utc;
+use serde_json::json;
+use sqlx::types::Json;
+use timekeeper_backend::{
+    handlers::audit_log_repo,
+    models::{audit_log::AuditLog, user::UserRole},
+};
+use uuid::Uuid;
+
+#[path = "support/mod.rs"]
+mod support;
+
+#[tokio::test]
+async fn audit_log_repo_inserts_and_fetches() {
+    let pool = support::test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+
+    let user = support::seed_user(&pool, UserRole::Admin, false).await;
+    let metadata_value = json!({ "source": "test" });
+    let log = AuditLog {
+        id: Uuid::new_v4().to_string(),
+        occurred_at: Utc::now(),
+        actor_id: Some(user.id.clone()),
+        actor_type: "user".into(),
+        event_type: "attendance_clock_in".into(),
+        target_type: Some("attendance".into()),
+        target_id: Some(Uuid::new_v4().to_string()),
+        result: "success".into(),
+        error_code: None,
+        metadata: Some(Json(metadata_value.clone())),
+        ip: Some("127.0.0.1".into()),
+        user_agent: Some("test-agent".into()),
+        request_id: Some("req-123".into()),
+    };
+
+    audit_log_repo::insert_audit_log(&pool, &log)
+        .await
+        .expect("insert audit log");
+
+    let fetched = audit_log_repo::fetch_audit_log(&pool, &log.id)
+        .await
+        .expect("fetch audit log")
+        .expect("audit log exists");
+
+    assert_eq!(fetched.id, log.id);
+    assert_eq!(fetched.actor_id, log.actor_id);
+    assert_eq!(fetched.actor_type, log.actor_type);
+    assert_eq!(fetched.event_type, log.event_type);
+    assert_eq!(fetched.target_type, log.target_type);
+    assert_eq!(fetched.target_id, log.target_id);
+    assert_eq!(fetched.result, log.result);
+    assert_eq!(fetched.error_code, log.error_code);
+    assert_eq!(
+        fetched.metadata.as_ref().map(|value| value.0.clone()),
+        Some(metadata_value)
+    );
+    assert_eq!(fetched.ip, log.ip);
+    assert_eq!(fetched.user_agent, log.user_agent);
+    assert_eq!(fetched.request_id, log.request_id);
+    assert_eq!(
+        fetched.occurred_at.timestamp_micros(),
+        log.occurred_at.timestamp_micros()
+    );
+}

--- a/backend/tests/support/mod.rs
+++ b/backend/tests/support/mod.rs
@@ -18,7 +18,7 @@ use timekeeper_backend::{
         leave_request::{LeaveRequest, LeaveType},
         overtime_request::OvertimeRequest,
     },
-    utils::password::hash_password,
+    utils::{cookies::SameSite, password::hash_password},
 };
 use uuid::Uuid;
 
@@ -114,6 +114,9 @@ pub fn test_config() -> Config {
         jwt_secret: "a_secure_token_that_is_long_enough_123".into(),
         jwt_expiration_hours: 1,
         refresh_token_expiration_days: 7,
+        cookie_secure: false,
+        cookie_same_site: SameSite::Lax,
+        cors_allow_origins: vec!["http://localhost:8000".into()],
         time_zone: Tokyo,
         mfa_issuer: "Timekeeper".into(),
     }


### PR DESCRIPTION
## Summary
- replace legacy audit_logs table with expanded schema and indexes
- add AuditLog model and repository helpers
- add repository integration test

## Related
- Closes #104

## Impact
- Backend: schema + repo + tests
- Frontend: none
- Env vars: none

## Tests
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings (fails: frontend reqwest_wasm RequestBuilder missing fetch_credentials_include)
- cd backend; cargo test
- pwsh -File .\scripts\test_backend.ps1 (fails: 403 clock-in on weekly holiday 2025-12-28)