### PR TITLE
feat(frontend): add dark mode support to table components

### DIFF
--- a/frontend/src/pages/admin/components/holidays.rs
+++ b/frontend/src/pages/admin/components/holidays.rs
@@ -430,8 +430,8 @@ pub fn HolidayManagementSection(
     };
 
     view! {
-        <div class="bg-white shadow rounded-lg p-6 space-y-4">
-            <h3 class="text-lg font-medium text-gray-900">{"祝日管理"}</h3>
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-4">
+            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{"祝日管理"}</h3>
             <form class="grid gap-3 lg:grid-cols-3" on:submit=on_create_holiday>
                 <DatePicker
                     label=Some("日付")
@@ -591,16 +591,16 @@ pub fn HolidayManagementSection(
                 </div>
             </div>
             <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-gray-200 text-sm">
-                    <thead class="bg-gray-50">
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                    <thead class="bg-gray-50 dark:bg-gray-700">
                         <tr>
-                            <th class="px-4 py-2 text-left text-gray-600">{"日付"}</th>
-                            <th class="px-4 py-2 text-left text-gray-600">{"名称"}</th>
-                            <th class="px-4 py-2 text-left text-gray-600">{"備考"}</th>
-                            <th class="px-4 py-2 text-right text-gray-600">{"操作"}</th>
+                            <th class="px-4 py-2 text-left text-gray-600 dark:text-gray-200">{"日付"}</th>
+                            <th class="px-4 py-2 text-left text-gray-600 dark:text-gray-200">{"名称"}</th>
+                            <th class="px-4 py-2 text-left text-gray-600 dark:text-gray-200">{"備考"}</th>
+                            <th class="px-4 py-2 text-right text-gray-600 dark:text-gray-200">{"操作"}</th>
                         </tr>
                     </thead>
-                    <tbody class="divide-y divide-gray-100">
+                    <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
                         <For
                             each=move || holidays_data.get()
                             key=|item| item.id.clone()
@@ -611,9 +611,9 @@ pub fn HolidayManagementSection(
                                 };
                                 view! {
                                     <tr>
-                                        <td class="px-4 py-2">{item.holiday_date.format("%Y-%m-%d").to_string()}</td>
-                                        <td class="px-4 py-2">{item.name.clone()}</td>
-                                        <td class="px-4 py-2 text-gray-600">{item.description.clone().unwrap_or_default()}</td>
+                                        <td class="px-4 py-2 dark:text-gray-100">{item.holiday_date.format("%Y-%m-%d").to_string()}</td>
+                                        <td class="px-4 py-2 dark:text-gray-100">{item.name.clone()}</td>
+                                        <td class="px-4 py-2 text-gray-600 dark:text-gray-400">{item.description.clone().unwrap_or_default()}</td>
                                         <td class="px-4 py-2 text-right">
                                             <button
                                                 class="px-3 py-1 rounded border text-sm disabled:opacity-50"
@@ -631,9 +631,9 @@ pub fn HolidayManagementSection(
                 </table>
             </div>
             <Show when=move || !google_holidays.get().is_empty()>
-                <div class="border rounded-lg p-4 space-y-2">
-                    <h4 class="text-sm font-medium text-gray-900">{"Google 祝日候補"}</h4>
-                    <ul class="space-y-1 text-sm text-gray-700">
+                <div class="border rounded-lg p-4 space-y-2 dark:border-gray-700">
+                    <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100">{"Google 祝日候補"}</h4>
+                    <ul class="space-y-1 text-sm text-gray-700 dark:text-gray-300">
                         <For
                             each=move || google_holidays.get()
                             key=|item| (item.name.clone(), item.holiday_date)

--- a/frontend/src/pages/admin/components/requests.rs
+++ b/frontend/src/pages/admin/components/requests.rs
@@ -86,8 +86,8 @@ pub fn AdminRequestsSection(
     };
 
     view! {
-        <div class="bg-white shadow rounded-lg p-6 space-y-4">
-            <h3 class="text-lg font-medium text-gray-900">{"申請一覧"}</h3>
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-4">
+            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{"申請一覧"}</h3>
             <div class="flex flex-col gap-3 lg:flex-row lg:flex-wrap lg:items-end">
                 <select
                     class="w-full lg:w-auto border-gray-300 rounded-md px-2 py-1"
@@ -130,17 +130,17 @@ pub fn AdminRequestsSection(
                 </div>
             </Show>
             <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-gray-200">
-                    <thead class="bg-gray-50">
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                    <thead class="bg-gray-50 dark:bg-gray-700">
                         <tr>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"種別"}</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"対象"}</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"ユーザー"}</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"ステータス"}</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"操作"}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"種別"}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"対象"}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"ユーザー"}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"ステータス"}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"操作"}</th>
                         </tr>
                     </thead>
