### PR TITLE
fix: secure defaults for cookie and jwt (#198)

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -130,9 +130,9 @@ impl Config {
             .unwrap_or(true);
 
         let cookie_secure = env::var("COOKIE_SECURE")
-            .unwrap_or_else(|_| "false".to_string())
+            .unwrap_or_else(|_| "true".to_string())
             .parse()
-            .unwrap_or(false);
+            .unwrap_or(true);
 
         let cookie_same_site =
             parse_same_site(env::var("COOKIE_SAMESITE").unwrap_or_else(|_| "Lax".to_string()))?;

--- a/backend/src/utils/jwt.rs
+++ b/backend/src/utils/jwt.rs
@@ -1,5 +1,5 @@
 use chrono::{Duration, Utc};
-use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -47,7 +47,7 @@ pub fn create_access_token(
 ) -> anyhow::Result<(String, Claims)> {
     let claims = Claims::new(user_id, username, role, expiration_hours);
     let token = encode(
-        &Header::default(),
+        &Header::new(Algorithm::HS256),
         &claims,
         &EncodingKey::from_secret(secret.as_ref()),
     )?;

--- a/env.example
+++ b/env.example
@@ -12,6 +12,7 @@ AWS_REGION=ap-northeast-1
 AWS_KMS_KEY_ID=alias/timekeeper-dev
 AWS_AUDIT_LOG_BUCKET=timekeeper-audit-logs
 AWS_CLOUDTRAIL_ENABLED=true
+# COOKIE_SECURE defaults to true if not set. For local dev (HTTP), set to false.
 COOKIE_SECURE=false
 COOKIE_SAMESITE=Lax
 CORS_ALLOW_ORIGINS=http://localhost:8000,http://localhost:8080,http://127.0.0.1:8080


### PR DESCRIPTION
## Summary
Enhances security defaults as identified in #198.

## Changes
- **Secure Cookies**: `COOKIE_SECURE` now defaults to `true` in `backend/src/config.rs`. This ensures cookies are Secure-flagged by default.
  - **Breaking Change**: Local development environments using HTTP **MUST** now explicitly set `COOKIE_SECURE=false` in `.env`.
- **Explicit JWT Algorithm**: Explicitly specifies `Algorithm::HS256` when creating access tokens in `backend/src/utils/jwt.rs`, mitigating potential algorithm confusion attacks.
- **Documentation**: Updated `env.example` to clarify the new default behavior for `COOKIE_SECURE`.

## Verification
- Verified `Config::load` defaults `cookie_secure` to `true` when unset.
- Verified `Config::load` respects explicit `false` (via test case).
- Verified JWT generation/verification still works via `cargo test utils::jwt`.

Fixes #198