### PR TITLE
test: cover password reset flow and validation

### DIFF
--- a/backend/src/utils/email.rs
+++ b/backend/src/utils/email.rs
@@ -40,6 +40,9 @@ impl EmailService {
     }
 
     pub fn send_password_reset_email(&self, to_email: &str, reset_token: &str) -> Result<()> {
+        if env::var("SMTP_SKIP_SEND").unwrap_or_default() == "true" {
+            return Ok(());
+        }
         let reset_url = format!(
             "{}/reset-password?token={}",
             env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:8000".to_string()),
@@ -76,6 +79,9 @@ Timekeeper 勤怠管理システム
     }
 
     pub fn send_password_changed_notification(&self, to_email: &str, username: &str) -> Result<()> {
+        if env::var("SMTP_SKIP_SEND").unwrap_or_default() == "true" {
+            return Ok(());
+        }
         let body = format!(
             r#"
 {}さんのパスワードが変更されました。


### PR DESCRIPTION
## Summary
- add integration tests for password reset request/reset endpoints and token reuse
- add WASM-level validation tests for forgot/reset password view models
- allow skipping SMTP sends during tests via `SMTP_SKIP_SEND`

## Testing
- `cd backend && DOCKER_HOST=unix:///run/user/1000/podman/podman.sock cargo test --test password_reset_api`
- `cd frontend && /home/marra/.cargo/bin/wasm-pack test --headless --firefox`