### PR TITLE
feat(frontend): change audit log event type filter to dropdown

### DIFF
--- a/frontend/src/pages/admin_audit_logs/panel.rs
+++ b/frontend/src/pages/admin_audit_logs/panel.rs
@@ -1,4 +1,4 @@
-use super::view_model::{use_audit_log_view_model, AuditLogFilters};
+use super::view_model::{use_audit_log_view_model, AuditLogFilters, AUDIT_EVENT_TYPES};
 use crate::components::common::{Button, ButtonVariant};
 use crate::components::empty_state::EmptyState;
 use crate::components::layout::Layout;
@@ -69,10 +69,15 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
                             </div>
                             <div>
                                 <label class="block text-sm font-medium text-gray-700">"イベントタイプ"</label>
-                                <input type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border px-2 py-1"
+                                <select class="mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border px-2 py-1"
                                     prop:value=move || vm.filters.get().event_type
-                                    on:input=move |ev| on_filter_change(ev, "event_type")
-                                />
+                                    on:change=move |ev| on_filter_change(ev, "event_type")
+                                >
+                                    <option value="">"すべて"</option>
+                                    {AUDIT_EVENT_TYPES.iter().map(|(val, label)| view! {
+                                        <option value=*val>{*label}</option>
+                                    }).collect_view()}
+                                </select>
                             </div>
                             <div>
                                 <label class="block text-sm font-medium text-gray-700">"結果"</label>

--- a/frontend/src/pages/admin_audit_logs/view_model.rs
+++ b/frontend/src/pages/admin_audit_logs/view_model.rs
@@ -2,6 +2,24 @@ use crate::api::{ApiClient, ApiError, AuditLogListResponse};
 use leptos::*;
 use wasm_bindgen::JsCast;
 
+pub const AUDIT_EVENT_TYPES: &[(&str, &str)] = &[
+    ("auth_login", "ログイン"),
+    ("auth_logout", "ログアウト"),
+    ("attendance_clock_in", "出勤打刻"),
+    ("attendance_clock_out", "退勤打刻"),
+    ("attendance_break_start", "休憩開始"),
+    ("attendance_break_end", "休憩終了"),
+    ("request_leave_create", "休暇申請作成"),
+    ("request_overtime_create", "残業申請作成"),
+    ("request_update", "申請更新"),
+    ("request_cancel", "申請取消"),
+    ("admin_request_approve", "申請承認"),
+    ("admin_request_reject", "申請却下"),
+    ("admin_attendance_upsert", "勤怠修正(管理者)"),
+    ("admin_user_create", "ユーザー作成"),
+    ("admin_mfa_reset", "MFAリセット"),
+];
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct AuditLogFilters {
     pub from: String,


### PR DESCRIPTION
## Context
Closes #122.

## Summary
Improves UX in the Audit Log admin page by changing the event type filter from a plain text input to a dropdown menu.

## Changes
- **Updated**: `frontend/src/pages/admin_audit_logs/view_model.rs`
  - Defined `AUDIT_EVENT_TYPES` constant with a curated list of important event types and their display names.
- **Updated**: `frontend/src/pages/admin_audit_logs/panel.rs`
  - Replaced the event type `input` with a `<select>` element.
  - Included an "All" (すべて) option.

## Verification
- ✅ `cargo check` passed.
- Curated list covers common events (login, logout, clock in/out, request create/approve/reject/cancel, user creation, MFA reset).