### PR TITLE
fix(i18n): map request status labels to Japanese

### DIFF
--- a/frontend/src/pages/requests/components/detail_modal.rs
+++ b/frontend/src/pages/requests/components/detail_modal.rs
@@ -1,3 +1,4 @@
+use crate::pages::requests::components::status_label::request_status_label;
 use crate::pages::requests::types::{RequestKind, RequestSummary};
 use leptos::*;
 
@@ -32,7 +33,7 @@ pub fn RequestDetailModal(selected: RwSignal<Option<RequestSummary>>) -> impl In
                                     <div class="space-y-2 text-sm text-fg">
                                         <div>
                                             <span class="font-medium text-fg-muted">{"ステータス: "}</span>
-                                            <span class="capitalize">{summary.status.clone()}</span>
+                                            <span class="capitalize">{request_status_label(&summary.status)}</span>
                                         </div>
                                         <div>
                                             <span class="font-medium text-fg-muted">{"期間/日付: "}</span>
@@ -87,7 +88,7 @@ mod host_tests {
             view! { <RequestDetailModal selected=selected /> }
         });
         assert!(html.contains("休暇申請"));
-        assert!(html.contains("pending"));
+        assert!(html.contains("承認待ち"));
         assert!(html.contains("family"));
     }
 }

--- a/frontend/src/pages/requests/components/list.rs
+++ b/frontend/src/pages/requests/components/list.rs
@@ -2,6 +2,7 @@ use crate::api::ApiError;
 use crate::components::{
     empty_state::EmptyState, error::InlineErrorMessage, layout::LoadingSpinner,
 };
+use crate::pages::requests::components::status_label::request_status_label;
 use crate::pages::requests::types::{RequestKind, RequestSummary};
 use leptos::*;
 
@@ -76,6 +77,7 @@ pub fn RequestsList(
                                     let status = summary_value.status.clone();
                                     let status_for_pending = status.clone();
                                     let status_for_not_pending = status.clone();
+                                    let status_label = request_status_label(&status);
                                     let primary_label =
                                         summary_value.primary_label.clone().unwrap_or_else(|| "-".into());
                                     let secondary_label =
@@ -109,7 +111,7 @@ pub fn RequestsList(
                                             </td>
                                             <td class="px-8 py-5 whitespace-nowrap">
                                                 <span class=format!("inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-black uppercase tracking-wider {}", status_style)>
-                                                    {status.clone()}
+                                                    {status_label.clone()}
                                                 </span>
                                             </td>
                                             <td class="px-8 py-5 whitespace-nowrap text-sm font-medium text-fg-muted">
@@ -219,7 +221,7 @@ mod host_tests {
             }
         });
         assert!(html.contains("申請一覧"));
-        assert!(html.contains("pending"));
+        assert!(html.contains("承認待ち"));
         assert!(html.contains("休暇"));
     }
 }

--- a/frontend/src/pages/requests/components/mod.rs
+++ b/frontend/src/pages/requests/components/mod.rs
@@ -4,3 +4,4 @@ pub mod filter;
 pub mod leave_form;
 pub mod list;
 pub mod overtime_form;
+pub mod status_label;

--- a/frontend/src/pages/requests/components/status_label.rs
+++ b/frontend/src/pages/requests/components/status_label.rs
@@ -1,0 +1,27 @@
+pub fn request_status_label(value: &str) -> String {
+    match value {
+        "pending" => "承認待ち".to_string(),
+        "approved" => "承認済み".to_string(),
+        "rejected" => "却下".to_string(),
+        "cancelled" => "取消".to_string(),
+        _ => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::request_status_label;
+
+    #[test]
+    fn request_status_label_maps_known_values() {
+        assert_eq!(request_status_label("pending"), "承認待ち".to_string());
+        assert_eq!(request_status_label("approved"), "承認済み".to_string());
+        assert_eq!(request_status_label("rejected"), "却下".to_string());
+        assert_eq!(request_status_label("cancelled"), "取消".to_string());
+    }
+
+    #[test]
+    fn request_status_label_handles_unknown_values() {
+        assert_eq!(request_status_label("unexpected"), "unexpected".to_string());
+    }
+}


### PR DESCRIPTION
## Summary
- add request status label mapping helper for requests UI components
- apply Japanese status labels in request list badges
- apply Japanese status labels in request detail modal
- update component tests to assert localized labels

## Test
- cargo test -p timekeeper-frontend --lib requests_list_renders_rows -- --nocapture
- cargo test -p timekeeper-frontend --lib request_detail_modal_renders_summary -- --nocapture
- cargo test -p timekeeper-frontend --lib request_status_label_maps_known_values -- --nocapture

Closes #362