### PR TITLE
fix: wasm credentials include for reqwest

### DIFF
--- a/frontend/src/api/client.rs
+++ b/frontend/src/api/client.rs
@@ -37,8 +37,7 @@ impl ApiClient {
 
     #[cfg(target_arch = "wasm32")]
     pub(crate) fn with_credentials(builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        use reqwest::wasm::RequestBuilderExt;
-        builder.credentials(web_sys::RequestCredentials::Include)
+        builder.fetch_credentials_include()
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
## 概要
- WASM で reqwest の private `reqwest::wasm` API を参照していた箇所を、公開APIの `fetch_credentials_include()` に切り替えました。
- `credentials` 未定義エラーを解消し、WASM ビルドが通るようにします。

## 影響範囲
- frontend: API クライアントのリクエスト生成

## テスト
- cargo check -p timekeeper-frontend --target wasm32-unknown-unknown
