### PR TITLE
fix: resolve login 500 and complete repository pattern (issue #153)

### DIFF
--- a/backend/migrations/004_fix_admin_password.sql
+++ b/backend/migrations/004_fix_admin_password.sql
@@ -10,4 +10,3 @@ WHERE username = 'admin';
 INSERT INTO users (id, username, password_hash, full_name, role, created_at, updated_at)
 SELECT 'admin-001', 'admin', '$argon2id$v=19$m=19456,t=2,p=1$SHjkBewYpN0AqfNJtz4BCQ$Q6EKet0GGAKSbQ5hQFsXf+6WG+AX8Z91wi5hlimtYew', 'System Administrator', 'admin', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 WHERE NOT EXISTS (SELECT 1 FROM users WHERE username = 'admin');
-

--- a/backend/migrations/023_fix_default_admin_uuid.sql
+++ b/backend/migrations/023_fix_default_admin_uuid.sql
@@ -1,0 +1,90 @@
+-- Ensure default admin uses a UUIDv5 derived from "admin-001".
+DO $$
+DECLARE
+    old_id TEXT := 'admin-001';
+    new_id TEXT := '05d512df-1c7b-5567-9cbc-efa7104e9a90';
+BEGIN
+    IF EXISTS (SELECT 1 FROM users WHERE id = old_id) THEN
+        -- Avoid username uniqueness conflicts when inserting the new row.
+        UPDATE users
+        SET username = username || '_legacy_admin_001'
+        WHERE id = old_id AND username = 'admin';
+
+        IF NOT EXISTS (SELECT 1 FROM users WHERE id = new_id) THEN
+            INSERT INTO users (
+                id,
+                username,
+                password_hash,
+                full_name,
+                role,
+                is_system_admin,
+                mfa_secret,
+                mfa_enabled_at,
+                created_at,
+                updated_at
+            )
+            SELECT
+                new_id,
+                'admin',
+                password_hash,
+                full_name,
+                role,
+                is_system_admin,
+                mfa_secret,
+                mfa_enabled_at,
+                created_at,
+                updated_at
+            FROM users
+            WHERE id = old_id;
+        END IF;
+
+        UPDATE attendance SET user_id = new_id WHERE user_id = old_id;
+        UPDATE attendance SET updated_by = new_id WHERE updated_by = old_id;
+        UPDATE break_records SET updated_by = new_id WHERE updated_by = old_id;
+
+        UPDATE leave_requests SET user_id = new_id WHERE user_id = old_id;
+        UPDATE leave_requests SET approved_by = new_id WHERE approved_by = old_id;
+        UPDATE leave_requests SET rejected_by = new_id WHERE rejected_by = old_id;
+        UPDATE leave_requests SET updated_by = new_id WHERE updated_by = old_id;
+
+        UPDATE overtime_requests SET user_id = new_id WHERE user_id = old_id;
+        UPDATE overtime_requests SET approved_by = new_id WHERE approved_by = old_id;
+        UPDATE overtime_requests SET rejected_by = new_id WHERE rejected_by = old_id;
+        UPDATE overtime_requests SET updated_by = new_id WHERE updated_by = old_id;
+
+        UPDATE refresh_tokens SET user_id = new_id WHERE user_id = old_id;
+        UPDATE active_access_tokens SET user_id = new_id WHERE user_id = old_id;
+
+        UPDATE consent_logs SET user_id = new_id WHERE user_id = old_id;
+        UPDATE user_permissions SET user_id = new_id WHERE user_id = old_id;
+
+        UPDATE holiday_exceptions SET user_id = new_id WHERE user_id = old_id;
+        UPDATE holiday_exceptions SET created_by = new_id WHERE created_by = old_id;
+
+        UPDATE subject_requests SET user_id = new_id WHERE user_id = old_id;
+        UPDATE subject_requests SET approved_by = new_id WHERE approved_by = old_id;
+        UPDATE subject_requests SET rejected_by = new_id WHERE rejected_by = old_id;
+
+        UPDATE audit_logs SET actor_id = new_id WHERE actor_id = old_id;
+        UPDATE audit_logs SET target_id = new_id WHERE target_id = old_id;
+
+        IF EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_name = 'audit_logs_legacy'
+        ) THEN
+            UPDATE audit_logs_legacy SET user_id = new_id WHERE user_id = old_id;
+        END IF;
+
+        UPDATE archived_users SET archived_by = new_id WHERE archived_by = old_id;
+        UPDATE archived_attendance SET user_id = new_id WHERE user_id = old_id;
+        UPDATE archived_leave_requests SET user_id = new_id WHERE user_id = old_id;
+        UPDATE archived_leave_requests SET approved_by = new_id WHERE approved_by = old_id;
+        UPDATE archived_overtime_requests SET user_id = new_id WHERE user_id = old_id;
+        UPDATE archived_overtime_requests SET approved_by = new_id WHERE approved_by = old_id;
+        UPDATE archived_holiday_exceptions SET user_id = new_id WHERE user_id = old_id;
+        UPDATE archived_holiday_exceptions SET created_by = new_id WHERE created_by = old_id;
+
+        DELETE FROM users WHERE id = old_id;
+    END IF;
+END $$;

