### PR TITLE
Fix admin user list permissions and audit log actor tracking

### DIFF
--- a/backend/src/handlers/admin/mod.rs
+++ b/backend/src/handlers/admin/mod.rs
@@ -90,7 +90,7 @@ pub async fn get_users(
     State((pool, _config)): State<(PgPool, Config)>,
     Extension(user): Extension<User>,
 ) -> Result<Json<Vec<UserResponse>>, (StatusCode, Json<Value>)> {
-    if !user.is_system_admin() {
+    if !(user.is_admin() || user.is_system_admin()) {
         return Err((StatusCode::FORBIDDEN, Json(json!({"error":"Forbidden"}))));
     }
     // Normalize role to snake_case at read to be resilient to legacy rows

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -239,6 +239,8 @@ fn admin_routes(state: AuthState) -> Router<AuthState> {
             "/api/admin/holidays/weekly/:id",
             delete(handlers::admin::delete_weekly_holiday),
         )
+        .route("/api/admin/users", get(handlers::admin::get_users))
+        .route("/api/admin/attendance", get(handlers::admin::get_all_attendance))
         .route(
             "/api/admin/holidays/:id",
             delete(handlers::admin::delete_holiday),
@@ -284,11 +286,11 @@ fn system_admin_routes(state: AuthState) -> Router<AuthState> {
         )
         .route(
             "/api/admin/users",
-            get(handlers::admin::get_users).post(handlers::admin::create_user),
+            post(handlers::admin::create_user),
         )
         .route(
             "/api/admin/attendance",
-            get(handlers::admin::get_all_attendance).put(handlers::admin::upsert_attendance),
+            put(handlers::admin::upsert_attendance),
         )
         .route(
             "/api/admin/breaks/:id/force-end",

--- a/backend/src/middleware/auth.rs
+++ b/backend/src/middleware/auth.rs
@@ -2,7 +2,7 @@ use axum::{
     extract::{Request, State},
     http::{header, StatusCode},
     middleware::Next,
-    response::Response,
+    response::{IntoResponse, Response},
 };
 use jsonwebtoken::{decode, DecodingKey, Validation};
 use sqlx::PgPool;
@@ -64,7 +64,9 @@ pub async fn auth_admin(
     )
     .await?;
     if !(user.is_admin() || user.is_system_admin()) {
-        return Err(StatusCode::FORBIDDEN);
+        let mut response = StatusCode::FORBIDDEN.into_response();
+        response.extensions_mut().insert(user);
+        return Ok(response);
     }
 
     request.extensions_mut().insert(claims.clone());
@@ -89,7 +91,9 @@ pub async fn auth_system_admin(
     )
     .await?;
     if !user.is_system_admin() {
-        return Err(StatusCode::FORBIDDEN);
+        let mut response = StatusCode::FORBIDDEN.into_response();
+        response.extensions_mut().insert(user);
+        return Ok(response);
     }
 
     request.extensions_mut().insert(claims.clone());


### PR DESCRIPTION
## Summary
This PR fixes two issues:
1.  **Admin Permission for User Listing**: dmin role users (not system-admin) were unable to list users, causing errors in the Requests page filtering. Moved GET /api/admin/users and GET /api/admin/attendance to the dmin layer.
2.  **Missing Actor in Audit Logs on 403**: Authenticated users were recorded as \nonymous\ in audit logs when they encountered a 403 Forbidden error. Updated auth middleware to propagate the user object in the response extensions.

## Changes
- \ackend/src/middleware/auth.rs\: Return \Response\ with \User\ extension on 403.
- \ackend/src/handlers/admin/mod.rs\: Update \get_users\ to allow \dmin\ role.
- \ackend/src/main.rs\: Moved routes for listing users and attendance to the admin (non-system) layer.