### PR TITLE
fix: revert to reqwest client with credentials

### DIFF
--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -20,7 +20,7 @@ leptos_meta = { version = "0.6", default-features = false }
 leptos_router = { version = "0.6", default-features = false, features = ["csr"] }
 
 # HTTP client (WASM)
-reqwest-wasm = { version = "0.11", default-features = false, features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
 wasm-bindgen-futures = "0.4"
 
 # Serialization
@@ -30,7 +30,7 @@ serde_json.workspace = true
 # Async runtime
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["console", "Window", "Storage", "Document", "Element", "HtmlElement", "HtmlInputElement", "Event", "MouseEvent", "KeyboardEvent", "Blob", "BlobPropertyBag", "Url", "HtmlAnchorElement"] }
+web-sys = { version = "0.3", features = ["console", "Window", "Storage", "Document", "Element", "HtmlElement", "HtmlInputElement", "Event", "MouseEvent", "KeyboardEvent", "Blob", "BlobPropertyBag", "Url", "HtmlAnchorElement", "RequestCredentials"] }
 gloo-timers = { version = "0.2", features = ["futures"] }
 base64 = { version = "0.21", default-features = false, features = ["alloc"] }
 

--- a/frontend/src/api/auth.rs
+++ b/frontend/src/api/auth.rs
@@ -13,14 +13,14 @@ impl ApiClient {
             request.device_label = Some(ensure_device_label(&storage)?);
         }
         let base_url = self.resolved_base_url().await;
-        let response = self
-            .http_client()
-            .post(format!("{}/auth/login", base_url))
-            .json(&request)
-            // .fetch_credentials_include()
-            .send()
-            .await
-            .map_err(|e| format!("Request failed: {}", e))?;
+        let response = ApiClient::with_credentials(
+            self.http_client()
+                .post(format!("{}/auth/login", base_url))
+                .json(&request),
+        )
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?;
 
         if response.status().is_success() {
             let login_response: LoginResponse = response
@@ -46,14 +46,14 @@ impl ApiClient {
             "device_label": device_label
         });
 
-        let response = self
-            .http_client()
-            .post(format!("{}/auth/refresh", base_url))
-            .json(&payload)
-            // .fetch_credentials_include()
-            .send()
-            .await
-            .map_err(|e| format!("Request failed: {}", e))?;
+        let response = ApiClient::with_credentials(
+            self.http_client()
+                .post(format!("{}/auth/refresh", base_url))
+                .json(&payload),
+        )
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?;
 
         let status = response.status();
         Self::handle_unauthorized_status(status);

--- a/frontend/src/api/requests.rs
+++ b/frontend/src/api/requests.rs
@@ -157,7 +157,7 @@ impl ApiClient {
         self.map_json_response(response).await
     }
 
-    async fn map_json_response(&self, response: reqwest_wasm::Response) -> Result<Value, String> {
+    async fn map_json_response(&self, response: reqwest::Response) -> Result<Value, String> {
         let status = response.status();
         Self::handle_unauthorized_status(status);
         if status.is_success() {

--- a/frontend/src/config.rs
+++ b/frontend/src/config.rs
@@ -1,3 +1,4 @@
+use crate::api::client::ApiClient;
 use chrono_tz::Tz;
 use serde::{Deserialize, Serialize};
 #[cfg(test)]
@@ -172,7 +173,7 @@ fn write_window_config(cfg: &RuntimeConfig) {
 }
 
 async fn fetch_runtime_config() -> Option<RuntimeConfig> {
-    let resp = reqwest_wasm::get("./config.json").await.ok()?;
+    let resp = reqwest::get("./config.json").await.ok()?;
     if !resp.status().is_success() {
         return None;
     }
@@ -210,11 +211,10 @@ async fn fetch_time_zone_from_api(base_url: &str) -> Result<String, String> {
         return result;
     }
 
-    let client = reqwest_wasm::Client::new();
+    let client = reqwest::Client::new();
     let trimmed = base_url.trim_end_matches('/');
     let url = format!("{}/config/timezone", trimmed);
-    let resp = client
-        .get(&url)
+    let resp = ApiClient::with_credentials(client.get(&url))
         .send()
         .await
         .map_err(|e| format!("Failed to request {}: {}", url, e))?;


### PR DESCRIPTION
## 概要
reqwest-wasmから公式reqwest 0.12への移行と、WASM環境でのクレデンシャル（Cookie）送信の実装

## 変更内容
- reqwest-wasm 0.11 → reqwest 0.12 への移行
- web-sysにRequestCredentials featureを追加
- ApiClient::with_credentials()ヘルパーメソッドの追加（WASM/非WASM対応）
- 認証系リクエスト（login, refresh）でcredentialsを有効化
- タイムゾーンAPI呼び出しでcredentialsを有効化

## 関連Issue
Closes #135