### PR TITLE
fix: align user_exists query with SQL types

### DIFF
--- a/backend/src/repositories/user.rs
+++ b/backend/src/repositories/user.rs
@@ -1,8 +1,7 @@
 //! Repository functions for user management operations.
 
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use sqlx::PgPool;
-use uuid::Uuid;
 
 /// Archives a user and all related data (soft delete).
 /// - Moves user to archived_users
@@ -123,6 +122,7 @@ pub async fn hard_delete_user(pool: &PgPool, user_id: &str) -> Result<(), sqlx::
 }
 
 /// Restores a user from the archive.
+#[allow(dead_code)]
 pub async fn restore_user(pool: &PgPool, user_id: &str) -> Result<(), sqlx::Error> {
     let mut tx = pool.begin().await?;
 
@@ -242,12 +242,13 @@ pub async fn restore_user(pool: &PgPool, user_id: &str) -> Result<(), sqlx::Erro
 
 /// Checks if a user exists by ID.
 pub async fn user_exists(pool: &PgPool, user_id: &str) -> Result<bool, sqlx::Error> {
-    let result: Option<(i64,)> =
-        sqlx::query_as("SELECT 1 FROM users WHERE id = $1")
-            .bind(user_id)
-            .fetch_optional(pool)
-            .await?;
-    Ok(result.is_some())
+    let exists = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (SELECT 1 FROM users WHERE id = $1)",
+    )
+    .bind(user_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(exists)
 }
 
 /// Fetches username by user ID.

--- a/backend/tests/user_repo.rs
+++ b/backend/tests/user_repo.rs
@@ -1,0 +1,38 @@
+use std::sync::OnceLock;
+
+use sqlx::Executor;
+use timekeeper_backend::models::user::UserRole;
+use timekeeper_backend::repositories::user as user_repo;
+use tokio::sync::Mutex;
+
+#[path = "support/mod.rs"]
+mod support;
+
+async fn integration_guard() -> tokio::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD.get_or_init(|| Mutex::new(())).lock().await
+}
+
+#[tokio::test]
+async fn user_exists_returns_expected_values() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    pool.execute("TRUNCATE users CASCADE")
+        .await
+        .expect("truncate users");
+
+    let user = support::seed_user(&pool, UserRole::Admin, false).await;
+    let exists = user_repo::user_exists(&pool, &user.id)
+        .await
+        .expect("user_exists for existing user");
+    assert!(exists);
+
+    let missing = user_repo::user_exists(&pool, "00000000-0000-0000-0000-000000000000")
+        .await
+        .expect("user_exists for missing user");
+    assert!(!missing);
+}


### PR DESCRIPTION
## 概要
- `user_exists` を `SELECT EXISTS` に切り替え、SQLx の INT4/INT8 不一致で削除が失敗する問題を解消
- 再発防止のリポジトリテストを追加

## 関連Issue/Linear
- N/A

## 影響範囲
- Backend: `user_exists` の型整合性を修正
- Frontend: なし

## 環境変数
- 変更なし

## テスト
- `cd backend; cargo test`
- `cd backend; cargo clippy --all-targets -- -D warnings`
- `pwsh -File .\\scripts\\test_backend.ps1` (DB初期化後)

## UI
- 変更なし

## 追加の注意
- マイグレーション不要