-                    <tbody class="bg-white divide-y divide-gray-200">
+                    <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                         <Show when=move || requests_data.get().is_object()>
                             {let data = requests_data.get();
                                 let leaves = data.get("leave_requests").cloned().unwrap_or(json!([]));
@@ -159,7 +159,7 @@ pub fn AdminRequestsSection(
                                 if rows.is_empty() {
                                     view! {
                                         <tr>
-                                            <td colspan="5" class="p-4 bg-gray-50">
+                                            <td colspan="5" class="p-4 bg-gray-50 dark:bg-gray-800">
                                                 <EmptyState
                                                     title="申請がありません"
                                                     description="表示できる申請データが見つかりませんでした。"
@@ -190,11 +190,11 @@ pub fn AdminRequestsSection(
                                         let kind_label = if kind == "leave" { "休暇" } else { "残業" };
                                         view! {
                                             <tr>
-                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{kind_label}</td>
-                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{target.clone()}</td>
-                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{user.clone()}</td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">{kind_label}</td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">{target.clone()}</td>
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">{user.clone()}</td>
                                                 <td class="px-6 py-4 whitespace-nowrap">
-                                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-100">
                                                         {statusv.clone()}
                                                     </span>
                                                 </td>

--- a/frontend/src/pages/admin/components/subject_requests.rs
+++ b/frontend/src/pages/admin/components/subject_requests.rs
@@ -114,8 +114,8 @@ pub fn AdminSubjectRequestsSection(
     };
 
     view! {
-        <div class="bg-white shadow rounded-lg p-6 space-y-4">
-            <h3 class="text-lg font-medium text-gray-900">{"本人対応申請"}</h3>
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-4">
+            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{"本人対応申請"}</h3>
             <div class="flex flex-col gap-3 lg:flex-row lg:flex-wrap lg:items-end">
                 <select
                     class="w-full lg:w-auto border-gray-300 rounded-md px-2 py-1"
@@ -168,17 +168,17 @@ pub fn AdminSubjectRequestsSection(
                 </div>
             </Show>
             <div class="overflow-x-auto">
-                <table class="min-w-full divide-y divide-gray-200">
-                    <thead class="bg-gray-50">
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                    <thead class="bg-gray-50 dark:bg-gray-700">
                         <tr>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"種別"}</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"ユーザー"}</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"ステータス"}</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"申請日"}</th>
-                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"操作"}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"種別"}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"ユーザー"}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"ステータス"}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"申請日"}</th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"操作"}</th>
                         </tr>
                     </thead>
