### PR TITLE
fix: resolve admin attendance view syntax

### DIFF
--- a/frontend/src/pages/admin/components/attendance.rs
+++ b/frontend/src/pages/admin/components/attendance.rs
@@ -191,9 +191,9 @@ pub fn AdminAttendanceToolsSection(
                             <button type="button" class="text-link hover:text-link-hover text-sm" on:click=add_break>{"行を追加"}</button>
                         </div>
                         <For
-                            each=move || breaks.get().into_iter().enumerate().collect::<Vec<_>>()
+                            each=move || breaks.get().into_iter().enumerate()
                             key=|(idx, _)| *idx
-                            children=move |(idx, (start, end))| {
+                            children=move |(idx, _)| {
                                 let start_value = {
                                     let breaks = breaks;
                                     move || {
@@ -271,8 +271,8 @@ pub fn AdminAttendanceToolsSection(
                     </div>
                 </div>
                 <Show when=move || error.get().is_some()>
-                <InlineErrorMessage error={error.into()} />
-            </Show>
+                    <InlineErrorMessage error={error.into()} />
+                </Show>
                 <Show when=move || message.get().is_some()>
                     <SuccessMessage message={message.get().unwrap_or_default()} />
                 </Show>


### PR DESCRIPTION
## Summary
- fix admin attendance tool view! syntax errors caused by turbofish in <For>
- keep break row rendering stable while avoiding macro parse errors

## Testing
- cargo check -p timekeeper-frontend
- cargo test (WSL)