### PR TITLE
fix(admin): prevent attendance correction decision race conditions

### DIFF
--- a/backend/src/handlers/admin/attendance_correction_requests.rs
+++ b/backend/src/handlers/admin/attendance_correction_requests.rs
@@ -92,12 +92,6 @@ pub async fn approve_attendance_correction_request(
     let repo = AttendanceCorrectionRequestRepository::new();
     let request = repo.find_by_id(&state.write_pool, &id).await?;
 
-    if request.status.db_value() != "pending" {
-        return Err(AppError::Conflict(
-            "Request not found or already processed".into(),
-        ));
-    }
-
     let original_snapshot = request
         .parse_original_snapshot()
         .map_err(|e| AppError::InternalServerError(e.into()))?;

--- a/backend/tests/attendance_correction_api.rs
+++ b/backend/tests/attendance_correction_api.rs
@@ -454,3 +454,96 @@ async fn concurrent_approval_stress_allows_only_one_success() {
     assert_eq!(effective.0, request_id);
     assert_eq!(effective.1, admin.id.to_string());
 }
+
+#[tokio::test]
+async fn concurrent_reject_stress_allows_only_one_success() {
+    let _guard = integration_guard().await;
+    let pool = test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+
+    let employee = seed_user(&pool, UserRole::Employee, false).await;
+    let admin = seed_user(&pool, UserRole::Admin, false).await;
+    let user_app = user_router(pool.clone(), employee.clone());
+    let admin_app = admin_router(pool.clone(), admin.clone());
+    let user_token = create_test_token(employee.id, employee.role.clone());
+    let admin_token = create_test_token(admin.id, admin.role.clone());
+
+    let date = NaiveDate::from_ymd_opt(2026, 2, 14).expect("valid date");
+    let clock_in = NaiveDateTime::new(date, chrono::NaiveTime::from_hms_opt(9, 0, 0).unwrap());
+    let clock_out = NaiveDateTime::new(date, chrono::NaiveTime::from_hms_opt(18, 0, 0).unwrap());
+    seed_attendance(&pool, employee.id, date, Some(clock_in), Some(clock_out)).await;
+
+    let create_payload = json!({
+        "date": date.to_string(),
+        "clock_out_time": (clock_out + Duration::minutes(25)).format("%Y-%m-%dT%H:%M:%S").to_string(),
+        "reason": "同時却下テスト"
+    });
+    let create_req = Request::builder()
+        .method("POST")
+        .uri("/api/attendance-corrections")
+        .header("Authorization", format!("Bearer {}", user_token))
+        .header("Content-Type", "application/json")
+        .body(Body::from(create_payload.to_string()))
+        .expect("build create request");
+    let create_res = user_app.oneshot(create_req).await.expect("create call");
+    assert_eq!(create_res.status(), StatusCode::OK);
+    let create_json = response_json(create_res).await;
+    let request_id = create_json["id"].as_str().expect("request id").to_string();
+
+    let workers = 24usize;
+    let barrier = Arc::new(tokio::sync::Barrier::new(workers));
+    let mut handles = Vec::with_capacity(workers);
+    for _ in 0..workers {
+        let app = admin_app.clone();
+        let token = admin_token.clone();
+        let rid = request_id.clone();
+        let barrier = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            let reject_payload = json!({ "comment": "stress reject" });
+            let reject_req = Request::builder()
+                .method("PUT")
+                .uri(format!("/api/admin/attendance-corrections/{rid}/reject"))
+                .header("Authorization", format!("Bearer {}", token))
+                .header("Content-Type", "application/json")
+                .body(Body::from(reject_payload.to_string()))
+                .expect("build reject request");
+            app.oneshot(reject_req).await.expect("reject call").status()
+        }));
+    }
+
+    let mut ok_count = 0usize;
+    let mut conflict_count = 0usize;
+    for handle in handles {
+        let status = handle.await.expect("join reject task");
+        if status == StatusCode::OK {
+            ok_count += 1;
+        } else if status == StatusCode::CONFLICT {
+            conflict_count += 1;
+        } else {
+            panic!("unexpected status from concurrent reject: {status}");
+        }
+    }
+    assert_eq!(ok_count, 1, "only one reject must succeed");
+    assert_eq!(
+        conflict_count,
+        workers - 1,
+        "remaining rejects must conflict"
+    );
+
+    let row: (String, String, String) = sqlx::query_as(
+        "SELECT status, rejected_by, decision_comment
+         FROM attendance_correction_requests
+         WHERE id = $1",
+    )
+    .bind(&request_id)
+    .fetch_one(&pool)
+    .await
+    .expect("fetch correction request");
+    assert_eq!(row.0, "rejected");
+    assert_eq!(row.1, admin.id.to_string());
+    assert_eq!(row.2, "stress reject");
+}


### PR DESCRIPTION
## Summary
- remove non-atomic pending-status precheck in `approve_attendance_correction_request` and rely on repository-side guarded update
- keep decision updates guarded by `status = 'pending'` semantics so only one admin action succeeds
- add concurrent reject stress test to verify only one reject succeeds while others return conflict

## Testing
- cargo test --test attendance_correction_api concurrent_approval_stress_allows_only_one_success -- --exact
- cargo test --test attendance_correction_api concurrent_reject_stress_allows_only_one_success -- --exact

Closes #303
