### PR TITLE
fix(i18n): localize forgot password link text

### DIFF
--- a/frontend/src/pages/login/components/form.rs
+++ b/frontend/src/pages/login/components/form.rs
@@ -115,7 +115,7 @@ pub fn LoginForm(
                     <div class="flex items-center justify-between">
                         <div class="text-sm">
                             <A href="/forgot-password" class="font-medium text-link hover:text-link-hover">
-                                "Forgot your password?"
+                                "パスワードをお忘れですか？"
                             </A>
                         </div>
                     </div>

--- a/frontend/src/pages/login/panel.rs
+++ b/frontend/src/pages/login/panel.rs
@@ -32,6 +32,6 @@ mod host_tests {
             }
         });
         assert!(html.contains("Timekeeper にログイン"));
-        assert!(html.contains("Forgot your password?"));
+        assert!(html.contains("パスワードをお忘れですか？"));
     }
 }


### PR DESCRIPTION
## Summary
- change login form link text from English to Japanese
- update `Forgot your password?` to `パスワードをお忘れですか？` in login UI

## Test
- cargo test -p timekeeper-frontend --lib login_form_renders_fields -- --nocapture

Closes #361