### PR TITLE
feat(frontend): add mvvm for password reset pages

### DIFF
--- a/frontend/src/pages/forgot_password/mod.rs
+++ b/frontend/src/pages/forgot_password/mod.rs
@@ -1,6 +1,8 @@
 use leptos::*;
 
 mod panel;
+mod repository;
+mod view_model;
 
 pub use panel::ForgotPasswordPanel;
 

--- a/frontend/src/pages/forgot_password/panel.rs
+++ b/frontend/src/pages/forgot_password/panel.rs
@@ -1,36 +1,16 @@
-use crate::api::ApiClient;
+use super::view_model::use_forgot_password_view_model;
 use leptos::*;
 use leptos_router::*;
 
 #[component]
 pub fn ForgotPasswordPanel() -> impl IntoView {
-    let api = expect_context::<ApiClient>();
-    let email = create_rw_signal(String::new());
-    let error = create_rw_signal(Option::<String>::None);
-    let success = create_rw_signal(Option::<String>::None);
-
-    let submit_action = create_action(move |e: &String| {
-        let email = e.clone();
-        let api = api.clone();
-        async move { api.request_password_reset(email).await }
-    });
+    let vm = use_forgot_password_view_model();
+    let email = vm.email;
+    let error = vm.error;
+    let success = vm.success;
+    let submit_action = vm.submit_action;
 
     let pending = submit_action.pending();
-
-    create_effect(move |_| {
-        if let Some(result) = submit_action.value().get() {
-            match result {
-                Ok(resp) => {
-                    success.set(Some(resp.message));
-                    error.set(None);
-                }
-                Err(e) => {
-                    error.set(Some(e.to_string()));
-                    success.set(None);
-                }
-            }
-        }
-    });
 
     view! {
         <div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">

--- a/frontend/src/pages/forgot_password/repository.rs
+++ b/frontend/src/pages/forgot_password/repository.rs
@@ -1,0 +1,17 @@
+use crate::api::{ApiClient, ApiError, MessageResponse};
+use std::rc::Rc;
+
+#[derive(Clone)]
+pub struct ForgotPasswordRepository {
+    client: Rc<ApiClient>,
+}
+
+impl ForgotPasswordRepository {
+    pub fn new_with_client(client: Rc<ApiClient>) -> Self {
+        Self { client }
+    }
+
+    pub async fn request_reset(&self, email: String) -> Result<MessageResponse, ApiError> {
+        self.client.request_password_reset(email).await
+    }
+}

--- a/frontend/src/pages/forgot_password/view_model.rs
+++ b/frontend/src/pages/forgot_password/view_model.rs
@@ -1,0 +1,55 @@
+use super::repository::ForgotPasswordRepository;
+use crate::api::{ApiClient, ApiError, MessageResponse};
+use leptos::*;
+use std::rc::Rc;
+
+#[derive(Clone)]
+pub struct ForgotPasswordViewModel {
+    pub email: RwSignal<String>,
+    pub error: RwSignal<Option<String>>,
+    pub success: RwSignal<Option<String>>,
+    pub submit_action: Action<String, Result<MessageResponse, ApiError>>,
+}
+
+pub fn use_forgot_password_view_model() -> ForgotPasswordViewModel {
+    let api = use_context::<ApiClient>().unwrap_or_else(ApiClient::new);
+    let repository = ForgotPasswordRepository::new_with_client(Rc::new(api));
+
+    let email = create_rw_signal(String::new());
+    let error = create_rw_signal(None);
+    let success = create_rw_signal(None);
+
+    let repo_for_submit = repository.clone();
+    let submit_action = create_action(move |value: &String| {
+        let repo = repo_for_submit.clone();
+        let email = value.trim().to_string();
+        async move {
+            if email.is_empty() {
+                return Err(ApiError::validation("Email is required"));
+            }
+            repo.request_reset(email).await
+        }
+    });
+
+    create_effect(move |_| {
+        if let Some(result) = submit_action.value().get() {
+            match result {
+                Ok(resp) => {
+                    success.set(Some(resp.message));
+                    error.set(None);
+                }
+                Err(err) => {
+                    error.set(Some(err.to_string()));
+                    success.set(None);
+                }
+            }
+        }
+    });
+
+    ForgotPasswordViewModel {
+        email,
+        error,
+        success,
+        submit_action,
+    }
+}

--- a/frontend/src/pages/reset_password/mod.rs
+++ b/frontend/src/pages/reset_password/mod.rs
@@ -1,6 +1,8 @@
 use leptos::*;
 
 mod panel;
+mod repository;
+mod view_model;
 
 pub use panel::ResetPasswordPanel;
 

--- a/frontend/src/pages/reset_password/panel.rs
+++ b/frontend/src/pages/reset_password/panel.rs
@@ -1,45 +1,16 @@
-use crate::api::ApiClient;
+use super::view_model::use_reset_password_view_model;
 use leptos::*;
 use leptos_router::*;
 
 #[component]
 pub fn ResetPasswordPanel() -> impl IntoView {
-    let api = expect_context::<ApiClient>();
-    let query = use_query_map();
-    let token = move || query.get().get("token").cloned().unwrap_or_default();
-
-    let password = create_rw_signal(String::new());
-    let error = create_rw_signal(Option::<String>::None);
-    let success = create_rw_signal(Option::<String>::None);
-
-    let submit_action = create_action(move |p: &String| {
-        let password = p.clone();
-        let token_val = token();
-        let api = api.clone();
-        async move {
-            if token_val.is_empty() {
-                return Err(crate::api::ApiError::validation("Invalid token"));
-            }
-            api.reset_password(token_val, password).await
-        }
-    });
+    let vm = use_reset_password_view_model();
+    let password = vm.password;
+    let error = vm.error;
+    let success = vm.success;
+    let submit_action = vm.submit_action;
 
     let pending = submit_action.pending();
-
-    create_effect(move |_| {
-        if let Some(result) = submit_action.value().get() {
-            match result {
-                Ok(resp) => {
-                    success.set(Some(resp.message));
-                    error.set(None);
-                }
-                Err(e) => {
-                    error.set(Some(e.to_string()));
-                    success.set(None);
-                }
-            }
-        }
-    });
 
     view! {
         <div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">

--- a/frontend/src/pages/reset_password/repository.rs
+++ b/frontend/src/pages/reset_password/repository.rs
@@ -1,0 +1,21 @@
+use crate::api::{ApiClient, ApiError, MessageResponse};
+use std::rc::Rc;
+
+#[derive(Clone)]
+pub struct ResetPasswordRepository {
+    client: Rc<ApiClient>,
+}
+
+impl ResetPasswordRepository {
+    pub fn new_with_client(client: Rc<ApiClient>) -> Self {
+        Self { client }
+    }
+
+    pub async fn reset_password(
+        &self,
+        token: String,
+        new_password: String,
+    ) -> Result<MessageResponse, ApiError> {
+        self.client.reset_password(token, new_password).await
+    }
+}

--- a/frontend/src/pages/reset_password/view_model.rs
+++ b/frontend/src/pages/reset_password/view_model.rs
@@ -1,0 +1,63 @@
+use super::repository::ResetPasswordRepository;
+use crate::api::{ApiClient, ApiError, MessageResponse};
+use leptos::*;
+use leptos_router::use_query_map;
+use std::rc::Rc;
+
+#[derive(Clone)]
+pub struct ResetPasswordViewModel {
+    pub password: RwSignal<String>,
+    pub error: RwSignal<Option<String>>,
+    pub success: RwSignal<Option<String>>,
+    pub submit_action: Action<String, Result<MessageResponse, ApiError>>,
+}
+
+pub fn use_reset_password_view_model() -> ResetPasswordViewModel {
+    let api = use_context::<ApiClient>().unwrap_or_else(ApiClient::new);
+    let repository = ResetPasswordRepository::new_with_client(Rc::new(api));
+    let query = use_query_map();
+    let token = Signal::derive(move || query.get().get("token").cloned().unwrap_or_default());
+
+    let password = create_rw_signal(String::new());
+    let error = create_rw_signal(None);
+    let success = create_rw_signal(None);
+
+    let repo_for_submit = repository.clone();
+    let token_for_submit = token.clone();
+    let submit_action = create_action(move |value: &String| {
+        let repo = repo_for_submit.clone();
+        let token = token_for_submit.get();
+        let new_password = value.to_string();
+        async move {
+            if token.trim().is_empty() {
+                return Err(ApiError::validation("Invalid token"));
+            }
+            if new_password.trim().is_empty() {
+                return Err(ApiError::validation("Password is required"));
+            }
+            repo.reset_password(token, new_password).await
+        }
+    });
+
+    create_effect(move |_| {
+        if let Some(result) = submit_action.value().get() {
+            match result {
+                Ok(resp) => {
+                    success.set(Some(resp.message));
+                    error.set(None);
+                }
+                Err(err) => {
+                    error.set(Some(err.to_string()));
+                    success.set(None);
+                }
+            }
+        }
+    });
+
+    ResetPasswordViewModel {
+        password,
+        error,
+        success,
+        submit_action,
+    }
+}


### PR DESCRIPTION
## Summary
- add MVVM repositories and view models for forgot/reset password pages
- wire panels to use view models instead of direct ApiClient calls
- keep existing login link and page layout intact

## Testing
- `/home/marra/.cargo/bin/wasm-pack test --headless --firefox`