### PR TITLE
fix(audit-log): detect export truncation and expose header

### DIFF
--- a/backend/tests/admin_audit_logs_api.rs
+++ b/backend/tests/admin_audit_logs_api.rs
@@ -162,6 +162,13 @@ async fn test_system_admin_can_export_audit_logs() {
 
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get("x-truncated")
+            .and_then(|value| value.to_str().ok()),
+        Some("false")
+    );
 }
 
 #[tokio::test]

--- a/backend/tests/audit_log_read_export.rs
+++ b/backend/tests/audit_log_read_export.rs
@@ -405,6 +405,13 @@ async fn audit_log_export_returns_json_file() {
         .and_then(|value| value.to_str().ok())
         .unwrap_or_default();
     assert!(content_disposition.starts_with("attachment; filename=\"audit_logs_"));
+    assert_eq!(
+        response
+            .headers()
+            .get("x-truncated")
+            .and_then(|value| value.to_str().ok()),
+        Some("false")
+    );
 
     let body = to_bytes(response.into_body(), 1024 * 64)
         .await


### PR DESCRIPTION
## Summary
- implement Option 3 for audit-log export by fetching max_rows + 1
- detect overflow without COUNT(*) and return only max_rows rows
- add X-Truncated response header (true/false) on export endpoint
- add repository and API tests for truncation detection/header behavior

## Testing
- cargo test --test audit_log_repo audit_log_export_reports_truncation_when_over_max_rows -- --exact
- cargo test --test audit_log_read_export audit_log_export_returns_json_file -- --exact
- cargo test --test admin_audit_logs_api test_system_admin_can_export_audit_logs -- --exact

Closes #356