### PR TITLE
fix(validation): unify password validation to config-driven policy

### DIFF
--- a/backend/src/models/password_reset.rs
+++ b/backend/src/models/password_reset.rs
@@ -7,7 +7,6 @@ use utoipa::ToSchema;
 use validator::Validate;
 
 use crate::types::UserId;
-use crate::validation::rules;
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 /// Database representation of a password reset token.
@@ -40,6 +39,6 @@ pub struct ResetPasswordPayload {
     /// Password reset token from the email.
     #[validate(length(min = 32, message = "Invalid reset token"))]
     pub token: String,
-    #[validate(custom(function = "rules::validate_password_strength"))]
+    #[validate(length(min = 1, message = "Password is required"))]
     pub new_password: String,
 }

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -105,7 +105,7 @@ pub struct CreateUser {
         custom(function = "validate_username_format")
     )]
     pub username: String,
-    #[validate(length(min = 8), custom(function = "validate_password_format"))]
+    #[validate(length(min = 1))]
     pub password: String,
     #[validate(length(min = 1, max = 100))]
     pub full_name: String,
@@ -118,10 +118,6 @@ pub struct CreateUser {
 
 fn validate_username_format(username: &str) -> Result<(), validator::ValidationError> {
     rules::validate_username(username)
-}
-
-fn validate_password_format(password: &str) -> Result<(), validator::ValidationError> {
-    rules::validate_password_strength(password)
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Validate)]
@@ -166,12 +162,8 @@ pub struct ChangePasswordRequest {
     #[validate(length(min = 1))]
     pub current_password: String,
     /// Replacement password that will be stored if verification succeeds.
-    #[validate(length(min = 8), custom(function = "validate_new_password"))]
+    #[validate(length(min = 1))]
     pub new_password: String,
-}
-
-fn validate_new_password(password: &str) -> Result<(), validator::ValidationError> {
-    rules::validate_password_strength(password)
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/backend/src/validation/rules.rs
+++ b/backend/src/validation/rules.rs
@@ -2,35 +2,6 @@
 
 use validator::ValidationError;
 
-/// Validates password strength requirements.
-///
-/// Requirements:
-/// - At least 8 characters
-/// - Contains at least one uppercase letter
-/// - Contains at least one lowercase letter
-/// - Contains at least one digit
-pub fn validate_password_strength(password: &str) -> Result<(), ValidationError> {
-    if password.len() < 8 {
-        return Err(ValidationError::new("password_too_short"));
-    }
-
-    let has_uppercase = password.chars().any(|c| c.is_uppercase());
-    let has_lowercase = password.chars().any(|c| c.is_lowercase());
-    let has_digit = password.chars().any(|c| c.is_ascii_digit());
-
-    if !has_uppercase {
-        return Err(ValidationError::new("password_missing_uppercase"));
-    }
-    if !has_lowercase {
-        return Err(ValidationError::new("password_missing_lowercase"));
-    }
-    if !has_digit {
-        return Err(ValidationError::new("password_missing_digit"));
-    }
-
-    Ok(())
-}
-
 /// Validates username format.
 ///
 /// Requirements:
@@ -63,36 +34,6 @@ pub fn validate_planned_hours(hours: f64) -> Result<(), ValidationError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn password_strength_rejects_short_password() {
-        let result = validate_password_strength("Short1A");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn password_strength_rejects_no_uppercase() {
-        let result = validate_password_strength("lowercase123");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn password_strength_rejects_no_lowercase() {
-        let result = validate_password_strength("UPPERCASE123");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn password_strength_rejects_no_digit() {
-        let result = validate_password_strength("NoDigitsHere");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn password_strength_accepts_valid_password() {
-        let result = validate_password_strength("ValidPass123");
-        assert!(result.is_ok());
-    }
 
     #[test]
     fn username_rejects_empty() {


### PR DESCRIPTION
## Summary
- remove the duplicate weak password validator (`validate_password_strength`) from `validation::rules`
- stop wiring model-level password validation to the weak rule; keep only basic presence checks in payload validation
- keep password policy enforcement unified through `validate_password_complexity` in handlers using runtime config
- add an integration test that confirms admin user creation rejects passwords missing required symbols under configured policy

## Testing
- cargo test --test admin_users_api test_create_user_rejects_password_without_required_symbol -- --exact
- cargo test --test admin_users_api test_system_admin_can_create_user -- --exact
- cargo test --lib validation::rules::tests::username_accepts_valid -- --exact

Closes #311
