### PR TITLE
fix: improve modal accessibility for requests and audit logs

### DIFF
--- a/frontend/src/pages/admin_audit_logs/panel.rs
+++ b/frontend/src/pages/admin_audit_logs/panel.rs
@@ -4,7 +4,11 @@ use crate::components::common::{Button, ButtonVariant};
 use crate::components::empty_state::EmptyState;
 use crate::components::layout::Layout;
 use crate::state::auth::use_auth;
+use leptos::ev::KeyboardEvent;
+use leptos::html;
 use leptos::*;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast;
 
 fn update_filter_value(filters: &mut AuditLogFilters, field: &str, value: String) {
     match field {
@@ -197,6 +201,10 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
     let vm = use_audit_log_view_model();
     let (auth, _) = use_auth();
     let selected_metadata = create_rw_signal::<Option<serde_json::Value>>(None);
+    let metadata_header_close_ref = create_node_ref::<html::Button>();
+    let metadata_footer_close_ref = create_node_ref::<html::Button>();
+    #[cfg(target_arch = "wasm32")]
+    let metadata_previously_focused = create_rw_signal(None::<web_sys::HtmlElement>);
     let is_system_admin = create_memo(move |_| {
         auth.get()
             .user
@@ -214,6 +222,54 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
         });
         vm.page.set(page);
     };
+    let on_metadata_modal_keydown = move |ev: KeyboardEvent| match ev.key().as_str() {
+        "Escape" => {
+            ev.prevent_default();
+            selected_metadata.update(clear_selected_metadata);
+            #[cfg(target_arch = "wasm32")]
+            if let Some(element) = metadata_previously_focused.get_untracked() {
+                let _ = element.focus();
+                metadata_previously_focused.set(None);
+            }
+        }
+        "Tab" => {
+            #[cfg(target_arch = "wasm32")]
+            {
+                let active_id = web_sys::window()
+                    .and_then(|window| window.document())
+                    .and_then(|document| document.active_element())
+                    .and_then(|element| element.get_attribute("id"))
+                    .unwrap_or_default();
+                if ev.shift_key() && active_id == "audit-metadata-modal-header-close" {
+                    ev.prevent_default();
+                    if let Some(button) = metadata_footer_close_ref.get() {
+                        let _ = button.focus();
+                    }
+                } else if !ev.shift_key() && active_id == "audit-metadata-modal-footer-close" {
+                    ev.prevent_default();
+                    if let Some(button) = metadata_header_close_ref.get() {
+                        let _ = button.focus();
+                    }
+                }
+            }
+        }
+        _ => {}
+    };
+    create_effect(move |_| {
+        if selected_metadata.get().is_some() {
+            #[cfg(target_arch = "wasm32")]
+            {
+                let active = web_sys::window()
+                    .and_then(|window| window.document())
+                    .and_then(|document| document.active_element())
+                    .and_then(|element| element.dyn_into::<web_sys::HtmlElement>().ok());
+                metadata_previously_focused.set(active);
+                if let Some(button) = metadata_header_close_ref.get() {
+                    let _ = button.focus();
+                }
+            }
+        }
+    });
 
     view! {
         <Layout>
@@ -348,10 +404,29 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
 
                     <Show when=move || selected_metadata.get().is_some()>
                         <div class="fixed inset-0 bg-overlay-backdrop flex items-center justify-center z-50 p-4">
-                            <div class="bg-surface-elevated rounded-lg shadow-xl w-full max-w-2xl flex flex-col max-h-[90vh]">
+                            <div
+                                class="bg-surface-elevated rounded-lg shadow-xl w-full max-w-2xl flex flex-col max-h-[90vh] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-action-primary-focus"
+                                role="dialog"
+                                aria-modal="true"
+                                tabindex="-1"
+                                on:keydown=on_metadata_modal_keydown
+                            >
                                 <div class="p-4 border-b border-border flex justify-between items-center">
                                     <h3 class="text-lg font-bold text-fg">"メタデータ詳細"</h3>
-                                    <button class="text-fg-muted hover:text-fg" on:click=move |_| selected_metadata.update(clear_selected_metadata)>
+                                    <button
+                                        id="audit-metadata-modal-header-close"
+                                        node_ref=metadata_header_close_ref
+                                        aria-label="閉じる"
+                                        class="text-fg-muted hover:text-fg"
+                                        on:click=move |_| {
+                                            selected_metadata.update(clear_selected_metadata);
+                                            #[cfg(target_arch = "wasm32")]
+                                            if let Some(element) = metadata_previously_focused.get_untracked() {
+                                                let _ = element.focus();
+                                                metadata_previously_focused.set(None);
+                                            }
+                                        }
+                                    >
                                         <i class="fas fa-times"></i>
                                     </button>
                                 </div>
@@ -360,8 +435,17 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
                                 </div>
                                 <div class="p-4 border-t border-border flex justify-end">
                                     <button
+                                        id="audit-metadata-modal-footer-close"
+                                        node_ref=metadata_footer_close_ref
                                         class="px-4 py-2 bg-surface-muted hover:bg-surface-elevated rounded text-sm font-medium text-fg"
-                                        on:click=move |_| selected_metadata.update(clear_selected_metadata)
+                                        on:click=move |_| {
+                                            selected_metadata.update(clear_selected_metadata);
+                                            #[cfg(target_arch = "wasm32")]
+                                            if let Some(element) = metadata_previously_focused.get_untracked() {
+                                                let _ = element.focus();
+                                                metadata_previously_focused.set(None);
+                                            }
+                                        }
                                     >
                                         "閉じる"
                                     </button>
@@ -383,6 +467,7 @@ mod host_tests {
     use crate::test_support::helpers::{admin_user, provide_auth, regular_user};
     use crate::test_support::ssr::{render_to_string, with_runtime};
     use chrono::{DateTime, Utc};
+    use leptos_router::{Router, RouterIntegrationContext, ServerIntegration};
 
     fn sample_log_response(
         items: Vec<AuditLog>,
@@ -435,8 +520,11 @@ mod host_tests {
     #[test]
     fn audit_logs_page_renders_denied_for_non_admin() {
         let html = render_to_string(move || {
+            provide_context(RouterIntegrationContext::new(ServerIntegration {
+                path: "http://localhost/admin/audit-logs".to_string(),
+            }));
             provide_auth(Some(regular_user()));
-            view! { <AdminAuditLogsPage /> }
+            view! { <Router><AdminAuditLogsPage /></Router> }
         });
         assert!(html.contains("権限がありません"));
     }
@@ -460,11 +548,14 @@ mod host_tests {
 
         let server = server.clone();
         let html = render_to_string(move || {
+            provide_context(RouterIntegrationContext::new(ServerIntegration {
+                path: "http://localhost/admin/audit-logs".to_string(),
+            }));
             provide_auth(Some(admin_user(true)));
             provide_context(crate::api::ApiClient::new_with_base_url(
                 &server.url("/api"),
             ));
-            view! { <AdminAuditLogsPage /> }
+            view! { <Router><AdminAuditLogsPage /></Router> }
         });
         assert!(html.contains("監査ログ"));
         assert!(html.contains("JSONエクスポート"));

--- a/frontend/src/pages/requests/components/detail_modal.rs
+++ b/frontend/src/pages/requests/components/detail_modal.rs
@@ -1,10 +1,70 @@
 use crate::pages::requests::components::status_label::request_status_label;
 use crate::pages::requests::types::{RequestKind, RequestSummary};
+use leptos::ev::KeyboardEvent;
+use leptos::html;
 use leptos::*;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast;
 
 #[component]
 pub fn RequestDetailModal(selected: RwSignal<Option<RequestSummary>>) -> impl IntoView {
-    let on_close = { move |_| selected.set(None) };
+    let header_close_ref = create_node_ref::<html::Button>();
+    let footer_close_ref = create_node_ref::<html::Button>();
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = (&header_close_ref, &footer_close_ref);
+    #[cfg(target_arch = "wasm32")]
+    let previously_focused = create_rw_signal(None::<web_sys::HtmlElement>);
+
+    let on_dialog_keydown = move |ev: KeyboardEvent| match ev.key().as_str() {
+        "Escape" => {
+            ev.prevent_default();
+            selected.set(None);
+            #[cfg(target_arch = "wasm32")]
+            if let Some(element) = previously_focused.get_untracked() {
+                let _ = element.focus();
+                previously_focused.set(None);
+            }
+        }
+        "Tab" => {
+            #[cfg(target_arch = "wasm32")]
+            {
+                let active_id = web_sys::window()
+                    .and_then(|window| window.document())
+                    .and_then(|document| document.active_element())
+                    .and_then(|element| element.get_attribute("id"))
+                    .unwrap_or_default();
+                if ev.shift_key() && active_id == "request-detail-modal-header-close" {
+                    ev.prevent_default();
+                    if let Some(button) = footer_close_ref.get() {
+                        let _ = button.focus();
+                    }
+                } else if !ev.shift_key() && active_id == "request-detail-modal-footer-close" {
+                    ev.prevent_default();
+                    if let Some(button) = header_close_ref.get() {
+                        let _ = button.focus();
+                    }
+                }
+            }
+        }
+        _ => {}
+    };
+
+    create_effect(move |_| {
+        if selected.get().is_some() {
+            #[cfg(target_arch = "wasm32")]
+            {
+                let active = web_sys::window()
+                    .and_then(|window| window.document())
+                    .and_then(|document| document.active_element())
+                    .and_then(|element| element.dyn_into::<web_sys::HtmlElement>().ok());
+                previously_focused.set(active);
+                if let Some(button) = header_close_ref.get() {
+                    let _ = button.focus();
+                }
+            }
+        }
+    });
+
     view! {
         <Show when=move || selected.get().is_some()>
             {move || {
@@ -13,8 +73,24 @@ pub fn RequestDetailModal(selected: RwSignal<Option<RequestSummary>>) -> impl In
                     .map(|summary| {
                         view! {
                             <div class="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
-                                <div class="fixed inset-0 bg-overlay-backdrop" on:click=on_close></div>
-                                <div class="relative bg-surface-elevated rounded-lg shadow-xl w-full max-w-md mx-4 p-6 space-y-4">
+                                <div
+                                    class="fixed inset-0 bg-overlay-backdrop"
+                                    on:click=move |_| {
+                                        selected.set(None);
+                                        #[cfg(target_arch = "wasm32")]
+                                        if let Some(element) = previously_focused.get_untracked() {
+                                            let _ = element.focus();
+                                            previously_focused.set(None);
+                                        }
+                                    }
+                                ></div>
+                                <div
+                                    class="relative bg-surface-elevated rounded-lg shadow-xl w-full max-w-md mx-4 p-6 space-y-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-action-primary-focus"
+                                    role="dialog"
+                                    aria-modal="true"
+                                    tabindex="-1"
+                                    on:keydown=on_dialog_keydown
+                                >
                                     <div class="flex items-center justify-between">
                                         <div>
                                             <p class="text-sm text-fg-muted">{"申請の詳細"}</p>
@@ -26,7 +102,20 @@ pub fn RequestDetailModal(selected: RwSignal<Option<RequestSummary>>) -> impl In
                                                 }}
                                             </p>
                                         </div>
-                                        <button class="text-fg-muted hover:text-fg" on:click=on_close>
+                                        <button
+                                            id="request-detail-modal-header-close"
+                                            node_ref=header_close_ref
+                                            aria-label="閉じる"
+                                            class="text-fg-muted hover:text-fg"
+                                            on:click=move |_| {
+                                                selected.set(None);
+                                                #[cfg(target_arch = "wasm32")]
+                                                if let Some(element) = previously_focused.get_untracked() {
+                                                    let _ = element.focus();
+                                                    previously_focused.set(None);
+                                                }
+                                            }
+                                        >
                                             {"✕"}
                                         </button>
                                     </div>
@@ -53,7 +142,19 @@ pub fn RequestDetailModal(selected: RwSignal<Option<RequestSummary>>) -> impl In
                                         </div>
                                     </div>
                                     <div class="flex justify-end">
-                                        <button class="px-4 py-2 rounded bg-surface-muted text-fg hover:bg-surface-elevated" on:click=on_close>
+                                        <button
+                                            id="request-detail-modal-footer-close"
+                                            node_ref=footer_close_ref
+                                            class="px-4 py-2 rounded bg-surface-muted text-fg hover:bg-surface-elevated"
+                                            on:click=move |_| {
+                                                selected.set(None);
+                                                #[cfg(target_arch = "wasm32")]
+                                                if let Some(element) = previously_focused.get_untracked() {
+                                                    let _ = element.focus();
+                                                    previously_focused.set(None);
+                                                }
+                                            }
+                                        >
                                             {"閉じる"}
                                         </button>
                                     </div>
@@ -88,6 +189,9 @@ mod host_tests {
             view! { <RequestDetailModal selected=selected /> }
         });
         assert!(html.contains("休暇申請"));
+        assert!(html.contains("role=\"dialog\""));
+        assert!(html.contains("aria-modal=\"true\""));
+        assert!(html.contains("aria-label=\"閉じる\""));
         assert!(html.contains("承認待ち"));
         assert!(html.contains("family"));
     }


### PR DESCRIPTION
## Summary
- add accessible dialog semantics (`role="dialog"`, `aria-modal="true"`) to request detail modal and audit metadata modal
- add keyboard support: Escape to close, focus trap within modal controls, and focus return to the trigger when closing
- add/update host-side rendering assertions for request detail modal accessibility attributes

## Testing
- cargo test -p timekeeper-frontend --lib request_detail_modal_renders_summary -- --nocapture
- cargo test -p timekeeper-frontend --lib audit_logs_page_renders_denied_for_non_admin -- --nocapture

Closes #365
