### PR TITLE
feat: expired session cleanup job

### DIFF
--- a/backend/src/bin/token_cleanup.rs
+++ b/backend/src/bin/token_cleanup.rs
@@ -1,6 +1,7 @@
 use timekeeper_backend::{
-    config::Config, db::connection::create_pool, repositories::auth as auth_repo,
-    repositories::password_reset as password_reset_repo,
+    config::Config,
+    db::connection::create_pool,
+    repositories::{active_session, auth as auth_repo, password_reset as password_reset_repo},
 };
 
 #[tokio::main]
@@ -12,10 +13,22 @@ async fn main() -> anyhow::Result<()> {
         .await
         .expect("cleanup active tokens");
 
+    let deleted_sessions = active_session::cleanup_expired_sessions(&pool)
+        .await
+        .expect("cleanup expired sessions");
+    if deleted_sessions > 0 {
+        tracing::info!("Deleted {} expired sessions", deleted_sessions);
+    }
+
     sqlx::query("VACUUM (ANALYZE) active_access_tokens")
         .execute(&pool)
         .await
         .expect("vacuum tokens table");
+
+    sqlx::query("VACUUM (ANALYZE) active_sessions")
+        .execute(&pool)
+        .await
+        .expect("vacuum active_sessions table");
 
     let deleted_count = password_reset_repo::delete_expired_tokens(&pool)
         .await


### PR DESCRIPTION
## Summary
- add expired active_sessions cleanup to token cleanup utility
- vacuum active_sessions after cleanup

## Testing
- cargo check