### PR TITLE
fix(security): parse referer and validate by origin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5097,6 +5097,7 @@ dependencies = [
  "tower_governor",
  "tracing",
  "tracing-subscriber",
+ "url",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -95,6 +95,7 @@ utoipa-swagger-ui = { version = "9", features = ["axum"] }
 async-trait = "0.1"
 sha2 = "0.10.9"
 hex = "0.4"
+url = "2.5"
 aws-config = "1.8"
 aws-sdk-kms = "1.90"
 


### PR DESCRIPTION
## Summary
- Parse Referer as URL and compare only origin (scheme, host, and port)
- Keep Origin header as first priority, and use Referer-origin as fallback
- Add regression tests for Referer with path/query and malformed Referer
- Add url crate dependency for robust URL parsing

## Testing
- cargo fmt --all
- cargo test --lib verify_referer_ -- --nocapture

Closes #299