--- a/backend/src/handlers/admin/attendance.rs
+++ b/backend/src/handlers/admin/attendance.rs
@@ -14,7 +14,7 @@ use crate::{
     config::Config,
     handlers::attendance::recalculate_total_hours,
     models::{
-        attendance::{Attendance, AttendanceResponse, AttendanceStatus},
+        attendance::{Attendance, AttendanceResponse},
         break_record::BreakRecordResponse,
         user::User,
     },
@@ -169,9 +169,8 @@ pub async fn upsert_attendance(
         .bind(att.date)
         .bind(att.clock_in_time)
         .bind(att.clock_out_time)
-          // Store enum as snake_case text to match sqlx mapping
-          .bind(match att.status { AttendanceStatus::Present => "present", AttendanceStatus::Absent => "absent", AttendanceStatus::Late => "late", AttendanceStatus::HalfDay => "half_day" })
-          .bind(att.total_work_hours)
+        .bind(att.status.db_value())
+        .bind(att.total_work_hours)
         .bind(att.created_at)
         .bind(att.updated_at)
         .execute(&mut *tx)

--- a/backend/src/handlers/attendance_utils.rs
+++ b/backend/src/handlers/attendance_utils.rs
@@ -1,8 +1,5 @@
 use crate::types::{AttendanceId, UserId};
-use crate::{
-    error::AppError,
-    models::attendance::{Attendance, AttendanceStatus},
-};
+use crate::{error::AppError, models::attendance::Attendance};
 use chrono::NaiveDate;
 use sqlx::PgPool;
 
@@ -92,7 +89,7 @@ pub async fn insert_attendance_record(
     .bind(attendance.date)
     .bind(attendance.clock_in_time)
     .bind(attendance.clock_out_time)
-    .bind(status_to_str(&attendance.status))
+    .bind(attendance.status.db_value())
     .bind(attendance.total_work_hours)
     .bind(attendance.created_at)
     .bind(attendance.updated_at)
@@ -125,14 +122,4 @@ pub async fn update_clock_out(pool: &PgPool, attendance: &Attendance) -> Result<
     .await?;
 
     Ok(())
-}
-
-pub fn status_to_str(status: &AttendanceStatus) -> &'static str {
-    use AttendanceStatus::*;
-    match status {
-        Present => "present",
-        Absent => "absent",
-        Late => "late",
-        HalfDay => "half_day",
-    }
 }

--- a/backend/src/handlers/mod.rs
+++ b/backend/src/handlers/mod.rs
@@ -9,5 +9,4 @@ pub mod holiday_exception_repo;
 pub mod holiday_exceptions;
 pub mod holidays;
 pub mod requests;
-pub mod requests_repo;
 pub mod subject_requests;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -32,8 +32,8 @@ mod utils;
 mod validation;
 
 use config::{AuditLogRetentionPolicy, Config};
-use middleware::rate_limit::create_auth_rate_limiter;
 use db::connection::{create_pool, DbPool};
+use middleware::rate_limit::create_auth_rate_limiter;
 use services::{
     audit_log::{AuditLogService, AuditLogServiceTrait},
     consent_log::ConsentLogService,
@@ -101,7 +101,11 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("Server listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>()).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
 
     Ok(())
 }

--- a/backend/src/middleware/rate_limit.rs
+++ b/backend/src/middleware/rate_limit.rs
@@ -1,12 +1,11 @@
 use axum::body::Body;
 use axum::http::{header::CONTENT_TYPE, HeaderValue, Response, StatusCode};
-use std::time::Duration;
 use governor::middleware::StateInformationMiddleware;
 use std::sync::Arc;
+use std::time::Duration;
 use tower_governor::{
-    governor::GovernorConfigBuilder,
-    key_extractor::PeerIpKeyExtractor,
-    GovernorError, GovernorLayer,
+    governor::GovernorConfigBuilder, key_extractor::PeerIpKeyExtractor, GovernorError,
+    GovernorLayer,
 };
 
 use crate::config::Config;

--- a/backend/src/models/attendance.rs
+++ b/backend/src/models/attendance.rs
@@ -46,6 +46,17 @@ pub enum AttendanceStatus {
     HalfDay,
 }
 
+impl AttendanceStatus {
+    pub fn db_value(&self) -> &'static str {
+        match self {
+            AttendanceStatus::Present => "present",
+            AttendanceStatus::Absent => "absent",
+            AttendanceStatus::Late => "late",
+            AttendanceStatus::HalfDay => "half_day",
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 /// Request payload used when an employee clocks in.
 pub struct ClockInRequest {
@@ -163,5 +174,13 @@ mod tests {
         let clock_out = date.and_hms_opt(17, 0, 0).unwrap();
         attendance.clock_out_time = Some(clock_out);
         assert!(attendance.is_clocked_out());
+    }
+
+    #[test]
+    fn attendance_status_db_value_matches_schema() {
+        assert_eq!(AttendanceStatus::Present.db_value(), "present");
+        assert_eq!(AttendanceStatus::Absent.db_value(), "absent");
+        assert_eq!(AttendanceStatus::Late.db_value(), "late");
+        assert_eq!(AttendanceStatus::HalfDay.db_value(), "half_day");
     }
 }

--- a/backend/src/models/leave_request.rs
+++ b/backend/src/models/leave_request.rs
@@ -193,12 +193,14 @@ mod tests {
         assert!(matches!(lt, LeaveType::Annual));
         let vlt = serde_json::to_value(LeaveType::Personal).unwrap();
         assert_eq!(vlt, serde_json::json!("personal"));
+        assert_eq!(LeaveType::Annual.db_value(), "annual");
 
         // RequestStatus
         let rs: RequestStatus = serde_json::from_str("\"rejected\"").unwrap();
         assert!(matches!(rs, RequestStatus::Rejected));
         let vrs = serde_json::to_value(RequestStatus::Cancelled).unwrap();
         assert_eq!(vrs, serde_json::json!("cancelled"));
+        assert_eq!(RequestStatus::Pending.db_value(), "pending");
     }
 
     #[test]

--- a/backend/src/models/overtime_request.rs
+++ b/backend/src/models/overtime_request.rs
@@ -152,6 +152,7 @@ mod tests {
         assert!(matches!(s, RequestStatus::Approved));
         let v = serde_json::to_value(RequestStatus::Pending).unwrap();
         assert_eq!(v, serde_json::json!("pending"));
+        assert_eq!(RequestStatus::Approved.db_value(), "approved");
     }
 
     #[test]

--- a/backend/src/repositories/attendance.rs
+++ b/backend/src/repositories/attendance.rs
@@ -1,0 +1,131 @@
+//! Attendance repository.
+//!
+//! Provides CRUD operations for attendance records.
+
+#![allow(dead_code)]
+
+use crate::error::AppError;
+use crate::models::attendance::Attendance;
+use crate::repositories::repository::Repository;
+use crate::types::{AttendanceId, UserId};
+use chrono::NaiveDate;
+use sqlx::PgPool;
+
+const TABLE_NAME: &str = "attendance";
+const SELECT_COLUMNS: &str =
+    "id, user_id, date, clock_in_time, clock_out_time, status, total_work_hours, created_at, updated_at";
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AttendanceRepository;
+
+impl AttendanceRepository {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn find_by_user_and_date(
+        &self,
+        db: &PgPool,
+        user_id: UserId,
+        date: NaiveDate,
+    ) -> Result<Option<Attendance>, AppError> {
+        let query = format!(
+            "SELECT {} FROM {} WHERE user_id = $1 AND date = $2",
+            SELECT_COLUMNS, TABLE_NAME
+        );
+        let row = sqlx::query_as::<_, Attendance>(&query)
+            .bind(user_id)
+            .bind(date)
+            .fetch_optional(db)
+            .await?;
+        Ok(row)
+    }
+
+    fn base_select_query() -> String {
+        format!("SELECT {} FROM {}", SELECT_COLUMNS, TABLE_NAME)
+    }
+}
+
+impl Repository<Attendance> for AttendanceRepository {
+    const TABLE: &'static str = TABLE_NAME;
+    type Id = AttendanceId;
+
+    async fn find_all(&self, db: &PgPool) -> Result<Vec<Attendance>, AppError> {
+        let query = format!("{} ORDER BY date DESC", Self::base_select_query());
+        let rows = sqlx::query_as::<_, Attendance>(&query)
+            .fetch_all(db)
+            .await?;
+        Ok(rows)
+    }
+
+    async fn find_by_id(&self, db: &PgPool, id: AttendanceId) -> Result<Attendance, AppError> {
+        let query = format!("{} WHERE id = $1", Self::base_select_query());
+        let result = sqlx::query_as::<_, Attendance>(&query)
+            .bind(id)
+            .fetch_optional(db)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Attendance record not found".into()))?;
+        Ok(result)
+    }
+
+    async fn create(&self, db: &PgPool, item: &Attendance) -> Result<Attendance, AppError> {
+        let query = format!(
+            "INSERT INTO {} (id, user_id, date, clock_in_time, clock_out_time, status, total_work_hours, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) \
+             RETURNING {}",
+            TABLE_NAME, SELECT_COLUMNS
+        );
+        let row = sqlx::query_as::<_, Attendance>(&query)
+            .bind(item.id)
+            .bind(item.user_id)
+            .bind(item.date)
+            .bind(item.clock_in_time)
+            .bind(item.clock_out_time)
+            .bind(item.status.db_value())
+            .bind(item.total_work_hours)
+            .bind(item.created_at)
+            .bind(item.updated_at)
+            .fetch_one(db)
+            .await?;
+        Ok(row)
+    }
+
+    async fn update(&self, db: &PgPool, item: &Attendance) -> Result<Attendance, AppError> {
+        let query = format!(
+            "UPDATE {} SET user_id = $2, date = $3, clock_in_time = $4, clock_out_time = $5, \
+             status = $6, total_work_hours = $7, updated_at = $8 WHERE id = $1 \
+             RETURNING {}",
+            TABLE_NAME, SELECT_COLUMNS
+        );
+        let row = sqlx::query_as::<_, Attendance>(&query)
+            .bind(item.id)
+            .bind(item.user_id)
+            .bind(item.date)
+            .bind(item.clock_in_time)
+            .bind(item.clock_out_time)
+            .bind(item.status.db_value())
+            .bind(item.total_work_hours)
+            .bind(item.updated_at)
+            .fetch_one(db)
+            .await?;
+        Ok(row)
+    }
+
+    async fn delete(&self, db: &PgPool, id: AttendanceId) -> Result<(), AppError> {
+        let query = format!("DELETE FROM {} WHERE id = $1", TABLE_NAME);
+        sqlx::query(&query).bind(id).execute(db).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attendance_select_columns_include_expected_fields() {
+        assert!(SELECT_COLUMNS.contains("clock_in_time"));
+        assert!(SELECT_COLUMNS.contains("total_work_hours"));
+        assert!(SELECT_COLUMNS.contains("updated_at"));
+    }
+}

--- a/backend/src/repositories/break_record.rs
+++ b/backend/src/repositories/break_record.rs
@@ -1,0 +1,126 @@
+//! Break record repository.
+//!
+//! Provides CRUD operations for break records.
+
+#![allow(dead_code)]
+
+use crate::error::AppError;
+use crate::models::break_record::BreakRecord;
+use crate::repositories::repository::Repository;
+use crate::types::{AttendanceId, BreakRecordId};
+use sqlx::PgPool;
+
+const TABLE_NAME: &str = "break_records";
+const SELECT_COLUMNS: &str =
+    "id, attendance_id, break_start_time, break_end_time, duration_minutes, created_at, updated_at";
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BreakRecordRepository;
+
+impl BreakRecordRepository {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn find_by_attendance(
+        &self,
+        db: &PgPool,
+        attendance_id: AttendanceId,
+    ) -> Result<Vec<BreakRecord>, AppError> {
+        let query = format!(
+            "SELECT {} FROM {} WHERE attendance_id = $1 ORDER BY break_start_time ASC",
+            SELECT_COLUMNS, TABLE_NAME
+        );
+        let rows = sqlx::query_as::<_, BreakRecord>(&query)
+            .bind(attendance_id)
+            .fetch_all(db)
+            .await?;
+        Ok(rows)
+    }
+
+    fn base_select_query() -> String {
+        format!("SELECT {} FROM {}", SELECT_COLUMNS, TABLE_NAME)
+    }
+}
+
+impl Repository<BreakRecord> for BreakRecordRepository {
+    const TABLE: &'static str = TABLE_NAME;
+    type Id = BreakRecordId;
+
+    async fn find_all(&self, db: &PgPool) -> Result<Vec<BreakRecord>, AppError> {
+        let query = format!(
+            "{} ORDER BY break_start_time DESC",
+            Self::base_select_query()
+        );
+        let rows = sqlx::query_as::<_, BreakRecord>(&query)
+            .fetch_all(db)
+            .await?;
+        Ok(rows)
+    }
+
+    async fn find_by_id(&self, db: &PgPool, id: BreakRecordId) -> Result<BreakRecord, AppError> {
+        let query = format!("{} WHERE id = $1", Self::base_select_query());
+        let result = sqlx::query_as::<_, BreakRecord>(&query)
+            .bind(id)
+            .fetch_optional(db)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Break record not found".into()))?;
+        Ok(result)
+    }
+
+    async fn create(&self, db: &PgPool, item: &BreakRecord) -> Result<BreakRecord, AppError> {
+        let query = format!(
+            "INSERT INTO {} (id, attendance_id, break_start_time, break_end_time, duration_minutes, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7) \
+             RETURNING {}",
+            TABLE_NAME, SELECT_COLUMNS
+        );
+        let row = sqlx::query_as::<_, BreakRecord>(&query)
+            .bind(item.id)
+            .bind(item.attendance_id)
+            .bind(item.break_start_time)
+            .bind(item.break_end_time)
+            .bind(item.duration_minutes)
+            .bind(item.created_at)
+            .bind(item.updated_at)
+            .fetch_one(db)
+            .await?;
+        Ok(row)
+    }
+
+    async fn update(&self, db: &PgPool, item: &BreakRecord) -> Result<BreakRecord, AppError> {
+        let query = format!(
+            "UPDATE {} SET attendance_id = $2, break_start_time = $3, break_end_time = $4, \
+             duration_minutes = $5, updated_at = $6 WHERE id = $1 \
+             RETURNING {}",
+            TABLE_NAME, SELECT_COLUMNS
+        );
+        let row = sqlx::query_as::<_, BreakRecord>(&query)
+            .bind(item.id)
+            .bind(item.attendance_id)
+            .bind(item.break_start_time)
+            .bind(item.break_end_time)
+            .bind(item.duration_minutes)
+            .bind(item.updated_at)
+            .fetch_one(db)
+            .await?;
+        Ok(row)
+    }
+
+    async fn delete(&self, db: &PgPool, id: BreakRecordId) -> Result<(), AppError> {
+        let query = format!("DELETE FROM {} WHERE id = $1", TABLE_NAME);
+        sqlx::query(&query).bind(id).execute(db).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn break_record_select_columns_include_expected_fields() {
+        assert!(SELECT_COLUMNS.contains("break_start_time"));
+        assert!(SELECT_COLUMNS.contains("duration_minutes"));
+    }
+}

--- a/backend/src/repositories/holiday.rs
+++ b/backend/src/repositories/holiday.rs
@@ -1,0 +1,118 @@
+//! Holiday repository.
+//!
+//! Provides CRUD operations for holidays.
+
+#![allow(dead_code)]
+
+use crate::error::AppError;
+use crate::models::holiday::Holiday;
+use crate::repositories::repository::Repository;
+use crate::types::HolidayId;
+use chrono::NaiveDate;
+use sqlx::PgPool;
+
+const TABLE_NAME: &str = "holidays";
+const SELECT_COLUMNS: &str = "id, holiday_date, name, description, created_at, updated_at";
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct HolidayRepository;
+
+impl HolidayRepository {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn find_by_date(
+        &self,
+        db: &PgPool,
+        date: NaiveDate,
+    ) -> Result<Option<Holiday>, AppError> {
+        let query = format!(
+            "SELECT {} FROM {} WHERE holiday_date = $1",
+            SELECT_COLUMNS, TABLE_NAME
+        );
+        let row = sqlx::query_as::<_, Holiday>(&query)
+            .bind(date)
+            .fetch_optional(db)
+            .await?;
+        Ok(row)
+    }
+
+    fn base_select_query() -> String {
+        format!("SELECT {} FROM {}", SELECT_COLUMNS, TABLE_NAME)
+    }
+}
+
+impl Repository<Holiday> for HolidayRepository {
+    const TABLE: &'static str = TABLE_NAME;
+    type Id = HolidayId;
+
+    async fn find_all(&self, db: &PgPool) -> Result<Vec<Holiday>, AppError> {
+        let query = format!("{} ORDER BY holiday_date DESC", Self::base_select_query());
+        let rows = sqlx::query_as::<_, Holiday>(&query).fetch_all(db).await?;
+        Ok(rows)
+    }
+
+    async fn find_by_id(&self, db: &PgPool, id: HolidayId) -> Result<Holiday, AppError> {
+        let query = format!("{} WHERE id = $1", Self::base_select_query());
+        let result = sqlx::query_as::<_, Holiday>(&query)
+            .bind(id)
+            .fetch_optional(db)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Holiday not found".into()))?;
+        Ok(result)
+    }
+
+    async fn create(&self, db: &PgPool, item: &Holiday) -> Result<Holiday, AppError> {
+        let query = format!(
+            "INSERT INTO {} (id, holiday_date, name, description, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6) \
+             RETURNING {}",
+            TABLE_NAME, SELECT_COLUMNS
+        );
+        let row = sqlx::query_as::<_, Holiday>(&query)
+            .bind(item.id)
+            .bind(item.holiday_date)
+            .bind(&item.name)
+            .bind(&item.description)
+            .bind(item.created_at)
+            .bind(item.updated_at)
+            .fetch_one(db)
+            .await?;
+        Ok(row)
+    }
+
+    async fn update(&self, db: &PgPool, item: &Holiday) -> Result<Holiday, AppError> {
+        let query = format!(
+            "UPDATE {} SET holiday_date = $2, name = $3, description = $4, updated_at = $5 \
+             WHERE id = $1 RETURNING {}",
+            TABLE_NAME, SELECT_COLUMNS
+        );
+        let row = sqlx::query_as::<_, Holiday>(&query)
+            .bind(item.id)
+            .bind(item.holiday_date)
+            .bind(&item.name)
+            .bind(&item.description)
+            .bind(item.updated_at)
+            .fetch_one(db)
+            .await?;
+        Ok(row)
+    }
+
+    async fn delete(&self, db: &PgPool, id: HolidayId) -> Result<(), AppError> {
+        let query = format!("DELETE FROM {} WHERE id = $1", TABLE_NAME);
+        sqlx::query(&query).bind(id).execute(db).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn holiday_select_columns_include_expected_fields() {
+        assert!(SELECT_COLUMNS.contains("holiday_date"));
+        assert!(SELECT_COLUMNS.contains("description"));
+    }
+}

--- a/backend/src/repositories/leave_request.rs
+++ b/backend/src/repositories/leave_request.rs
@@ -1,0 +1,254 @@
+//! Leave request repository.
+//!
+//! Provides CRUD operations for leave requests.
+
+use crate::error::AppError;
+use crate::models::leave_request::{LeaveRequest, RequestStatus};
+use crate::repositories::repository::Repository;
+use crate::types::{LeaveRequestId, UserId};
+use chrono::{DateTime, NaiveDate, Utc};
+use sqlx::PgPool;
+
+const TABLE_NAME: &str = "leave_requests";
+const SELECT_COLUMNS: &str = "id, user_id, leave_type, start_date, end_date, reason, status, \
+approved_by, approved_at, rejected_by, rejected_at, cancelled_at, decision_comment, created_at, updated_at";
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LeaveRequestRepository;
+
+impl LeaveRequestRepository {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn find_by_user(
+        &self,
+        db: &PgPool,
+        user_id: UserId,
+    ) -> Result<Vec<LeaveRequest>, AppError> {
+        let query = format!(
+            "SELECT {} FROM {} WHERE user_id = $1 ORDER BY created_at DESC",
+            SELECT_COLUMNS, TABLE_NAME
+        );
+        let rows = sqlx::query_as::<_, LeaveRequest>(&query)
+            .bind(user_id)
+            .fetch_all(db)
+            .await?;
+        Ok(rows)
+    }
+
+    #[allow(dead_code)]
+    pub async fn find_by_user_and_date_range(
+        &self,
+        db: &PgPool,
+        user_id: UserId,
+        start_date: NaiveDate,
+        end_date: NaiveDate,
+    ) -> Result<Vec<LeaveRequest>, AppError> {
+        let query = format!(
+            "SELECT {} FROM {} WHERE user_id = $1 AND start_date >= $2 AND end_date <= $3 \
+             ORDER BY start_date DESC",
+            SELECT_COLUMNS, TABLE_NAME
+        );
+        let rows = sqlx::query_as::<_, LeaveRequest>(&query)
+            .bind(user_id)
+            .bind(start_date)
+            .bind(end_date)
+            .fetch_all(db)
+            .await?;
+        Ok(rows)
+    }
+
+    pub async fn find_by_id_for_user(
+        &self,
+        db: &PgPool,
+        id: LeaveRequestId,
+        user_id: UserId,
+    ) -> Result<Option<LeaveRequest>, AppError> {
+        let query = format!(
+            "SELECT {} FROM {} WHERE id = $1 AND user_id = $2",
+            SELECT_COLUMNS, TABLE_NAME
+        );
+        let row = sqlx::query_as::<_, LeaveRequest>(&query)
+            .bind(id)
+            .bind(user_id)
+            .fetch_optional(db)
+            .await?;
+        Ok(row)
+    }
+
+    pub async fn cancel(
+        &self,
+        db: &PgPool,
+        id: LeaveRequestId,
+        user_id: UserId,
+        timestamp: DateTime<Utc>,
+    ) -> Result<u64, AppError> {
+        let query = format!(
+            "UPDATE {} SET status = $1, cancelled_at = $2, updated_at = $3 \
+             WHERE id = $4 AND user_id = $5 AND status = 'pending'",
+            TABLE_NAME
+        );
+        let result = sqlx::query(&query)
+            .bind(RequestStatus::Cancelled.db_value())
+            .bind(timestamp)
+            .bind(timestamp)
+            .bind(id)
+            .bind(user_id)
+            .execute(db)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    pub async fn approve(
+        &self,
+        db: &PgPool,
+        id: LeaveRequestId,
+        approver_id: UserId,
+        comment: &str,
+        timestamp: DateTime<Utc>,
+    ) -> Result<u64, AppError> {
+        let query = format!(
+            "UPDATE {} SET status = $1, approved_by = $2, approved_at = $3, decision_comment = $4, \
+             updated_at = $5 WHERE id = $6 AND status = 'pending'",
+            TABLE_NAME
+        );
+        let result = sqlx::query(&query)
+            .bind(RequestStatus::Approved.db_value())
+            .bind(approver_id)
+            .bind(timestamp)
+            .bind(comment)
+            .bind(timestamp)
+            .bind(id)
+            .execute(db)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    pub async fn reject(
+        &self,
+        db: &PgPool,
+        id: LeaveRequestId,
+        approver_id: UserId,
+        comment: &str,
+        timestamp: DateTime<Utc>,
+    ) -> Result<u64, AppError> {
+        let query = format!(
+            "UPDATE {} SET status = $1, rejected_by = $2, rejected_at = $3, decision_comment = $4, \
+             updated_at = $5 WHERE id = $6 AND status = 'pending'",
+            TABLE_NAME
+        );
+        let result = sqlx::query(&query)
+            .bind(RequestStatus::Rejected.db_value())
+            .bind(approver_id)
+            .bind(timestamp)
+            .bind(comment)
+            .bind(timestamp)
+            .bind(id)
+            .execute(db)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    fn base_select_query() -> String {
+        format!("SELECT {} FROM {}", SELECT_COLUMNS, TABLE_NAME)
+    }
+}
+
+impl Repository<LeaveRequest> for LeaveRequestRepository {
+    const TABLE: &'static str = TABLE_NAME;
+    type Id = LeaveRequestId;
+
+    async fn find_all(&self, db: &PgPool) -> Result<Vec<LeaveRequest>, AppError> {
+        let query = format!("{} ORDER BY start_date DESC", Self::base_select_query());
+        let rows = sqlx::query_as::<_, LeaveRequest>(&query)
+            .fetch_all(db)
+            .await?;
+        Ok(rows)
+    }
+
+    async fn find_by_id(&self, db: &PgPool, id: LeaveRequestId) -> Result<LeaveRequest, AppError> {
+        let query = format!("{} WHERE id = $1", Self::base_select_query());
+        let result = sqlx::query_as::<_, LeaveRequest>(&query)
+            .bind(id)
+            .fetch_optional(db)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Leave request not found".into()))?;
+        Ok(result)
+    }
+
+    async fn create(&self, db: &PgPool, item: &LeaveRequest) -> Result<LeaveRequest, AppError> {
+        let query = format!(
+            "INSERT INTO {} (id, user_id, leave_type, start_date, end_date, reason, status, \
+             approved_by, approved_at, decision_comment, rejected_by, rejected_at, cancelled_at, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) \
+             RETURNING {}",
+            TABLE_NAME, SELECT_COLUMNS
+        );
+        let row = sqlx::query_as::<_, LeaveRequest>(&query)
+            .bind(item.id)
+            .bind(item.user_id)
+            .bind(item.leave_type.db_value())
+            .bind(item.start_date)
+            .bind(item.end_date)
+            .bind(&item.reason)
+            .bind(item.status.db_value())
+            .bind(item.approved_by)
+            .bind(item.approved_at)
+            .bind(&item.decision_comment)
+            .bind(item.rejected_by)
+            .bind(item.rejected_at)
+            .bind(item.cancelled_at)
+            .bind(item.created_at)
+            .bind(item.updated_at)
+            .fetch_one(db)
+            .await?;
+        Ok(row)
+    }
+
+    async fn update(&self, db: &PgPool, item: &LeaveRequest) -> Result<LeaveRequest, AppError> {
+        let query = format!(
+            "UPDATE {} SET user_id = $2, leave_type = $3, start_date = $4, end_date = $5, reason = $6, \
+             status = $7, approved_by = $8, approved_at = $9, decision_comment = $10, rejected_by = $11, \
+             rejected_at = $12, cancelled_at = $13, updated_at = $14 WHERE id = $1 \
+             RETURNING {}",
+            TABLE_NAME, SELECT_COLUMNS
+        );
+        let row = sqlx::query_as::<_, LeaveRequest>(&query)
+            .bind(item.id)
+            .bind(item.user_id)
+            .bind(item.leave_type.db_value())
+            .bind(item.start_date)
+            .bind(item.end_date)
+            .bind(&item.reason)
+            .bind(item.status.db_value())
+            .bind(item.approved_by)
+            .bind(item.approved_at)
+            .bind(&item.decision_comment)
+            .bind(item.rejected_by)
+            .bind(item.rejected_at)
+            .bind(item.cancelled_at)
+            .bind(item.updated_at)
+            .fetch_one(db)
+            .await?;
+        Ok(row)
+    }
+
+    async fn delete(&self, db: &PgPool, id: LeaveRequestId) -> Result<(), AppError> {
+        let query = format!("DELETE FROM {} WHERE id = $1", TABLE_NAME);
+        sqlx::query(&query).bind(id).execute(db).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leave_request_select_columns_include_expected_fields() {
+        assert!(SELECT_COLUMNS.contains("decision_comment"));
+        assert!(SELECT_COLUMNS.contains("rejected_at"));
+        assert!(SELECT_COLUMNS.contains("cancelled_at"));
+    }
+}

--- a/backend/src/repositories/mod.rs
+++ b/backend/src/repositories/mod.rs
@@ -1,5 +1,25 @@
+#![allow(unused_imports)]
+
+pub mod attendance;
 pub mod audit_log;
+pub mod break_record;
 pub mod consent_log;
+pub mod holiday;
+pub mod leave_request;
+pub mod overtime_request;
 pub mod permissions;
+pub mod repository;
 pub mod subject_request;
 pub mod user;
+
+pub use attendance::*;
+pub use audit_log::*;
+pub use break_record::*;
+pub use consent_log::*;
+pub use holiday::*;
+pub use leave_request::*;
+pub use overtime_request::*;
+pub use permissions::*;
+pub use repository::*;
+pub use subject_request::*;
+pub use user::*;

--- a/backend/src/repositories/overtime_request.rs
+++ b/backend/src/repositories/overtime_request.rs
@@ -1,0 +1,262 @@
+//! Overtime request repository.
+//!
+//! Provides CRUD operations for overtime requests.
+
+use crate::error::AppError;
+use crate::models::overtime_request::{OvertimeRequest, RequestStatus};
+use crate::repositories::repository::Repository;
+use crate::types::{OvertimeRequestId, UserId};
+use chrono::{DateTime, NaiveDate, Utc};
+use sqlx::PgPool;
+
+const TABLE_NAME: &str = "overtime_requests";
+const SELECT_COLUMNS: &str = "id, user_id, date, planned_hours, reason, status, approved_by, \
+approved_at, rejected_by, rejected_at, cancelled_at, decision_comment, created_at, updated_at";
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OvertimeRequestRepository;
+
+impl OvertimeRequestRepository {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn find_by_user(
+        &self,
+        db: &PgPool,
+        user_id: UserId,
+    ) -> Result<Vec<OvertimeRequest>, AppError> {
+        let query = format!(
+            "SELECT {} FROM {} WHERE user_id = $1 ORDER BY created_at DESC",
+            SELECT_COLUMNS, TABLE_NAME
+        );
+        let rows = sqlx::query_as::<_, OvertimeRequest>(&query)
+            .bind(user_id)
+            .fetch_all(db)
+            .await?;
+        Ok(rows)
+    }
+
+    #[allow(dead_code)]
+    pub async fn find_by_user_and_date_range(
+        &self,
+        db: &PgPool,
+        user_id: UserId,
+        start_date: NaiveDate,
+        end_date: NaiveDate,
+    ) -> Result<Vec<OvertimeRequest>, AppError> {
+        let query = format!(
+            "SELECT {} FROM {} WHERE user_id = $1 AND date >= $2 AND date <= $3 \
+             ORDER BY date DESC",
+            SELECT_COLUMNS, TABLE_NAME
+        );
+        let rows = sqlx::query_as::<_, OvertimeRequest>(&query)
+            .bind(user_id)
+            .bind(start_date)
+            .bind(end_date)
+            .fetch_all(db)
+            .await?;
+        Ok(rows)
+    }
+
+    pub async fn find_by_id_for_user(
+        &self,
+        db: &PgPool,
+        id: OvertimeRequestId,
+        user_id: UserId,
+    ) -> Result<Option<OvertimeRequest>, AppError> {
+        let query = format!(
+            "SELECT {} FROM {} WHERE id = $1 AND user_id = $2",
+            SELECT_COLUMNS, TABLE_NAME
+        );
+        let row = sqlx::query_as::<_, OvertimeRequest>(&query)
+            .bind(id)
+            .bind(user_id)
+            .fetch_optional(db)
+            .await?;
+        Ok(row)
+    }
+
+    pub async fn cancel(
+        &self,
+        db: &PgPool,
+        id: OvertimeRequestId,
+        user_id: UserId,
+        timestamp: DateTime<Utc>,
+    ) -> Result<u64, AppError> {
+        let query = format!(
+            "UPDATE {} SET status = $1, cancelled_at = $2, updated_at = $3 \
+             WHERE id = $4 AND user_id = $5 AND status = 'pending'",
+            TABLE_NAME
+        );
+        let result = sqlx::query(&query)
+            .bind(RequestStatus::Cancelled.db_value())
+            .bind(timestamp)
+            .bind(timestamp)
+            .bind(id)
+            .bind(user_id)
+            .execute(db)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    pub async fn approve(
+        &self,
+        db: &PgPool,
+        id: OvertimeRequestId,
+        approver_id: UserId,
+        comment: &str,
+        timestamp: DateTime<Utc>,
+    ) -> Result<u64, AppError> {
+        let query = format!(
+            "UPDATE {} SET status = $1, approved_by = $2, approved_at = $3, decision_comment = $4, \
+             updated_at = $5 WHERE id = $6 AND status = 'pending'",
+            TABLE_NAME
+        );
+        let result = sqlx::query(&query)
+            .bind(RequestStatus::Approved.db_value())
+            .bind(approver_id)
+            .bind(timestamp)
+            .bind(comment)
+            .bind(timestamp)
+            .bind(id)
+            .execute(db)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    pub async fn reject(
+        &self,
+        db: &PgPool,
+        id: OvertimeRequestId,
+        approver_id: UserId,
+        comment: &str,
+        timestamp: DateTime<Utc>,
+    ) -> Result<u64, AppError> {
+        let query = format!(
+            "UPDATE {} SET status = $1, rejected_by = $2, rejected_at = $3, decision_comment = $4, \
+             updated_at = $5 WHERE id = $6 AND status = 'pending'",
+            TABLE_NAME
+        );
+        let result = sqlx::query(&query)
+            .bind(RequestStatus::Rejected.db_value())
+            .bind(approver_id)
+            .bind(timestamp)
+            .bind(comment)
+            .bind(timestamp)
+            .bind(id)
+            .execute(db)
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    fn base_select_query() -> String {
+        format!("SELECT {} FROM {}", SELECT_COLUMNS, TABLE_NAME)
+    }
+}
+
+impl Repository<OvertimeRequest> for OvertimeRequestRepository {
+    const TABLE: &'static str = TABLE_NAME;
+    type Id = OvertimeRequestId;
+
+    async fn find_all(&self, db: &PgPool) -> Result<Vec<OvertimeRequest>, AppError> {
+        let query = format!("{} ORDER BY date DESC", Self::base_select_query());
+        let rows = sqlx::query_as::<_, OvertimeRequest>(&query)
+            .fetch_all(db)
+            .await?;
+        Ok(rows)
+    }
+
+    async fn find_by_id(
+        &self,
+        db: &PgPool,
+        id: OvertimeRequestId,
+    ) -> Result<OvertimeRequest, AppError> {
+        let query = format!("{} WHERE id = $1", Self::base_select_query());
+        let result = sqlx::query_as::<_, OvertimeRequest>(&query)
+            .bind(id)
+            .fetch_optional(db)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Overtime request not found".into()))?;
+        Ok(result)
+    }
+
+    async fn create(
+        &self,
+        db: &PgPool,
+        item: &OvertimeRequest,
+    ) -> Result<OvertimeRequest, AppError> {
+        let query = format!(
+            "INSERT INTO {} (id, user_id, date, planned_hours, reason, status, approved_by, approved_at, \
+             decision_comment, rejected_by, rejected_at, cancelled_at, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) \
+             RETURNING {}",
+            TABLE_NAME, SELECT_COLUMNS
+        );
+        let row = sqlx::query_as::<_, OvertimeRequest>(&query)
+            .bind(item.id)
+            .bind(item.user_id)
+            .bind(item.date)
+            .bind(item.planned_hours)
+            .bind(&item.reason)
+            .bind(item.status.db_value())
+            .bind(item.approved_by)
+            .bind(item.approved_at)
+            .bind(&item.decision_comment)
+            .bind(item.rejected_by)
+            .bind(item.rejected_at)
+            .bind(item.cancelled_at)
+            .bind(item.created_at)
+            .bind(item.updated_at)
+            .fetch_one(db)
+            .await?;
+        Ok(row)
+    }
+
+    async fn update(
+        &self,
+        db: &PgPool,
+        item: &OvertimeRequest,
+    ) -> Result<OvertimeRequest, AppError> {
+        let query = format!(
+            "UPDATE {} SET user_id = $2, date = $3, planned_hours = $4, reason = $5, status = $6, \
+             approved_by = $7, approved_at = $8, decision_comment = $9, rejected_by = $10, rejected_at = $11, \
+             cancelled_at = $12, updated_at = $13 WHERE id = $1 RETURNING {}",
+            TABLE_NAME, SELECT_COLUMNS
+        );
+        let row = sqlx::query_as::<_, OvertimeRequest>(&query)
+            .bind(item.id)
+            .bind(item.user_id)
+            .bind(item.date)
+            .bind(item.planned_hours)
+            .bind(&item.reason)
+            .bind(item.status.db_value())
+            .bind(item.approved_by)
+            .bind(item.approved_at)
+            .bind(&item.decision_comment)
+            .bind(item.rejected_by)
+            .bind(item.rejected_at)
+            .bind(item.cancelled_at)
+            .bind(item.updated_at)
+            .fetch_one(db)
+            .await?;
+        Ok(row)
+    }
+
+    async fn delete(&self, db: &PgPool, id: OvertimeRequestId) -> Result<(), AppError> {
+        let query = format!("DELETE FROM {} WHERE id = $1", TABLE_NAME);
+        sqlx::query(&query).bind(id).execute(db).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overtime_request_select_columns_include_expected_fields() {
+        assert!(SELECT_COLUMNS.contains("planned_hours"));
+        assert!(SELECT_COLUMNS.contains("decision_comment"));
+    }
+}

--- a/backend/src/repositories/repository.rs
+++ b/backend/src/repositories/repository.rs
@@ -1,0 +1,75 @@
+//! Repository trait and common functionality
+//!
+//! This module defines the standard repository trait that all repository modules
+//! should implement, along with transaction management utilities.
+
+use crate::error::AppError;
+use sqlx::PgPool;
+
+/// Standard repository trait for database operations
+///
+/// All repository modules should implement this trait to ensure consistent
+/// data access patterns and transaction handling.
+#[allow(async_fn_in_trait, dead_code)]
+pub trait Repository<T> {
+    /// Target table name.
+    const TABLE: &'static str;
+    /// Primary key type for the record.
+    type Id;
+    /// Find all records of type T
+    async fn find_all(&self, db: &PgPool) -> Result<Vec<T>, AppError>;
+
+    /// Find a single record by ID
+    async fn find_by_id(&self, db: &PgPool, id: Self::Id) -> Result<T, AppError>;
+
+    /// Create a new record
+    async fn create(&self, db: &PgPool, item: &T) -> Result<T, AppError>;
+
+    /// Update an existing record
+    async fn update(&self, db: &PgPool, item: &T) -> Result<T, AppError>;
+
+    /// Delete a record by ID
+    async fn delete(&self, db: &PgPool, id: Self::Id) -> Result<(), AppError>;
+}
+
+/// Transaction management for database operations
+///
+/// Provides begin, commit, and rollback utilities for managing database
+/// transactions across repository operations.
+#[allow(dead_code)]
+pub mod transaction {
+    use crate::error::AppError;
+    use sqlx::postgres::PgTransaction;
+    use sqlx::PgPool;
+
+    /// Begin a new database transaction
+    ///
+    /// Returns a transaction handle that can be used for multiple database operations.
+    /// On success, the transaction can be committed via [`commit_transaction`].
+    /// On failure, the transaction can be rolled back via [`rollback_transaction`].
+    pub async fn begin_transaction(db: &PgPool) -> Result<PgTransaction<'_>, AppError> {
+        db.begin()
+            .await
+            .map_err(|e| AppError::InternalServerError(e.into()))
+    }
+
+    /// Commit a transaction
+    ///
+    /// Commits all changes made within the transaction to the database.
+    /// Returns error if commit fails.
+    pub async fn commit_transaction(tx: PgTransaction<'_>) -> Result<(), AppError> {
+        tx.commit()
+            .await
+            .map_err(|e| AppError::InternalServerError(e.into()))
+    }
+
+    /// Rollback a transaction
+    ///
+    /// Undoes all changes made within the transaction since it began.
+    /// Returns error if rollback fails.
+    pub async fn rollback_transaction(tx: PgTransaction<'_>) -> Result<(), AppError> {
+        tx.rollback()
+            .await
+            .map_err(|e| AppError::InternalServerError(e.into()))
+    }
+}

--- a/backend/tests/attendance_repository.rs
+++ b/backend/tests/attendance_repository.rs
@@ -1,0 +1,112 @@
+use chrono::{NaiveDate, Utc};
+use std::sync::OnceLock;
+use timekeeper_backend::{
+    models::{
+        attendance::{Attendance, AttendanceStatus},
+        break_record::BreakRecord,
+        user::UserRole,
+    },
+    repositories::{repository::Repository, AttendanceRepository, BreakRecordRepository},
+};
+use tokio::sync::Mutex;
+
+#[path = "support/mod.rs"]
+mod support;
+
+async fn integration_guard() -> tokio::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD.get_or_init(|| Mutex::new(())).lock().await
+}
+
+#[tokio::test]
+async fn attendance_repository_roundtrip() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    sqlx::query("TRUNCATE break_records, attendance")
+        .execute(&pool)
+        .await
+        .expect("truncate attendance tables");
+
+    let user = support::seed_user(&pool, UserRole::Employee, false).await;
+    let now = Utc::now();
+    let date = NaiveDate::from_ymd_opt(2024, 4, 1).unwrap();
+    let mut attendance = Attendance::new(user.id, date, now);
+
+    let repo = AttendanceRepository::new();
+    let saved = repo
+        .create(&pool, &attendance)
+        .await
+        .expect("create attendance");
+    assert_eq!(saved.user_id, user.id);
+    assert!(matches!(saved.status, AttendanceStatus::Present));
+
+    attendance.clock_in_time = Some(date.and_hms_opt(9, 0, 0).unwrap());
+    attendance.status = AttendanceStatus::Late;
+    attendance.updated_at = now;
+    let updated = repo
+        .update(&pool, &attendance)
+        .await
+        .expect("update attendance");
+    assert!(matches!(updated.status, AttendanceStatus::Late));
+    assert!(updated.clock_in_time.is_some());
+
+    let fetched = repo
+        .find_by_user_and_date(&pool, user.id, date)
+        .await
+        .expect("find by user date");
+    assert!(fetched.is_some());
+}
+
+#[tokio::test]
+async fn break_record_repository_roundtrip() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    sqlx::query("TRUNCATE break_records, attendance")
+        .execute(&pool)
+        .await
+        .expect("truncate attendance tables");
+
+    let user = support::seed_user(&pool, UserRole::Employee, false).await;
+    let now = Utc::now();
+    let date = NaiveDate::from_ymd_opt(2024, 3, 15).unwrap();
+    let attendance = Attendance::new(user.id, date, now);
+    let attendance_repo = AttendanceRepository::new();
+    let saved_attendance = attendance_repo
+        .create(&pool, &attendance)
+        .await
+        .expect("create attendance");
+
+    let start = date.and_hms_opt(12, 0, 0).unwrap();
+    let mut record = BreakRecord::new(saved_attendance.id, start, now);
+    let repo = BreakRecordRepository::new();
+    let saved = repo
+        .create(&pool, &record)
+        .await
+        .expect("create break record");
+    assert_eq!(saved.attendance_id, saved_attendance.id);
+    assert!(saved.duration_minutes.is_none());
+
+    let end = start + chrono::Duration::minutes(15);
+    record.break_end_time = Some(end);
+    record.duration_minutes = Some(15);
+    record.updated_at = now;
+    let updated = repo
+        .update(&pool, &record)
+        .await
+        .expect("update break record");
+    assert_eq!(updated.duration_minutes, Some(15));
+
+    let listed = repo
+        .find_by_attendance(&pool, saved_attendance.id)
+        .await
+        .expect("list break records");
+    assert_eq!(listed.len(), 1);
+}

--- a/backend/tests/holiday_repository.rs
+++ b/backend/tests/holiday_repository.rs
@@ -1,0 +1,57 @@
+use chrono::{NaiveDate, Utc};
+use std::sync::OnceLock;
+use timekeeper_backend::{
+    models::{holiday::Holiday, user::UserRole},
+    repositories::{repository::Repository, HolidayRepository},
+};
+use tokio::sync::Mutex;
+
+#[path = "support/mod.rs"]
+mod support;
+
+async fn integration_guard() -> tokio::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD.get_or_init(|| Mutex::new(())).lock().await
+}
+
+#[tokio::test]
+async fn holiday_repository_roundtrip() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    sqlx::query("TRUNCATE holidays")
+        .execute(&pool)
+        .await
+        .expect("truncate holidays");
+
+    let _user = support::seed_user(&pool, UserRole::Admin, false).await;
+    let date = NaiveDate::from_ymd_opt(2024, 12, 25).unwrap();
+    let holiday = Holiday::new(date, "Holiday".into(), Some("seasonal".into()));
+
+    let repo = HolidayRepository::new();
+    let saved = repo.create(&pool, &holiday).await.expect("create holiday");
+    assert_eq!(saved.holiday_date, date);
+
+    let by_date = repo.find_by_date(&pool, date).await.expect("find by date");
+    assert!(by_date.is_some());
+
+    let mut updated = saved;
+    updated.name = "Updated".into();
+    updated.description = None;
+    updated.updated_at = Utc::now();
+    let saved_update = repo.update(&pool, &updated).await.expect("update holiday");
+    assert_eq!(saved_update.name, "Updated");
+    assert!(saved_update.description.is_none());
+
+    repo.delete(&pool, saved_update.id)
+        .await
+        .expect("delete holiday");
+    let missing = repo
+        .find_by_date(&pool, date)
+        .await
+        .expect("find after delete");
+    assert!(missing.is_none());
+}

--- a/backend/tests/rate_limit_integration_tests.rs
+++ b/backend/tests/rate_limit_integration_tests.rs
@@ -1,15 +1,8 @@
-use axum::{
-    http::StatusCode,
-    routing::post,
-    Router,
-};
+use axum::{http::StatusCode, routing::post, Router};
 use std::{net::SocketAddr, time::Duration};
 use tokio::net::TcpListener;
 
-use timekeeper_backend::{
-    config::Config,
-    middleware::rate_limit::create_auth_rate_limiter,
-};
+use timekeeper_backend::{config::Config, middleware::rate_limit::create_auth_rate_limiter};
 
 fn test_config(rate_limit_ip_max_requests: u32, rate_limit_ip_window_seconds: u64) -> Config {
     Config {
@@ -46,7 +39,10 @@ async fn spawn_rate_limited_app(config: Config) -> (SocketAddr, tokio::task::Joi
         .route("/login", post(|| async { StatusCode::OK }))
         .route_layer(limiter);
 
-    let server = axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>());
+    let server = axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    );
     let handle = tokio::spawn(async move {
         server.await.expect("server should run");
     });

--- a/backend/tests/request_repositories.rs
+++ b/backend/tests/request_repositories.rs
@@ -1,0 +1,108 @@
+use chrono::{NaiveDate, Utc};
+use std::sync::OnceLock;
+use timekeeper_backend::{
+    models::{
+        leave_request::{LeaveRequest, LeaveType, RequestStatus},
+        overtime_request::OvertimeRequest,
+        user::UserRole,
+    },
+    repositories::{repository::Repository, LeaveRequestRepository, OvertimeRequestRepository},
+};
+use tokio::sync::Mutex;
+
+#[path = "support/mod.rs"]
+mod support;
+
+async fn integration_guard() -> tokio::sync::MutexGuard<'static, ()> {
+    static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    GUARD.get_or_init(|| Mutex::new(())).lock().await
+}
+
+#[tokio::test]
+async fn leave_request_repository_approve_roundtrip() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    sqlx::query("TRUNCATE leave_requests")
+        .execute(&pool)
+        .await
+        .expect("truncate leave_requests");
+
+    let user = support::seed_user(&pool, UserRole::Employee, false).await;
+    let admin = support::seed_user(&pool, UserRole::Admin, false).await;
+    let start = NaiveDate::from_ymd_opt(2024, 5, 1).unwrap();
+    let end = NaiveDate::from_ymd_opt(2024, 5, 2).unwrap();
+    let request = LeaveRequest::new(user.id, LeaveType::Annual, start, end, Some("trip".into()));
+
+    let repo = LeaveRequestRepository::new();
+    let saved = repo
+        .create(&pool, &request)
+        .await
+        .expect("create leave request");
+    assert_eq!(saved.user_id, user.id);
+    assert!(matches!(saved.status, RequestStatus::Pending));
+
+    let fetched = repo
+        .find_by_id_for_user(&pool, saved.id, user.id)
+        .await
+        .expect("fetch leave request");
+    assert!(fetched.is_some());
+
+    let now = Utc::now();
+    let updated = repo
+        .approve(&pool, saved.id, admin.id, "ok", now)
+        .await
+        .expect("approve leave request");
+    assert_eq!(updated, 1);
+
+    let approved = repo
+        .find_by_id(&pool, saved.id)
+        .await
+        .expect("fetch approved request");
+    assert!(matches!(approved.status, RequestStatus::Approved));
+    assert_eq!(approved.approved_by, Some(admin.id));
+}
+
+#[tokio::test]
+async fn overtime_request_repository_reject_roundtrip() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    sqlx::query("TRUNCATE overtime_requests")
+        .execute(&pool)
+        .await
+        .expect("truncate overtime_requests");
+
+    let user = support::seed_user(&pool, UserRole::Employee, false).await;
+    let admin = support::seed_user(&pool, UserRole::Admin, false).await;
+    let date = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+    let request = OvertimeRequest::new(user.id, date, 2.5, Some("release".into()));
+
+    let repo = OvertimeRequestRepository::new();
+    let saved = repo
+        .create(&pool, &request)
+        .await
+        .expect("create overtime request");
+    assert_eq!(saved.user_id, user.id);
+    assert!(matches!(saved.status, RequestStatus::Pending));
+
+    let now = Utc::now();
+    let updated = repo
+        .reject(&pool, saved.id, admin.id, "busy", now)
+        .await
+        .expect("reject overtime request");
+    assert_eq!(updated, 1);
+
+    let rejected = repo
+        .find_by_id(&pool, saved.id)
+        .await
+        .expect("fetch rejected request");
+    assert!(matches!(rejected.status, RequestStatus::Rejected));
+    assert_eq!(rejected.rejected_by, Some(admin.id));
+}


### PR DESCRIPTION
**目的**
- Fix login failures caused by non-UUID admin IDs while completing repository pattern coverage for issue #153.

**実装概要**
- default admin をUUIDへ移行する `backend/migrations/023_fix_default_admin_uuid.sql` を追加
- Repository実装の不整合修正とハンドラのRepo経由化
- Repo用統合テスト・DB不要テストを追加/更新

**検証手順・結果**
- `cargo fmt --all` (OK)
- `cargo clippy --all-targets -- -D warnings` (OK)
- `TEST_DATABASE_URL=postgres://timekeeper:timekeeper@127.0.0.1/timekeeper cargo test` (OK)
- `pwsh -File .\scripts\test_backend.ps1` (OK)

**残課題**
- なし
