### PR TITLE
fix(repo): preserve archive data for corrections and rejected requests

### DIFF
--- a/backend/migrations/036_archive_attendance_corrections_and_decision_fields.sql
+++ b/backend/migrations/036_archive_attendance_corrections_and_decision_fields.sql
@@ -1,0 +1,47 @@
+ALTER TABLE archived_leave_requests
+    ADD COLUMN decision_comment TEXT,
+    ADD COLUMN rejected_by TEXT,
+    ADD COLUMN rejected_at TIMESTAMPTZ,
+    ADD COLUMN cancelled_at TIMESTAMPTZ;
+
+ALTER TABLE archived_overtime_requests
+    ADD COLUMN decision_comment TEXT,
+    ADD COLUMN rejected_by TEXT,
+    ADD COLUMN rejected_at TIMESTAMPTZ,
+    ADD COLUMN cancelled_at TIMESTAMPTZ;
+
+CREATE TABLE archived_attendance_correction_requests (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    attendance_id TEXT NOT NULL,
+    date DATE NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    reason TEXT NOT NULL,
+    original_snapshot_json JSONB NOT NULL,
+    proposed_values_json JSONB NOT NULL,
+    decision_comment TEXT,
+    approved_by TEXT,
+    approved_at TIMESTAMPTZ,
+    rejected_by TEXT,
+    rejected_at TIMESTAMPTZ,
+    cancelled_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_archived_attendance_correction_requests_user_id
+    ON archived_attendance_correction_requests(user_id);
+
+CREATE TABLE archived_attendance_correction_effective_values (
+    attendance_id TEXT PRIMARY KEY,
+    source_request_id TEXT NOT NULL,
+    clock_in_time_corrected TIMESTAMP WITHOUT TIME ZONE,
+    clock_out_time_corrected TIMESTAMP WITHOUT TIME ZONE,
+    break_records_corrected_json JSONB NOT NULL,
+    applied_by TEXT,
+    applied_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    archived_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+


### PR DESCRIPTION
## Summary
- add migration to extend archived leave/overtime tables with `decision_comment`, `rejected_by`, `rejected_at`, `cancelled_at`
- add archived tables for attendance correction requests/effective values
- archive and restore attendance correction request/effective-value data in `soft_delete_user` / `restore_user`
- preserve leave/overtime rejection and cancellation fields during archive/restore
- update archived hard-delete cleanup to remove archived attendance correction data
- extend repository integration tests to cover correction archival and decision-field preservation

## Testing
- cargo test --test user_repository

Closes #304
