### PR TITLE
feat: support dark mode in Admin Modals and Filters

### DIFF
--- a/frontend/src/pages/admin/components/attendance.rs
+++ b/frontend/src/pages/admin/components/attendance.rs
@@ -170,8 +170,8 @@ pub fn AdminAttendanceToolsSection(
 
     view! {
         <Show when=move || system_admin_allowed.get()>
-            <div class="bg-white shadow rounded-lg p-6 space-y-4">
-                <h3 class="text-lg font-medium text-gray-900">{"勤怠ツール"}</h3>
+            <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-4">
+                <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{"勤怠ツール"}</h3>
                 <form class="space-y-3" on:submit=on_submit_attendance>
                     <AdminUserSelect
                         users=users
@@ -183,11 +183,11 @@ pub fn AdminAttendanceToolsSection(
                         label=Some("対象日")
                         value=att_date
                     />
-                    <input type="datetime-local" class="w-full border rounded px-2 py-1" on:input=move |ev| att_in.set(event_target_value(&ev)) />
-                    <input type="datetime-local" class="w-full border rounded px-2 py-1" on:input=move |ev| att_out.set(event_target_value(&ev)) />
+                    <input type="datetime-local" class="w-full border rounded px-2 py-1 dark:bg-gray-700 dark:border-gray-600 dark:text-white" on:input=move |ev| att_in.set(event_target_value(&ev)) />
+                    <input type="datetime-local" class="w-full border rounded px-2 py-1 dark:bg-gray-700 dark:border-gray-600 dark:text-white" on:input=move |ev| att_out.set(event_target_value(&ev)) />
                     <div>
                         <div class="flex items-center justify-between mb-1">
-                            <span class="text-sm text-gray-700">{"休憩（任意）"}</span>
+                            <span class="text-sm text-gray-700 dark:text-gray-300">{"休憩（任意）"}</span>
                             <button type="button" class="text-blue-600 text-sm" on:click=add_break>{"行を追加"}</button>
                         </div>
                         <For
@@ -198,8 +198,8 @@ pub fn AdminAttendanceToolsSection(
                                 let e = create_rw_signal(e0);
                                 view! {
                                     <div class="flex space-x-2 mb-2">
-                                        <input type="datetime-local" class="border rounded px-2 py-1 w-full" prop:value=s on:input=move |ev| s.set(event_target_value(&ev)) />
-                                        <input type="datetime-local" class="border rounded px-2 py-1 w-full" prop:value=e on:input=move |ev| e.set(event_target_value(&ev)) />
+                                        <input type="datetime-local" class="border rounded px-2 py-1 w-full dark:bg-gray-700 dark:border-gray-600 dark:text-white" prop:value=s on:input=move |ev| s.set(event_target_value(&ev)) />
+                                        <input type="datetime-local" class="border rounded px-2 py-1 w-full dark:bg-gray-700 dark:border-gray-600 dark:text-white" prop:value=e on:input=move |ev| e.set(event_target_value(&ev)) />
                                     </div>
                                 }
                             }
@@ -214,11 +214,11 @@ pub fn AdminAttendanceToolsSection(
                     </button>
                 </form>
                 <div class="mt-4">
-                    <h4 class="text-sm font-medium text-gray-900 mb-2">{"休憩の強制終了"}</h4>
+                    <h4 class="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">{"休憩の強制終了"}</h4>
                     <div class="flex space-x-2">
                         <input
                             placeholder="Break ID"
-                            class="border rounded px-2 py-1 w-full"
+                            class="border rounded px-2 py-1 w-full dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                             on:input=move |ev| break_force_id.set(event_target_value(&ev))
                         />
                         <button

--- a/frontend/src/pages/admin/components/requests.rs
+++ b/frontend/src/pages/admin/components/requests.rs
@@ -90,7 +90,7 @@ pub fn AdminRequestsSection(
             <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{"申請一覧"}</h3>
             <div class="flex flex-col gap-3 lg:flex-row lg:flex-wrap lg:items-end">
                 <select
-                    class="w-full lg:w-auto border-gray-300 rounded-md px-2 py-1"
+                    class="w-full lg:w-auto border-gray-300 rounded-md px-2 py-1 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                     on:change=move |ev| on_status_change(event_target_value(&ev))
                 >
                     <option value="">{ "すべて" }</option>
@@ -212,14 +212,14 @@ pub fn AdminRequestsSection(
                 </table>
             </div>
             <Show when=move || modal_open.get()>
-                <div class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
-                    <div class="bg-white rounded-lg shadow-lg w-full max-w-lg p-6">
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">{"申請詳細"}</h3>
-                        <pre class="text-xs bg-gray-50 p-2 rounded overflow-auto max-h-64">{format!("{}", modal_data.get())}</pre>
+                <div class="fixed inset-0 bg-black/30 dark:bg-black/80 flex items-center justify-center z-50">
+                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg w-full max-w-lg p-6">
+                        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">{"申請詳細"}</h3>
+                        <pre class="text-xs bg-gray-50 dark:bg-gray-900 dark:text-gray-300 p-2 rounded overflow-auto max-h-64">{format!("{}", modal_data.get())}</pre>
                         <div class="mt-3">
-                            <label class="block text-sm font-medium text-gray-700">{"コメント（任意）"}</label>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">{"コメント（任意）"}</label>
                             <textarea
-                                class="w-full border rounded px-2 py-1"
+                                class="w-full border rounded px-2 py-1 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                                 on:input=move |ev| modal_comment.set(event_target_value(&ev))
                             ></textarea>
                         </div>
@@ -227,7 +227,7 @@ pub fn AdminRequestsSection(
                             <InlineErrorMessage error={action_error.into()} />
                         </Show>
                         <div class="mt-4 flex justify-end space-x-2">
-                            <button class="px-3 py-1 rounded border" on:click=move |_| modal_open.set(false)>{"閉じる"}</button>
+                            <button class="px-3 py-1 rounded border dark:border-gray-600 dark:text-gray-300" on:click=move |_| modal_open.set(false)>{"閉じる"}</button>
                             <button
                                 class="px-3 py-1 rounded bg-red-600 text-white disabled:opacity-50"
                                 disabled={move || action_pending.get()}

--- a/frontend/src/pages/admin/components/subject_requests.rs
+++ b/frontend/src/pages/admin/components/subject_requests.rs
@@ -118,7 +118,7 @@ pub fn AdminSubjectRequestsSection(
             <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{"本人対応申請"}</h3>
             <div class="flex flex-col gap-3 lg:flex-row lg:flex-wrap lg:items-end">
                 <select
-                    class="w-full lg:w-auto border-gray-300 rounded-md px-2 py-1"
+                    class="w-full lg:w-auto border-gray-300 rounded-md px-2 py-1 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                     on:change=move |ev| on_status_change(event_target_value(&ev))
                 >
                     <option value="">{ "すべて" }</option>
@@ -128,7 +128,7 @@ pub fn AdminSubjectRequestsSection(
                     <option value="cancelled">{ "取消" }</option>
                 </select>
                 <select
-                    class="w-full lg:w-auto border-gray-300 rounded-md px-2 py-1"
+                    class="w-full lg:w-auto border-gray-300 rounded-md px-2 py-1 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                     on:change=move |ev| on_type_change(event_target_value(&ev))
                 >
                     <option value="">{ "請求種別" }</option>
@@ -222,14 +222,14 @@ pub fn AdminSubjectRequestsSection(
                 </table>
             </div>
             <Show when=move || modal_open.get()>
-                <div class="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
-                    <div class="bg-white rounded-lg shadow-lg w-full max-w-lg p-6">
-                        <h3 class="text-lg font-medium text-gray-900 mb-2">{"本人対応申請の詳細"}</h3>
-                        <pre class="text-xs bg-gray-50 p-2 rounded overflow-auto max-h-64 whitespace-pre-wrap">{move || modal_detail.get()}</pre>
+                <div class="fixed inset-0 bg-black/30 dark:bg-black/80 flex items-center justify-center z-50">
+                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg w-full max-w-lg p-6">
+                        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">{"本人対応申請の詳細"}</h3>
+                        <pre class="text-xs bg-gray-50 dark:bg-gray-900 dark:text-gray-300 p-2 rounded overflow-auto max-h-64 whitespace-pre-wrap">{move || modal_detail.get()}</pre>
                         <div class="mt-3">
-                            <label class="block text-sm font-medium text-gray-700">{"コメント"}</label>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">{"コメント"}</label>
                             <textarea
-                                class="w-full border rounded px-2 py-1"
+                                class="w-full border rounded px-2 py-1 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                                 on:input=move |ev| modal_comment.set(event_target_value(&ev))
                             ></textarea>
                         </div>
@@ -242,7 +242,7 @@ pub fn AdminSubjectRequestsSection(
                             />
                         </Show>
                         <div class="mt-4 flex justify-end space-x-2">
-                            <button class="px-3 py-1 rounded border" on:click=move |_| modal_open.set(false)>{"閉じる"}</button>
+                            <button class="px-3 py-1 rounded border dark:border-gray-600 dark:text-gray-300" on:click=move |_| modal_open.set(false)>{"閉じる"}</button>
                             <button
                                 class="px-3 py-1 rounded bg-red-600 text-white disabled:opacity-50"
                                 disabled={move || action_pending.get() || !modal_pending.get()}

--- a/frontend/src/pages/admin/components/system_tools.rs
+++ b/frontend/src/pages/admin/components/system_tools.rs
@@ -66,8 +66,8 @@ pub fn AdminMfaResetSection(
 
     view! {
         <Show when=move || system_admin_allowed.get()>
-            <div class="bg-white shadow rounded-lg p-6">
-                <h3 class="text-lg font-medium text-gray-900 mb-4">{"MFA リセット"}</h3>
+            <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+                <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{"MFA リセット"}</h3>
                 <div class="flex flex-col gap-2">
                     <AdminUserSelect
                         users=users

--- a/frontend/src/pages/admin/components/user_select.rs
+++ b/frontend/src/pages/admin/components/user_select.rs
@@ -100,12 +100,12 @@ pub fn AdminUserSelect(
     view! {
         <div class="space-y-1">
             <Show when=move || has_label>
-                <label class="block text-sm font-medium text-gray-700">
+                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
                     {label_value.clone()}
                 </label>
             </Show>
             <select
-                class="w-full border rounded px-2 py-1 bg-white disabled:opacity-50"
+                class="w-full border rounded px-2 py-1 bg-white dark:bg-gray-700 dark:border-gray-600 dark:text-white disabled:opacity-50"
                 on:change=on_change
                 prop:value=selected
                 disabled=disabled

--- a/frontend/src/pages/admin/layout.rs
+++ b/frontend/src/pages/admin/layout.rs
@@ -5,8 +5,8 @@ use leptos::*;
 pub fn UnauthorizedMessage() -> impl IntoView {
     view! {
         <div class="space-y-6">
-            <div class="bg-white shadow rounded-lg p-6">
-                <p class="text-sm text-gray-700">
+            <div class="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+                <p class="text-sm text-gray-700 dark:text-gray-300">
                     {"このページは管理者以上の権限が必要です。"}
                 </p>
             </div>
@@ -19,8 +19,8 @@ pub fn AdminDashboardFrame(children: Children) -> impl IntoView {
     view! {
         <div class="space-y-6">
             <div>
-                <h1 class="text-2xl font-bold text-gray-900">{"管理者ツール"}</h1>
-                <p class="mt-1 text-sm text-gray-600">
+                <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">{"管理者ツール"}</h1>
+                <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
                     {"週次休日や申請、勤怠、MFA、祝日管理をまとめて実行できます。"}
                 </p>
             </div>


### PR DESCRIPTION
## Summary
Addresses issue #243 by adding dark mode support to Admin UI components including Modals, Filter sections, and Layouts.

## Changes
- **Admin Layout (`layout.rs`)**: Updated `UnauthorizedMessage` and `AdminDashboardFrame` with dark mode colors.
- **System Tools (`system_tools.rs`)**: Added dark mode support to MFA reset section.
- **Attendance (`attendance.rs`)**: Styled inputs, date pickers, and containers for dark mode.
- **Requests (`requests.rs`)**: 
  - Updated Modal overlay to be darker (`bg-black/80`) in dark mode.
  - Styled Modal content, text, and inputs.
  - Updated Filter selects.
- **Subject Requests (`subject_requests.rs`)**: Applied similar dark mode styles to Modals and Filters.
- **User Select (`user_select.rs`)**: Updated Select dropdown and labels for dark mode.

## Verification
- Ran `cargo check` in `frontend` directory.
- Verified all additive `dark:` classes match the project's design system.

Closes #243