-                    <tbody class="bg-white divide-y divide-gray-200">
+                    <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                         <Show when=move || data.get().is_some()>
                             {move || {
                                 data.get()
@@ -198,14 +198,14 @@ pub fn AdminSubjectRequestsSection(
                                                 };
                                                 view! {
                                                     <tr>
-                                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{type_label}</td>
-                                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{item.user_id}</td>
+                                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">{type_label}</td>
+                                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">{item.user_id}</td>
                                                         <td class="px-6 py-4 whitespace-nowrap">
-                                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                                                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-100">
                                                                 {status_label}
                                                             </span>
                                                         </td>
-                                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{created_label}</td>
+                                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">{created_label}</td>
                                                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm">
                                                             <button class="text-blue-600" on:click=open>{"詳細"}</button>
                                                             <span class="sr-only">{id}</span>

--- a/frontend/src/pages/admin/components/weekly_holidays.rs
+++ b/frontend/src/pages/admin/components/weekly_holidays.rs
@@ -92,11 +92,11 @@ pub fn WeeklyHolidaySection(
     let on_refresh = move |_| reload.update(|value| *value = value.wrapping_add(1));
 
     view! {
-        <div class="bg-white shadow rounded-lg p-6 space-y-4">
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-4">
             <div class="flex flex-col gap-1 lg:flex-row lg:items-center lg:justify-between">
                 <div>
-                    <h2 class="text-lg font-semibold text-gray-900">{"週次休日"}</h2>
-                    <p class="text-sm text-gray-600">
+                    <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">{"週次休日"}</h2>
+                    <p class="text-sm text-gray-600 dark:text-gray-400">
                         {"週単位の休日を登録します。システム管理者は即日開始も設定できます。"}
                     </p>
                 </div>
@@ -176,24 +176,24 @@ pub fn WeeklyHolidaySection(
             </Show>
             <Show when=move || !holidays_loading.get() && !holidays_data.get().is_empty()>
                 <div class="overflow-x-auto">
-                    <table class="min-w-full divide-y divide-gray-200 text-sm">
-                        <thead class="bg-gray-50">
+                    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
+                        <thead class="bg-gray-50 dark:bg-gray-700">
                             <tr>
-                                <th class="px-4 py-2 text-left text-gray-600">{"曜日"}</th>
-                                <th class="px-4 py-2 text-left text-gray-600">{"指定期間"}</th>
-                                <th class="px-4 py-2 text-left text-gray-600">{"適用期間"}</th>
-                                <th class="px-4 py-2 text-right text-gray-600">{"操作"}</th>
+                                <th class="px-4 py-2 text-left text-gray-600 dark:text-gray-200">{"曜日"}</th>
+                                <th class="px-4 py-2 text-left text-gray-600 dark:text-gray-200">{"指定期間"}</th>
+                                <th class="px-4 py-2 text-left text-gray-600 dark:text-gray-200">{"適用期間"}</th>
+                                <th class="px-4 py-2 text-right text-gray-600 dark:text-gray-200">{"操作"}</th>
                             </tr>
                         </thead>
-                        <tbody class="divide-y divide-gray-100">
+                        <tbody class="divide-y divide-gray-100 dark:divide-gray-700">
                             <For
                                 each=move || holidays_data.get()
                                 key=|item| item.id.clone()
                                 children=move |item| {
                                     view! {
                                         <tr>
-                                            <td class="px-4 py-2">{crate::pages::admin::utils::weekday_label(item.weekday)}</td>
-                                            <td class="px-4 py-2 text-gray-600">
+                                            <td class="px-4 py-2 dark:text-gray-100">{crate::pages::admin::utils::weekday_label(item.weekday)}</td>
+                                            <td class="px-4 py-2 text-gray-600 dark:text-gray-400">
                                                 {format!(
                                                     "{} 〜 {}",
                                                     item.starts_on.format("%Y-%m-%d"),
@@ -203,7 +203,7 @@ pub fn WeeklyHolidaySection(
                                                         .unwrap_or_else(|| "未設定".into())
                                                 )}
                                             </td>
-                                            <td class="px-4 py-2 text-gray-600">
+                                            <td class="px-4 py-2 text-gray-600 dark:text-gray-400">
                                                 {format!(
                                                     "{} 〜 {}",
                                                     item.enforced_from.format("%Y-%m-%d"),

--- a/frontend/src/pages/admin_audit_logs/panel.rs
+++ b/frontend/src/pages/admin_audit_logs/panel.rs
@@ -45,31 +45,31 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
                         <p class="mt-1 text-sm text-gray-600">"システム操作の履歴を確認・エクスポートします。"</p>
                     </div>
 
-                    <div class="bg-white p-4 rounded-lg shadow space-y-4">
+                    <div class="bg-white dark:bg-gray-800 p-4 rounded-lg shadow space-y-4">
                         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
                             <div>
-                                <label class="block text-sm font-medium text-gray-700">"日時 (From)"</label>
+                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">"日時 (From)"</label>
                                 <input type="datetime-local" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border px-2 py-1"
                                     prop:value=move || vm.filters.get().from
                                     on:input=move |ev| on_filter_change(ev, "from")
                                 />
                             </div>
                             <div>
-                                <label class="block text-sm font-medium text-gray-700">"日時 (To)"</label>
+                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">"日時 (To)"</label>
                                 <input type="datetime-local" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border px-2 py-1"
                                     prop:value=move || vm.filters.get().to
                                     on:input=move |ev| on_filter_change(ev, "to")
                                 />
                             </div>
                             <div>
-                                <label class="block text-sm font-medium text-gray-700">"ユーザーID"</label>
+                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">"ユーザーID"</label>
                                 <input type="text" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border px-2 py-1"
                                     prop:value=move || vm.filters.get().actor_id
                                     on:input=move |ev| on_filter_change(ev, "actor_id")
                                 />
                             </div>
                             <div>
-                                <label class="block text-sm font-medium text-gray-700">"イベントタイプ"</label>
+                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">"イベントタイプ"</label>
                                 <select class="mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border px-2 py-1"
                                     prop:value=move || vm.filters.get().event_type
                                     on:change=move |ev| on_filter_change(ev, "event_type")
@@ -81,7 +81,7 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
                                 </select>
                             </div>
                             <div>
-                                <label class="block text-sm font-medium text-gray-700">"結果"</label>
+                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">"結果"</label>
                                 <select class="mt-1 block w-full rounded-md border-gray-300 shadow-sm sm:text-sm border px-2 py-1"
                                     prop:value=move || vm.filters.get().result
                                     on:change=move |ev| on_filter_change(ev, "result")
@@ -114,19 +114,19 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
                         </div>
                     </div>
 
-                    <div class="bg-white shadow overflow-hidden sm:rounded-lg overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
+                    <div class="bg-white dark:bg-gray-800 shadow overflow-hidden sm:rounded-lg overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                            <thead class="bg-gray-50 dark:bg-gray-700">
                                 <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">"日時"</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">"ユーザー"</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">"イベント"</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">"対象"</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">"結果"</th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">"詳細"</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">"日時"</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">"ユーザー"</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">"イベント"</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">"対象"</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">"結果"</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">"詳細"</th>
                                 </tr>
                             </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
+                            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                                 <Suspense fallback=move || view! { <tr><td colspan="6" class="p-4 text-center">"読み込み中..."</td></tr> }>
                                     {move || vm.logs_resource.get().map(|res| match res {
                                         Ok(response) => {
@@ -145,17 +145,17 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
                                                 response.items.into_iter().map(|log| {
                                                     view! {
                                                         <tr>
-                                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                                                                 {log.occurred_at.format("%Y-%m-%d %H:%M:%S").to_string()}
                                                             </td>
-                                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                                                 {log.actor_id.unwrap_or_else(|| "-".to_string())}
-                                                                <span class="text-xs text-gray-500 block">{log.actor_type}</span>
+                                                                <span class="text-xs text-gray-500 dark:text-gray-400 block">{log.actor_type}</span>
                                                             </td>
-                                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                                                 {log.event_type}
                                                             </td>
-                                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                                                                 {format!("{} {}", log.target_type.unwrap_or_default(), log.target_id.unwrap_or_default())}
                                                             </td>
                                                              <td class="px-6 py-4 whitespace-nowrap text-sm">
@@ -164,7 +164,7 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
                                                                 </span>
                                                                 {log.error_code.clone().map(|c| view! { <span class="block text-xs text-red-500">{c}</span> })}
                                                             </td>
-                                                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                                                                  {
                                                                     let m = log.metadata.clone();
                                                                     m.map(|val| {
@@ -227,19 +227,19 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
 
                     <Show when=move || selected_metadata.get().is_some()>
                         <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-                            <div class="bg-white rounded-lg shadow-xl w-full max-w-2xl flex flex-col max-h-[90vh]">
-                                <div class="p-4 border-b flex justify-between items-center">
-                                    <h3 class="text-lg font-bold">"メタデータ詳細"</h3>
-                                    <button class="text-gray-500 hover:text-gray-700" on:click=move |_| selected_metadata.set(None)>
+                            <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl flex flex-col max-h-[90vh]">
+                                <div class="p-4 border-b dark:border-gray-700 flex justify-between items-center">
+                                    <h3 class="text-lg font-bold dark:text-gray-100">"メタデータ詳細"</h3>
+                                    <button class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200" on:click=move |_| selected_metadata.set(None)>
                                         <i class="fas fa-times"></i>
                                     </button>
                                 </div>
-                                <div class="p-4 overflow-auto flex-1 bg-gray-50 font-mono text-xs sm:text-sm">
+                                <div class="p-4 overflow-auto flex-1 bg-gray-50 dark:bg-gray-900 font-mono text-xs sm:text-sm text-gray-900 dark:text-gray-100">
                                     <pre>{move || selected_metadata.get().map(|m| serde_json::to_string_pretty(&m).unwrap_or_default()).unwrap_or_default()}</pre>
                                 </div>
-                                <div class="p-4 border-t flex justify-end">
+                                <div class="p-4 border-t dark:border-gray-700 flex justify-end">
                                     <button
-                                        class="px-4 py-2 bg-gray-200 hover:bg-gray-300 rounded text-sm font-medium"
+                                        class="px-4 py-2 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded text-sm font-medium dark:text-gray-100"
                                         on:click=move |_| selected_metadata.set(None)
                                     >
                                         "閉じる"

--- a/frontend/src/pages/admin_users/components/list.rs
+++ b/frontend/src/pages/admin_users/components/list.rs
@@ -19,11 +19,11 @@ pub fn UserList(
     let fetch_error = Signal::derive(move || users_resource.get().and_then(|result| result.err()));
 
     view! {
-        <div class="bg-white shadow rounded-lg p-6 space-y-4">
+        <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-4">
             <div class="flex flex-col gap-1 lg:flex-row lg:items-center lg:justify-between">
                 <div>
-                    <h3 class="text-lg font-medium text-gray-900">{"ユーザー一覧"}</h3>
-                    <p class="text-sm text-gray-600">{"行をクリックすると詳細ドロワーが開きます。"}</p>
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{"ユーザー一覧"}</h3>
+                    <p class="text-sm text-gray-600 dark:text-gray-400">{"行をクリックすると詳細ドロワーが開きます。"}</p>
                 </div>
             </div>
 
@@ -52,38 +52,38 @@ pub fn UserList(
                                 };
                                 view! {
                                     <button
-                                        class="w-full text-left border border-gray-200 rounded-lg p-4 shadow-sm hover:bg-gray-50"
+                                        class="w-full text-left border border-gray-200 dark:border-gray-700 rounded-lg p-4 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700"
                                         on:click=click_handler
                                         type="button"
                                     >
                                         <div class="flex items-start justify-between gap-3">
                                             <div>
-                                                <p class="text-sm text-gray-500">{"ユーザー名"}</p>
-                                                <p class="text-base font-semibold text-gray-900">
+                                                <p class="text-sm text-gray-500 dark:text-gray-400">{"ユーザー名"}</p>
+                                                <p class="text-base font-semibold text-gray-900 dark:text-gray-100">
                                                     {row_user.username}
                                                 </p>
                                             </div>
                                             <div class="text-right">
-                                                <p class="text-sm text-gray-500">{"権限"}</p>
-                                                <p class="text-sm font-medium text-gray-900">
+                                                <p class="text-sm text-gray-500 dark:text-gray-400">{"権限"}</p>
+                                                <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
                                                     {row_user.role}
                                                 </p>
                                             </div>
                                         </div>
                                         <div class="mt-3 grid grid-cols-2 gap-3 text-sm">
                                             <div>
-                                                <p class="text-gray-500">{"氏名"}</p>
-                                                <p class="text-gray-900">{row_user.full_name}</p>
+                                                <p class="text-gray-500 dark:text-gray-400">{"氏名"}</p>
+                                                <p class="text-gray-900 dark:text-gray-100">{row_user.full_name}</p>
                                             </div>
                                             <div>
-                                                <p class="text-gray-500">{"システム管理者"}</p>
-                                                <p class="text-gray-900">
+                                                <p class="text-gray-500 dark:text-gray-400">{"システム管理者"}</p>
+                                                <p class="text-gray-900 dark:text-gray-100">
                                                     {if row_user.is_system_admin { "Yes" } else { "No" }}
                                                 </p>
                                             </div>
                                             <div>
-                                                <p class="text-gray-500">{"MFA"}</p>
-                                                <p class="text-gray-900">
+                                                <p class="text-gray-500 dark:text-gray-400">{"MFA"}</p>
+                                                <p class="text-gray-900 dark:text-gray-100">
                                                     {if row_user.mfa_enabled { "Enabled" } else { "Disabled" }}
                                                 </p>
                                             </div>
@@ -94,27 +94,27 @@ pub fn UserList(
                         />
                     </div>
                     <div class="hidden lg:block overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead>
+                        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                            <thead class="bg-gray-50 dark:bg-gray-700">
                                 <tr>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">
                                         {"ユーザー名"}
                                     </th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">
                                         {"氏名"}
                                     </th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">
                                         {"権限"}
                                     </th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">
                                         {"システム管理者"}
                                     </th>
-                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">
                                         {"MFA"}
                                     </th>
                                 </tr>
                             </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
+                            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                                 <For
                                     each=move || users.get()
                                     key=|user| user.id.clone()
@@ -126,22 +126,22 @@ pub fn UserList(
                                         };
                                         view! {
                                             <tr
-                                                class="hover:bg-gray-50 cursor-pointer"
+                                                class="hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer"
                                                 on:click=click_handler
                                             >
-                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                                     {row_user.username}
                                                 </td>
-                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                                     {row_user.full_name}
                                                 </td>
-                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                                     {row_user.role}
                                                 </td>
-                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                                     {if row_user.is_system_admin { "Yes" } else { "No" }}
                                                 </td>
-                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                                     {if row_user.mfa_enabled { "Enabled" } else { "Disabled" }}
                                                 </td>
                                             </tr>

--- a/frontend/src/pages/requests/components/list.rs
+++ b/frontend/src/pages/requests/components/list.rs
@@ -16,9 +16,9 @@ pub fn RequestsList(
     message: RwSignal<crate::pages::requests::utils::MessageState>,
 ) -> impl IntoView {
     view! {
-        <div class="bg-white shadow-premium rounded-3xl overflow-hidden border border-gray-100/50">
-            <div class="px-8 py-6 border-b border-gray-100">
-                <h3 class="text-xl font-display font-bold text-slate-900">{"申請一覧"}</h3>
+        <div class="bg-white dark:bg-gray-800 shadow-premium rounded-3xl overflow-hidden border border-gray-100/50 dark:border-gray-700/50">
+            <div class="px-8 py-6 border-b border-gray-100 dark:border-gray-700">
+                <h3 class="text-xl font-display font-bold text-slate-900 dark:text-slate-100">{"申請一覧"}</h3>
                 <Show when=move || message.get().error.is_some()>
                     <div class="mt-4">
                         <InlineErrorMessage error={Signal::derive(move || message.get().error).into()} />
@@ -55,18 +55,18 @@ pub fn RequestsList(
 
             <Show when=move || !summaries.get().is_empty()>
                 <div class="overflow-x-auto">
-                    <table class="min-w-full divide-y divide-gray-100">
+                    <table class="min-w-full divide-y divide-gray-100 dark:divide-gray-700">
                         <thead>
-                            <tr class="bg-slate-50/50">
-                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 uppercase tracking-widest">{"種類"}</th>
-                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 uppercase tracking-widest">{"期間 / 日付"}</th>
-                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 uppercase tracking-widest">{"補足"}</th>
-                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 uppercase tracking-widest">{"ステータス"}</th>
-                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 uppercase tracking-widest">{"提出日"}</th>
-                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 uppercase tracking-widest">{"操作"}</th>
+                            <tr class="bg-slate-50/50 dark:bg-gray-700/50">
+                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 dark:text-slate-200 uppercase tracking-widest">{"種類"}</th>
+                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 dark:text-slate-200 uppercase tracking-widest">{"期間 / 日付"}</th>
+                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 dark:text-slate-200 uppercase tracking-widest">{"補足"}</th>
+                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 dark:text-slate-200 uppercase tracking-widest">{"ステータス"}</th>
+                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 dark:text-slate-200 uppercase tracking-widest">{"提出日"}</th>
+                                <th class="px-8 py-4 text-left text-xs font-bold text-slate-400 dark:text-slate-200 uppercase tracking-widest">{"操作"}</th>
                             </tr>
                         </thead>
-                        <tbody class="divide-y divide-gray-50 bg-white">
+                        <tbody class="divide-y divide-gray-50 bg-white dark:bg-gray-800 dark:divide-gray-700">
                             <For
                                 each=move || summaries.get()
                                 key=|summary| summary.id.clone()
@@ -91,7 +91,7 @@ pub fn RequestsList(
                                     };
 
                                     view! {
-                                        <tr class="hover:bg-slate-50/80 transition-colors group cursor-pointer" on:click=move |_| on_select.call(summary.get_value())>
+                                        <tr class="hover:bg-slate-50/80 dark:hover:bg-gray-700/80 transition-colors group cursor-pointer" on:click=move |_| on_select.call(summary.get_value())>
                                             <td class="px-8 py-5 whitespace-nowrap">
                                                 <span class="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold bg-slate-100 text-slate-600 uppercase">
                                                     {match summary_value.kind {
@@ -100,10 +100,10 @@ pub fn RequestsList(
                                                     }}
                                                 </span>
                                             </td>
-                                            <td class="px-8 py-5 whitespace-nowrap text-sm font-bold text-slate-900">
+                                            <td class="px-8 py-5 whitespace-nowrap text-sm font-bold text-slate-900 dark:text-slate-100">
                                                 {primary_label.clone()}
                                             </td>
-                                            <td class="px-8 py-5 whitespace-nowrap text-sm text-slate-500">
+                                            <td class="px-8 py-5 whitespace-nowrap text-sm text-slate-500 dark:text-slate-400">
                                                 {secondary_label.clone()}
                                             </td>
                                             <td class="px-8 py-5 whitespace-nowrap">

--- a/frontend/src/pages/settings/panel.rs
+++ b/frontend/src/pages/settings/panel.rs
@@ -220,8 +220,8 @@ pub fn SettingsPage() -> impl IntoView {
             <div class="mx-auto max-w-3xl space-y-8">
 
                 // --- Password Change Section ---
-                <div class="bg-white shadow rounded-lg p-6 space-y-4">
-                    <h2 class="text-xl font-semibold text-gray-900 border-b pb-2">"パスワード変更"</h2>
+                <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-4">
+                    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 border-b pb-2">"パスワード変更"</h2>
 
                     <Show when=move || password_success_msg.get().is_some() fallback=|| ()>
                         <SuccessMessage message={password_success_msg.get().unwrap_or_default()} />
@@ -232,7 +232,7 @@ pub fn SettingsPage() -> impl IntoView {
 
                     <form class="space-y-4" on:submit=on_submit_password>
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">"現在のパスワード"</label>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">"現在のパスワード"</label>
                             <input type="password" required
                                 class="mt-1 w-full border rounded px-3 py-2"
                                 on:input=move |ev| set_current_password.set(event_target_value(&ev))
@@ -240,7 +240,7 @@ pub fn SettingsPage() -> impl IntoView {
                             />
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">"新しいパスワード"</label>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">"新しいパスワード"</label>
                             <input type="password" required
                                 class="mt-1 w-full border rounded px-3 py-2"
                                 on:input=move |ev| set_new_password.set(event_target_value(&ev))
@@ -248,7 +248,7 @@ pub fn SettingsPage() -> impl IntoView {
                             />
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">"新しいパスワード（確認）"</label>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">"新しいパスワード（確認）"</label>
                             <input type="password" required
                                 class="mt-1 w-full border rounded px-3 py-2"
                                 on:input=move |ev| set_confirm_password.set(event_target_value(&ev))
@@ -291,8 +291,8 @@ pub fn SettingsPage() -> impl IntoView {
                 </div>
 
                 // --- Subject Request Section ---
-                <div class="bg-white shadow rounded-lg p-6 space-y-4">
-                    <h2 class="text-xl font-semibold text-gray-900 border-b pb-2">"本人対応申請"</h2>
+                <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-4">
+                    <h2 class="text-xl font-semibold text-gray-900 dark:text-gray-100 border-b pb-2">"本人対応申請"</h2>
                     <Show when=move || subject_success_msg.get().is_some() fallback=|| ()>
                         <SuccessMessage message={subject_success_msg.get().unwrap_or_default()} />
                     </Show>
@@ -301,7 +301,7 @@ pub fn SettingsPage() -> impl IntoView {
                     </Show>
                     <form class="space-y-3" on:submit=on_submit_subject>
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">"申請種別"</label>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">"申請種別"</label>
                             <select
                                 class="mt-1 w-full border rounded px-3 py-2"
                                 prop:value={move || subject_request_type.get()}
@@ -314,7 +314,7 @@ pub fn SettingsPage() -> impl IntoView {
                             </select>
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">"詳細"</label>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">"詳細"</label>
                             <textarea
                                 class="mt-1 w-full border rounded px-3 py-2"
                                 rows="3"
@@ -333,21 +333,21 @@ pub fn SettingsPage() -> impl IntoView {
                         </div>
                     </form>
                     <div>
-                        <h3 class="text-sm font-medium text-gray-700 mb-2">{"申請履歴"}</h3>
+                        <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{"申請履歴"}</h3>
                         <Show when=move || subject_requests_error.get().is_some()>
                             <ErrorMessage message={subject_requests_error.get().unwrap_or_default()} />
                         </Show>
                         <div class="overflow-x-auto">
-                            <table class="min-w-full divide-y divide-gray-200">
-                                <thead class="bg-gray-50">
+                            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                <thead class="bg-gray-50 dark:bg-gray-700">
                                     <tr>
-                                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"種別"}</th>
-                                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"ステータス"}</th>
-                                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{"申請日"}</th>
-                                        <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">{"操作"}</th>
+                                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"種別"}</th>
+                                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"ステータス"}</th>
+                                        <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"申請日"}</th>
+                                        <th class="px-4 py-2 text-right text-xs font-medium text-gray-500 dark:text-gray-200 uppercase tracking-wider">{"操作"}</th>
                                     </tr>
                                 </thead>
-                                <tbody class="bg-white divide-y divide-gray-200">
+                                <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                                     {move || {
                                         subject_requests
                                             .get()
@@ -364,9 +364,9 @@ pub fn SettingsPage() -> impl IntoView {
                                                 };
                                                 view! {
                                                     <tr>
-                                                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-900">{type_label}</td>
-                                                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700">{status_label}</td>
-                                                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700">{created_label}</td>
+                                                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">{type_label}</td>
+                                                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{status_label}</td>
+                                                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">{created_label}</td>
                                                         <td class="px-4 py-2 whitespace-nowrap text-right text-sm">
                                                             <button
                                                                 class="text-red-600 disabled:opacity-50"


### PR DESCRIPTION
## Summary
Addresses issue #241.
Updates table components across the frontend to support dark mode using Tailwind `dark:` classes.

## Changes
- Updated 8 files containing table components:
  - `frontend/src/pages/admin/components/holidays.rs`
  - `frontend/src/pages/admin/components/requests.rs`
  - `frontend/src/pages/admin/components/subject_requests.rs`
  - `frontend/src/pages/admin/components/weekly_holidays.rs`
  - `frontend/src/pages/admin_audit_logs/panel.rs`
  - `frontend/src/pages/admin_users/components/list.rs`
  - `frontend/src/pages/requests/components/list.rs`
  - `frontend/src/pages/settings/panel.rs`
- Applied dark mode styles to:
  - Backgrounds (`bg-white` -> `dark:bg-gray-800`)
  - Headers (`dark:bg-gray-700`, `dark:text-gray-200`)
  - Rows (`dark:text-gray-100`)
  - Borders (`dark:divide-gray-700`)