### PR TITLE
fix(admin): prevent admins from deciding their own requests

### DIFF
--- a/backend/src/handlers/admin/attendance_correction_requests.rs
+++ b/backend/src/handlers/admin/attendance_correction_requests.rs
@@ -91,6 +91,7 @@ pub async fn approve_attendance_correction_request(
 
     let repo = AttendanceCorrectionRequestRepository::new();
     let request = repo.find_by_id(&state.write_pool, &id).await?;
+    ensure_not_self_request(request.user_id, user.id)?;
 
     if request.status.db_value() != "pending" {
         return Err(AppError::Conflict(
@@ -132,9 +133,23 @@ pub async fn reject_attendance_correction_request(
     validate_comment(&payload.comment)?;
 
     let repo = AttendanceCorrectionRequestRepository::new();
+    let request = repo.find_by_id(&state.write_pool, &id).await?;
+    ensure_not_self_request(request.user_id, user.id)?;
     repo.reject(&state.write_pool, &id, user.id, &payload.comment)
         .await?;
     Ok(Json(serde_json::json!({ "message": "Request rejected" })))
+}
+
+fn ensure_not_self_request(
+    request_user_id: crate::types::UserId,
+    actor_id: crate::types::UserId,
+) -> Result<(), AppError> {
+    if request_user_id == actor_id {
+        return Err(AppError::Forbidden(
+            "Admins cannot approve or reject their own requests".into(),
+        ));
+    }
+    Ok(())
 }
 
 fn validate_comment(comment: &str) -> Result<(), AppError> {


### PR DESCRIPTION
## Summary
- add self-decision guard in admin request approve/reject handlers
- reject operations with `403 Forbidden` when `actor_id == request.user_id`
- keep existing behavior for non-self requests and already-processed requests
- add integration tests to verify admins cannot approve or reject their own leave requests

## Testing
- cargo test --test admin_requests_api test_admin_cannot_approve_own_request -- --exact
- cargo test --test admin_requests_api test_admin_cannot_reject_own_request -- --exact
- cargo test --test admin_requests_api admin_can_

Closes #301
