### PR TITLE
Implement x-request-id response header

### DIFF
--- a/CONTINUITY.md
+++ b/CONTINUITY.md
@@ -1,16 +1,17 @@
 # Continuity Ledger
 
-- Goal: Review uncommitted changes in the workspace and report findings.
+- Goal: Fix env.js loading error causing HTML to be executed as JS.
 - Constraints/Assumptions: Follow project coding standards, LF endings, UTF-8 for non-ASCII, stay within writable roots.
 - Key decisions: Existing data compatibility concerns are not an issue because service not live yet.
-- State: REVIEW_FEEDBACK_ACKED
+- State: FIXING_ENV_JS
 - Done:
-    - Loaded workspace instructions and continuity ledger.
+    - Verified current frontend assets; browser cache likely cause of prior WASM error.
+    - CSP updated for Google Fonts.
 - Now:
-    - Inspecting uncommitted changes to prepare review findings.
+    - Added default `frontend/env.js` and Dockerfile copy step so env.js is real JS, not index.html fallback.
 - Next:
-    - Summarize any issues found in JSON schema per review request.
+    - Rebuild frontend image or static assets; confirm env.js loads without syntax error.
 - Open questions:
     - None.
 - Working set:
-    - Pending: determine touched files from VCS status.
+    - `frontend` build artifacts/load path

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -72,6 +72,7 @@ async fn main() -> anyhow::Result<()> {
         .merge(SwaggerUi::new("/api/docs").url("/api-doc/openapi.json", openapi.clone()))
         .layer(
             ServiceBuilder::new()
+                .layer(axum_middleware::from_fn(middleware::request_id))
                 .layer(axum_middleware::from_fn(middleware::log_error_responses))
                 .layer(TraceLayer::new_for_http())
                 .layer(cors_layer(&config)),

--- a/backend/src/middleware/audit_log.rs
+++ b/backend/src/middleware/audit_log.rs
@@ -19,6 +19,7 @@ use crate::{
     config::Config,
     models::user::User,
     services::audit_log::{AuditLogEntry, AuditLogService},
+    middleware::request_id::RequestId,
 };
 
 const DEFAULT_CLOCK_SOURCE: &str = "api";
@@ -60,7 +61,11 @@ pub async fn audit_log(
 
     let audit_service = request.extensions().get::<Arc<AuditLogService>>().cloned();
     let actor_before = request.extensions().get::<User>().cloned();
-    let request_id = extract_request_id(&headers);
+    let request_id = request
+        .extensions()
+        .get::<RequestId>()
+        .map(|id| id.0.clone())
+        .unwrap_or_else(|| extract_request_id(&headers));
 
     let response = next.run(request).await;
 

--- a/backend/src/middleware/mod.rs
+++ b/backend/src/middleware/mod.rs
@@ -2,6 +2,9 @@ pub mod audit_log;
 pub mod auth;
 pub mod logging;
 
+pub mod request_id;
+
 pub use audit_log::*;
 pub use auth::*;
 pub use logging::*;
+pub use request_id::*;

--- a/backend/src/middleware/request_id.rs
+++ b/backend/src/middleware/request_id.rs
@@ -1,0 +1,39 @@
+use axum::{
+    extract::Request,
+    http::{header::HeaderName, HeaderValue},
+    middleware::Next,
+    response::Response,
+};
+use uuid::Uuid;
+
+const REQUEST_ID_HEADER: &str = "x-request-id";
+const CORRELATION_ID_HEADER: &str = "x-correlation-id";
+
+#[derive(Clone, Debug)]
+pub struct RequestId(pub String);
+
+pub async fn request_id(mut req: Request, next: Next) -> Response {
+    let header_name = HeaderName::from_static(REQUEST_ID_HEADER);
+
+    let id = req
+        .headers()
+        .get(&header_name)
+        .or_else(|| {
+            req.headers()
+                .get(HeaderName::from_static(CORRELATION_ID_HEADER))
+        })
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    let request_id = RequestId(id.clone());
+    req.extensions_mut().insert(request_id.clone());
+
+    let mut response = next.run(req).await;
+
+    if let Ok(value) = HeaderValue::from_str(&id) {
+        response.headers_mut().insert(header_name, value);
+    }
+
+    response
+}

--- a/backend/tests/request_id_header.rs
+++ b/backend/tests/request_id_header.rs
@@ -1,0 +1,67 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use tower::ServiceExt;
+use uuid::Uuid;
+use timekeeper_backend::{middleware::request_id::RequestId, services::audit_log::AuditLogService};
+use std::sync::Arc;
+use axum::Extension;
+
+#[tokio::test]
+async fn test_request_id_header_added_to_response() {
+    let app = axum::Router::new()
+        .route("/test", axum::routing::get(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(timekeeper_backend::middleware::request_id::request_id));
+
+    let response = app
+        .oneshot(Request::builder().uri("/test").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert!(response.headers().contains_key("x-request-id"));
+    let id = response.headers().get("x-request-id").unwrap().to_str().unwrap();
+    assert!(Uuid::parse_str(id).is_ok());
+}
+
+#[tokio::test]
+async fn test_request_id_header_persists_client_id() {
+    let app = axum::Router::new()
+        .route("/test", axum::routing::get(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(timekeeper_backend::middleware::request_id::request_id));
+
+    let client_id = "client-req-123";
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/test")
+                .header("x-request-id", client_id)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.headers().get("x-request-id").unwrap(), client_id);
+}
+
+#[tokio::test]
+async fn test_request_id_header_persists_correlation_id() {
+    let app = axum::Router::new()
+        .route("/test", axum::routing::get(|| async { "ok" }))
+        .layer(axum::middleware::from_fn(timekeeper_backend::middleware::request_id::request_id));
+
+    let correlation_id = "corr-req-456";
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/test")
+                .header("x-correlation-id", correlation_id)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.headers().get("x-request-id").unwrap(), correlation_id);
+}


### PR DESCRIPTION
## Summary
This PR implements the x-request-id header in all API responses to improve traceability. 

## Changes
- Created a global equest_id middleware.
- Integrated the shared request ID with the audit log middleware for consistency.
- Added integration tests to verify header presence and persistence of client-supplied IDs.

## Verification
- Ran cargo test --test request_id_header (all tests passed).