### PR TITLE
fix(backend): isolate repository/handler/middleware adjustments

### DIFF
--- a/backend/src/handlers/admin/holidays.rs
+++ b/backend/src/handlers/admin/holidays.rs
@@ -308,8 +308,8 @@ mod tests {
 
     #[test]
     fn test_admin_holiday_list_response_structure() {
-        use crate::models::holiday::AdminHolidayListItem;
         use crate::models::holiday::AdminHolidayKind;
+        use crate::models::holiday::AdminHolidayListItem;
         use chrono::Utc;
 
         let item = AdminHolidayListItem {
@@ -458,7 +458,10 @@ mod tests {
     fn test_parse_type_filter_rejects_invalid_type() {
         let result = parse_type_filter(Some("invalid"));
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "`type` must be one of public, weekly, exception, all");
+        assert_eq!(
+            result.unwrap_err(),
+            "`type` must be one of public, weekly, exception, all"
+        );
     }
 
     #[test]

--- a/backend/src/handlers/admin/requests.rs
+++ b/backend/src/handlers/admin/requests.rs
@@ -14,9 +14,9 @@ use crate::{
         leave_request::LeaveRequestResponse, overtime_request::OvertimeRequestResponse, user::User,
     },
     repositories::{
-        request::{RequestListFilters, RequestRepository, RequestStatusUpdate},
         leave_request::{LeaveRequestRepository, LeaveRequestRepositoryTrait},
         overtime_request::{OvertimeRequestRepository, OvertimeRequestRepositoryTrait},
+        request::{RequestListFilters, RequestRepository, RequestStatusUpdate},
     },
     state::AppState,
     types::{LeaveRequestId, OvertimeRequestId},
@@ -470,7 +470,10 @@ mod tests {
 
     #[test]
     fn test_request_list_page_info_structure() {
-        let info = AdminRequestListPageInfo { page: 1, per_page: 20 };
+        let info = AdminRequestListPageInfo {
+            page: 1,
+            per_page: 20,
+        };
         assert_eq!(info.page, 1);
         assert_eq!(info.per_page, 20);
     }
@@ -480,7 +483,10 @@ mod tests {
         let response = AdminRequestListResponse {
             leave_requests: vec![],
             overtime_requests: vec![],
-            page_info: AdminRequestListPageInfo { page: 1, per_page: 20 },
+            page_info: AdminRequestListPageInfo {
+                page: 1,
+                per_page: 20,
+            },
         };
         assert!(response.leave_requests.is_empty());
         assert!(response.overtime_requests.is_empty());

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -1201,8 +1201,7 @@ mod tests {
     }
 
     fn build_user() -> User {
-        let password_hash =
-            hash_password("Secret123!").expect("hash password for tests");
+        let password_hash = hash_password("Secret123!").expect("hash password for tests");
         User::new(
             "tester".into(),
             password_hash,
@@ -1289,15 +1288,9 @@ mod tests {
             .max_connections(1)
             .connect_lazy("postgres://127.0.0.1:1/timekeeper")
             .expect("create lazy pool");
-        ensure_password_not_reused(
-            &pool,
-            UserId::new(),
-            "candidate",
-            "hash",
-            0,
-        )
-        .await
-        .expect("history limit zero should skip db");
+        ensure_password_not_reused(&pool, UserId::new(), "candidate", "hash", 0)
+            .await
+            .expect("history limit zero should skip db");
     }
 
     #[tokio::test]
@@ -1313,9 +1306,9 @@ mod tests {
             .access_claims(&config.jwt_secret)
             .expect("claims decode");
         assert_eq!(claims.sub, user.id.to_string());
-        let refresh_data =
-            session.refresh_token_data(config.refresh_token_expiration_days)
-                .expect("refresh data");
+        let refresh_data = session
+            .refresh_token_data(config.refresh_token_expiration_days)
+            .expect("refresh data");
         assert_eq!(refresh_data.user_id, user.id.to_string());
     }
 
@@ -1336,10 +1329,7 @@ mod tests {
     #[test]
     fn extract_ip_prefers_forwarded_for_and_falls_back_to_real_ip() {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            "x-forwarded-for",
-            " 1.2.3.4 , 5.6.7.8 ".parse().unwrap(),
-        );
+        headers.insert("x-forwarded-for", " 1.2.3.4 , 5.6.7.8 ".parse().unwrap());
         headers.insert("x-real-ip", "9.9.9.9".parse().unwrap());
         assert_eq!(extract_ip(&headers), Some("1.2.3.4".to_string()));
         headers.remove("x-forwarded-for");
@@ -1349,10 +1339,7 @@ mod tests {
     #[test]
     fn extract_user_agent_trims_value() {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            header::USER_AGENT,
-            "  TestAgent/1.0 ".parse().unwrap(),
-        );
+        headers.insert(header::USER_AGENT, "  TestAgent/1.0 ".parse().unwrap());
         assert_eq!(
             extract_user_agent(&headers),
             Some("TestAgent/1.0".to_string())
@@ -1362,14 +1349,8 @@ mod tests {
     #[test]
     fn cookie_header_value_reads_cookie_string() {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            header::COOKIE,
-            "foo=bar; baz=qux".parse().unwrap(),
-        );
-        assert_eq!(
-            cookie_header_value(&headers),
-            Some("foo=bar; baz=qux")
-        );
+        headers.insert(header::COOKIE, "foo=bar; baz=qux".parse().unwrap());
+        assert_eq!(cookie_header_value(&headers), Some("foo=bar; baz=qux"));
     }
 
     #[tokio::test]

--- a/backend/src/handlers/holiday_exceptions.rs
+++ b/backend/src/handlers/holiday_exceptions.rs
@@ -140,7 +140,9 @@ mod tests {
     fn map_exception_error_handles_conflict() {
         let err = holiday_exception_error_to_app_error(HolidayExceptionError::Conflict);
         match err {
-            AppError::Conflict(msg) => assert_eq!(msg, "Holiday exception already exists for this date"),
+            AppError::Conflict(msg) => {
+                assert_eq!(msg, "Holiday exception already exists for this date")
+            }
             _ => panic!("Expected Conflict"),
         }
     }

--- a/backend/src/handlers/holidays.rs
+++ b/backend/src/handlers/holidays.rs
@@ -290,12 +290,18 @@ END:VEVENT
 END:VCALENDAR"#;
 
         let result = parse_google_calendar_ics(ics_content, None);
-        
+
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].name, "元日");
-        assert_eq!(result[0].holiday_date, NaiveDate::from_ymd_opt(2024, 1, 1).unwrap());
+        assert_eq!(
+            result[0].holiday_date,
+            NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()
+        );
         assert_eq!(result[1].name, "成人の日");
-        assert_eq!(result[1].holiday_date, NaiveDate::from_ymd_opt(2024, 1, 8).unwrap());
+        assert_eq!(
+            result[1].holiday_date,
+            NaiveDate::from_ymd_opt(2024, 1, 8).unwrap()
+        );
     }
 
     #[test]
@@ -314,7 +320,7 @@ END:VEVENT
 END:VCALENDAR"#;
 
         let result = parse_google_calendar_ics(ics_content, Some(2024));
-        
+
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "元日 2024");
     }
@@ -335,7 +341,7 @@ END:VEVENT
 END:VCALENDAR"#;
 
         let result = parse_google_calendar_ics(ics_content, None);
-        
+
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].name, "成人の日");
     }
@@ -352,7 +358,7 @@ END:VEVENT
 END:VCALENDAR"#;
 
         let result = parse_google_calendar_ics(ics_content, None);
-        
+
         assert_eq!(result.len(), 1);
         // ICS continuation lines concatenate without adding a space
         assert_eq!(result[0].name, "Very Long HolidayName That Continues");
@@ -379,7 +385,7 @@ END:VEVENT
 END:VCALENDAR"#;
 
         let result = parse_google_calendar_ics(ics_content, None);
-        
+
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].name, "元日");
         assert_eq!(result[1].name, "Independence Day");

--- a/backend/src/handlers/requests.rs
+++ b/backend/src/handlers/requests.rs
@@ -12,9 +12,9 @@ use crate::{
         overtime_request::{CreateOvertimeRequest, OvertimeRequest, OvertimeRequestResponse},
     },
     repositories::{
-        request::{RequestCreate, RequestRecord, RequestRepository},
         leave_request::{LeaveRequestRepository, LeaveRequestRepositoryTrait},
         overtime_request::{OvertimeRequestRepository, OvertimeRequestRepositoryTrait},
+        request::{RequestCreate, RequestRecord, RequestRepository},
     },
     state::AppState,
     types::{LeaveRequestId, OvertimeRequestId},

--- a/backend/src/handlers/sessions.rs
+++ b/backend/src/handlers/sessions.rs
@@ -208,10 +208,15 @@ mod tests {
     #[test]
     fn extract_ip_from_x_forwarded_for() {
         let mut headers = HeaderMap::new();
-        headers.insert("x-forwarded-for", "203.0.113.195, 70.41.3.18, 150.172.238.178".parse().unwrap());
-        
+        headers.insert(
+            "x-forwarded-for",
+            "203.0.113.195, 70.41.3.18, 150.172.238.178"
+                .parse()
+                .unwrap(),
+        );
+
         let result = extract_ip(&headers);
-        
+
         assert_eq!(result, Some("203.0.113.195".to_string()));
     }
 
@@ -219,9 +224,9 @@ mod tests {
     fn extract_ip_from_x_real_ip() {
         let mut headers = HeaderMap::new();
         headers.insert("x-real-ip", "192.168.1.100".parse().unwrap());
-        
+
         let result = extract_ip(&headers);
-        
+
         assert_eq!(result, Some("192.168.1.100".to_string()));
     }
 
@@ -230,37 +235,43 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-forwarded-for", "203.0.113.195".parse().unwrap());
         headers.insert("x-real-ip", "192.168.1.100".parse().unwrap());
-        
+
         let result = extract_ip(&headers);
-        
+
         assert_eq!(result, Some("203.0.113.195".to_string()));
     }
 
     #[test]
     fn extract_ip_returns_none_when_missing() {
         let headers = HeaderMap::new();
-        
+
         let result = extract_ip(&headers);
-        
+
         assert_eq!(result, None);
     }
 
     #[test]
     fn extract_user_agent_from_header() {
         let mut headers = HeaderMap::new();
-        headers.insert(USER_AGENT, "Mozilla/5.0 (Windows NT 10.0; Win64; x64)".parse().unwrap());
-        
+        headers.insert(
+            USER_AGENT,
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64)".parse().unwrap(),
+        );
+
         let result = extract_user_agent(&headers);
-        
-        assert_eq!(result, Some("Mozilla/5.0 (Windows NT 10.0; Win64; x64)".to_string()));
+
+        assert_eq!(
+            result,
+            Some("Mozilla/5.0 (Windows NT 10.0; Win64; x64)".to_string())
+        );
     }
 
     #[test]
     fn extract_user_agent_returns_none_when_missing() {
         let headers = HeaderMap::new();
-        
+
         let result = extract_user_agent(&headers);
-        
+
         assert_eq!(result, None);
     }
 
@@ -268,9 +279,9 @@ mod tests {
     fn extract_user_agent_trims_whitespace() {
         let mut headers = HeaderMap::new();
         headers.insert(USER_AGENT, "  TestAgent  ".parse().unwrap());
-        
+
         let result = extract_user_agent(&headers);
-        
+
         assert_eq!(result, Some("TestAgent".to_string()));
     }
 }

--- a/backend/src/middleware/auth.rs
+++ b/backend/src/middleware/auth.rs
@@ -264,10 +264,7 @@ mod tests {
     #[test]
     fn test_extract_auth_headers_with_authorization() {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            header::AUTHORIZATION,
-            "Bearer test_token".parse().unwrap(),
-        );
+        headers.insert(header::AUTHORIZATION, "Bearer test_token".parse().unwrap());
         let (auth, cookie) = extract_auth_headers(&headers);
         assert_eq!(auth, Some("Bearer test_token".to_string()));
         assert_eq!(cookie, None);
@@ -276,10 +273,7 @@ mod tests {
     #[test]
     fn test_extract_auth_headers_with_cookie() {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            header::COOKIE,
-            "access_token=cookie_token".parse().unwrap(),
-        );
+        headers.insert(header::COOKIE, "access_token=cookie_token".parse().unwrap());
         let (auth, cookie) = extract_auth_headers(&headers);
         assert_eq!(auth, None);
         assert_eq!(cookie, Some("access_token=cookie_token".to_string()));
@@ -288,14 +282,8 @@ mod tests {
     #[test]
     fn test_extract_auth_headers_with_both() {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            header::AUTHORIZATION,
-            "Bearer test_token".parse().unwrap(),
-        );
-        headers.insert(
-            header::COOKIE,
-            "access_token=cookie_token".parse().unwrap(),
-        );
+        headers.insert(header::AUTHORIZATION, "Bearer test_token".parse().unwrap());
+        headers.insert(header::COOKIE, "access_token=cookie_token".parse().unwrap());
         let (auth, cookie) = extract_auth_headers(&headers);
         assert_eq!(auth, Some("Bearer test_token".to_string()));
         assert_eq!(cookie, Some("access_token=cookie_token".to_string()));
@@ -311,35 +299,37 @@ mod tests {
 
     #[test]
     fn test_verify_token_with_valid_token() {
-        use crate::utils::jwt::{create_access_token, verify_access_token};
-        use crate::types::UserId;
         use crate::models::user::UserRole;
+        use crate::types::UserId;
+        use crate::utils::jwt::{create_access_token, verify_access_token};
 
         let user_id = UserId::new();
         let username = "testuser".to_string();
         let role = format!("{:?}", UserRole::Employee);
         let secret = "test_secret_key_for_jwt_tokens";
-        let (token_string, _claims) = create_access_token(user_id.to_string(), username, role, &secret, 1).unwrap();
+        let (token_string, _claims) =
+            create_access_token(user_id.to_string(), username, role, &secret, 1).unwrap();
 
         let result = verify_access_token(&token_string, secret);
         assert!(result.is_ok());
-        
+
         let claims = result.unwrap();
         assert_eq!(claims.sub, user_id.to_string());
     }
 
     #[test]
     fn test_verify_token_with_invalid_secret() {
-        use crate::utils::jwt::{create_access_token, verify_access_token};
-        use crate::types::UserId;
         use crate::models::user::UserRole;
+        use crate::types::UserId;
+        use crate::utils::jwt::{create_access_token, verify_access_token};
 
         let user_id = UserId::new();
         let username = "testuser".to_string();
         let role = format!("{:?}", UserRole::Employee);
         let secret = "correct_secret";
         let wrong_secret = "wrong_secret";
-        let (token_string, _claims) = create_access_token(user_id.to_string(), username, role, &secret, 1).unwrap();
+        let (token_string, _claims) =
+            create_access_token(user_id.to_string(), username, role, &secret, 1).unwrap();
 
         let result = verify_access_token(&token_string, wrong_secret);
         assert!(result.is_err());

--- a/backend/src/middleware/request_id.rs
+++ b/backend/src/middleware/request_id.rs
@@ -131,10 +131,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(
-            response.headers().get("x-request-id").unwrap(),
-            "req-id"
-        );
+        assert_eq!(response.headers().get("x-request-id").unwrap(), "req-id");
     }
 
     #[test]

--- a/backend/src/repositories/attendance_repository.rs
+++ b/backend/src/repositories/attendance_repository.rs
@@ -5,9 +5,9 @@
 
 use async_trait::async_trait;
 use chrono::NaiveDate;
-use sqlx::{PgPool, Postgres};
 use sqlx::postgres::PgTransaction;
 use sqlx::Row as _;
+use sqlx::{PgPool, Postgres};
 
 use crate::error::AppError;
 use crate::models::attendance::Attendance;
@@ -118,10 +118,7 @@ impl AttendanceRepositoryTrait for AttendanceRepository {
     async fn find_by_id(&self, db: &PgPool, id: AttendanceId) -> Result<Attendance, AppError> {
         const SELECT_COLUMNS: &str =
             "id, user_id, date, clock_in_time, clock_out_time, status, total_work_hours, created_at, updated_at";
-        let query = format!(
-            "SELECT {} FROM attendance WHERE id = $1",
-            SELECT_COLUMNS
-        );
+        let query = format!("SELECT {} FROM attendance WHERE id = $1", SELECT_COLUMNS);
         let result = sqlx::query_as::<_, Attendance>(&query)
             .bind(id)
             .fetch_optional(db)
@@ -239,10 +236,7 @@ impl AttendanceRepositoryTrait for AttendanceRepository {
     ) -> Result<Option<Attendance>, AppError> {
         const SELECT_COLUMNS: &str =
             "id, user_id, date, clock_in_time, clock_out_time, status, total_work_hours, created_at, updated_at";
-        let query = format!(
-            "SELECT {} FROM attendance WHERE id = $1",
-            SELECT_COLUMNS
-        );
+        let query = format!("SELECT {} FROM attendance WHERE id = $1", SELECT_COLUMNS);
         let result = sqlx::query_as::<_, Attendance>(&query)
             .bind(id)
             .fetch_optional(db)

--- a/backend/src/repositories/leave_request_repository.rs
+++ b/backend/src/repositories/leave_request_repository.rs
@@ -35,7 +35,11 @@ pub trait LeaveRequestRepositoryTrait: Send + Sync {
     async fn delete(&self, db: &PgPool, id: LeaveRequestId) -> Result<(), AppError>;
 
     /// Find leave requests by user
-    async fn find_by_user(&self, db: &PgPool, user_id: UserId) -> Result<Vec<LeaveRequest>, AppError>;
+    async fn find_by_user(
+        &self,
+        db: &PgPool,
+        user_id: UserId,
+    ) -> Result<Vec<LeaveRequest>, AppError>;
 
     /// Find leave requests by user and date range
     async fn find_by_user_and_date_range(
@@ -217,7 +221,11 @@ impl LeaveRequestRepositoryTrait for LeaveRequestRepository {
         Ok(())
     }
 
-    async fn find_by_user(&self, db: &PgPool, user_id: UserId) -> Result<Vec<LeaveRequest>, AppError> {
+    async fn find_by_user(
+        &self,
+        db: &PgPool,
+        user_id: UserId,
+    ) -> Result<Vec<LeaveRequest>, AppError> {
         let query = format!(
             "SELECT {} FROM {} WHERE user_id = $1 ORDER BY created_at DESC",
             "id, user_id, leave_type, start_date, end_date, reason, status, \

--- a/backend/src/repositories/mod.rs
+++ b/backend/src/repositories/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod active_session;
 pub mod attendance;
+pub mod attendance_repository;
 pub mod audit_log;
 pub mod auth;
 pub mod break_record;
@@ -9,8 +10,11 @@ pub mod common;
 pub mod consent_log;
 pub mod holiday;
 pub mod holiday_exception;
+pub mod holiday_repository;
 pub mod leave_request;
+pub mod leave_request_repository;
 pub mod overtime_request;
+pub mod overtime_request_repository;
 pub mod password_reset;
 pub mod permissions;
 pub mod repository;
@@ -19,10 +23,6 @@ pub mod subject_request;
 pub mod transaction;
 pub mod user;
 pub mod user_repository;
-pub mod attendance_repository;
-pub mod leave_request_repository;
-pub mod overtime_request_repository;
-pub mod holiday_repository;
 pub mod weekly_holiday;
 
 pub use active_session::*;
@@ -42,7 +42,9 @@ pub use user_repository::*;
 pub use weekly_holiday::*;
 
 pub use attendance::{AttendanceRepository, AttendanceRepositoryTrait};
+pub use holiday::{HolidayRepository, HolidayRepositoryTrait};
 pub use leave_request::{LeaveRequestRepository, LeaveRequestRepositoryTrait};
 pub use overtime_request::{OvertimeRequestRepository, OvertimeRequestRepositoryTrait};
-pub use holiday::{HolidayRepository, HolidayRepositoryTrait};
-pub use request::{RequestCreate, RequestListFilters, RequestRecord, RequestRepository, RequestStatusUpdate};
+pub use request::{
+    RequestCreate, RequestListFilters, RequestRecord, RequestRepository, RequestStatusUpdate,
+};

--- a/backend/src/repositories/overtime_request_repository.rs
+++ b/backend/src/repositories/overtime_request_repository.rs
@@ -23,19 +23,35 @@ pub trait OvertimeRequestRepositoryTrait: Send + Sync {
     async fn find_all(&self, db: &PgPool) -> Result<Vec<OvertimeRequest>, AppError>;
 
     /// Find an overtime request by ID
-    async fn find_by_id(&self, db: &PgPool, id: OvertimeRequestId) -> Result<OvertimeRequest, AppError>;
+    async fn find_by_id(
+        &self,
+        db: &PgPool,
+        id: OvertimeRequestId,
+    ) -> Result<OvertimeRequest, AppError>;
 
     /// Create a new overtime request
-    async fn create(&self, db: &PgPool, item: &OvertimeRequest) -> Result<OvertimeRequest, AppError>;
+    async fn create(
+        &self,
+        db: &PgPool,
+        item: &OvertimeRequest,
+    ) -> Result<OvertimeRequest, AppError>;
 
     /// Update an existing overtime request
-    async fn update(&self, db: &PgPool, item: &OvertimeRequest) -> Result<OvertimeRequest, AppError>;
+    async fn update(
+        &self,
+        db: &PgPool,
+        item: &OvertimeRequest,
+    ) -> Result<OvertimeRequest, AppError>;
 
     /// Delete an overtime request by ID
     async fn delete(&self, db: &PgPool, id: OvertimeRequestId) -> Result<(), AppError>;
 
     /// Find overtime requests by user
-    async fn find_by_user(&self, db: &PgPool, user_id: UserId) -> Result<Vec<OvertimeRequest>, AppError>;
+    async fn find_by_user(
+        &self,
+        db: &PgPool,
+        user_id: UserId,
+    ) -> Result<Vec<OvertimeRequest>, AppError>;
 
     /// Find overtime requests by user and date range
     async fn find_by_user_and_date_range(
@@ -109,7 +125,11 @@ impl OvertimeRequestRepositoryTrait for OvertimeRequestRepository {
         Ok(rows)
     }
 
-    async fn find_by_id(&self, db: &PgPool, id: OvertimeRequestId) -> Result<OvertimeRequest, AppError> {
+    async fn find_by_id(
+        &self,
+        db: &PgPool,
+        id: OvertimeRequestId,
+    ) -> Result<OvertimeRequest, AppError> {
         let query = format!(
             "SELECT {} FROM {} WHERE id = $1",
             "id, user_id, date, planned_hours, reason, status, approved_by, \
@@ -124,7 +144,11 @@ impl OvertimeRequestRepositoryTrait for OvertimeRequestRepository {
         Ok(result)
     }
 
-    async fn create(&self, db: &PgPool, item: &OvertimeRequest) -> Result<OvertimeRequest, AppError> {
+    async fn create(
+        &self,
+        db: &PgPool,
+        item: &OvertimeRequest,
+    ) -> Result<OvertimeRequest, AppError> {
         use crate::models::request::RequestStatus;
 
         let query = format!(
@@ -161,7 +185,11 @@ impl OvertimeRequestRepositoryTrait for OvertimeRequestRepository {
         Ok(row)
     }
 
-    async fn update(&self, db: &PgPool, item: &OvertimeRequest) -> Result<OvertimeRequest, AppError> {
+    async fn update(
+        &self,
+        db: &PgPool,
+        item: &OvertimeRequest,
+    ) -> Result<OvertimeRequest, AppError> {
         use crate::models::request::RequestStatus;
 
         let query = format!(
@@ -202,7 +230,11 @@ impl OvertimeRequestRepositoryTrait for OvertimeRequestRepository {
         Ok(())
     }
 
-    async fn find_by_user(&self, db: &PgPool, user_id: UserId) -> Result<Vec<OvertimeRequest>, AppError> {
+    async fn find_by_user(
+        &self,
+        db: &PgPool,
+        user_id: UserId,
+    ) -> Result<Vec<OvertimeRequest>, AppError> {
         let query = format!(
             "SELECT {} FROM {} WHERE user_id = $1 ORDER BY created_at DESC",
             "id, user_id, date, planned_hours, reason, status, approved_by, \

--- a/backend/src/repositories/repository.rs
+++ b/backend/src/repositories/repository.rs
@@ -47,7 +47,7 @@ mod mock_tests {
             T: Repository<Id>,
         {
         }
-        
+
         // Trait exists - test passes
         assert!(true);
     }

--- a/backend/src/repositories/request.rs
+++ b/backend/src/repositories/request.rs
@@ -5,9 +5,10 @@ use std::str::FromStr;
 use crate::error::AppError;
 use crate::models::{leave_request::LeaveRequest, overtime_request::OvertimeRequest};
 use crate::repositories::{
-    common::push_clause, repository::Repository,
+    common::push_clause,
     leave_request::{LeaveRequestRepository, LeaveRequestRepositoryTrait},
     overtime_request::{OvertimeRequestRepository, OvertimeRequestRepositoryTrait},
+    repository::Repository,
 };
 use crate::types::{LeaveRequestId, OvertimeRequestId, UserId};
 

--- a/backend/src/repositories/user.rs
+++ b/backend/src/repositories/user.rs
@@ -98,11 +98,11 @@ pub async fn reset_mfa(pool: &PgPool, user_id: &str) -> Result<bool, sqlx::Error
 
 /// Checks if a username exists (for conflict check).
 pub async fn username_exists(pool: &PgPool, username: &str) -> Result<bool, sqlx::Error> {
-    let result: Option<(i64,)> = sqlx::query_as("SELECT 1 FROM users WHERE username = $1")
+    let result: (bool,) = sqlx::query_as("SELECT EXISTS(SELECT 1 FROM users WHERE username = $1)")
         .bind(username)
-        .fetch_optional(pool)
+        .fetch_one(pool)
         .await?;
-    Ok(result.is_some())
+    Ok(result.0)
 }
 
 /// Updates a user's profile (self-service).
@@ -472,11 +472,12 @@ pub async fn hard_delete_archived_user(pool: &PgPool, user_id: &str) -> Result<(
 
 /// Checks if an archived user exists by ID.
 pub async fn archived_user_exists(pool: &PgPool, user_id: &str) -> Result<bool, sqlx::Error> {
-    let result: Option<(i64,)> = sqlx::query_as("SELECT 1 FROM archived_users WHERE id = $1")
-        .bind(user_id)
-        .fetch_optional(pool)
-        .await?;
-    Ok(result.is_some())
+    let result: (bool,) =
+        sqlx::query_as("SELECT EXISTS(SELECT 1 FROM archived_users WHERE id = $1)")
+            .bind(user_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(result.0)
 }
 
 /// Fetches archived username by user ID.
@@ -541,7 +542,7 @@ mod tests {
     fn user_role_to_string_conversion() {
         let employee = UserRole::Employee;
         let admin = UserRole::Admin;
-        
+
         let emp_str = match employee {
             UserRole::Employee => "employee",
             UserRole::Admin => "admin",
@@ -550,7 +551,7 @@ mod tests {
             UserRole::Employee => "employee",
             UserRole::Admin => "admin",
         };
-        
+
         assert_eq!(emp_str, "employee");
         assert_eq!(adm_str, "admin");
     }


### PR DESCRIPTION
## Summary
`issue-155-coverage-tests` から `repository/handler/middleware` 側の差分を分離したPRです。

## Changes
- `backend/src/repositories/*` の調整
- `backend/src/handlers/*` の調整
- `backend/src/middleware/*` の調整
- 主な機能差分: `backend/src/repositories/user.rs` の存在確認クエリを `SELECT EXISTS(...)` へ統一

## Related Issue
- Refs #282

## Notes
- このPRは `issue-155-coverage-tests` をベースにした stacked PR です。
