### PR TITLE
feat: add destructive action confirmation dialog

### DIFF
--- a/frontend/src/components/confirm_dialog.rs
+++ b/frontend/src/components/confirm_dialog.rs
@@ -1,0 +1,128 @@
+use leptos::ev::KeyboardEvent;
+use leptos::*;
+
+#[component]
+pub fn ConfirmDialog(
+    is_open: Signal<bool>,
+    #[prop(into)] title: MaybeSignal<String>,
+    #[prop(into)] message: MaybeSignal<String>,
+    on_confirm: Callback<()>,
+    on_cancel: Callback<()>,
+    #[prop(optional, into)] confirm_label: MaybeSignal<String>,
+    #[prop(optional, into)] cancel_label: MaybeSignal<String>,
+    #[prop(optional, into)] confirm_disabled: MaybeSignal<bool>,
+    #[prop(optional)] destructive: bool,
+) -> impl IntoView {
+    let confirm_button_class = if destructive {
+        "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold bg-action-danger-bg text-action-danger-text hover:bg-action-danger-bg-hover disabled:opacity-50"
+    } else {
+        "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold bg-action-primary-bg text-action-primary-text hover:bg-action-primary-bg-hover disabled:opacity-50"
+    };
+
+    let confirm_label_text = Signal::derive(move || {
+        let text = confirm_label.get();
+        if text.trim().is_empty() {
+            "はい".to_string()
+        } else {
+            text
+        }
+    });
+    let title_text = Signal::derive(move || title.get());
+    let message_text = Signal::derive(move || message.get());
+    let cancel_label_text = Signal::derive(move || {
+        let text = cancel_label.get();
+        if text.trim().is_empty() {
+            "いいえ".to_string()
+        } else {
+            text
+        }
+    });
+
+    let cancel_on_backdrop = on_cancel;
+    let cancel_on_header_button = on_cancel;
+    let cancel_on_esc = on_cancel;
+    let cancel_on_footer_button = on_cancel;
+    let confirm_on_footer_button = on_confirm;
+
+    view! {
+        <Show when=move || is_open.get()>
+            <div class="fixed inset-0 z-[70] flex items-center justify-center p-4">
+                <button
+                    type="button"
+                    aria-label="閉じる"
+                    class="absolute inset-0 bg-overlay-backdrop"
+                    on:click=move |_| cancel_on_backdrop.call(())
+                ></button>
+                <div
+                    class="relative z-[71] w-full max-w-md rounded-lg bg-surface-elevated shadow-xl border border-border p-6 space-y-4"
+                    role="dialog"
+                    aria-modal="true"
+                    tabindex="-1"
+                    on:keydown=move |ev: KeyboardEvent| {
+                        if ev.key() == "Escape" {
+                            ev.prevent_default();
+                            cancel_on_esc.call(());
+                        }
+                    }
+                >
+                    <div class="flex items-start justify-between gap-3">
+                        <h2 class="text-lg font-semibold text-fg">{move || title_text.get()}</h2>
+                        <button
+                            type="button"
+                            aria-label="閉じる"
+                            class="text-fg-muted hover:text-fg"
+                            on:click=move |_| cancel_on_header_button.call(())
+                        >
+                            {"✕"}
+                        </button>
+                    </div>
+                    <p class="text-sm text-fg-muted">{move || message_text.get()}</p>
+                    <div class="flex justify-end gap-2">
+                        <button
+                            type="button"
+                            class="inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold bg-surface-muted text-fg hover:bg-surface-elevated"
+                            on:click=move |_| cancel_on_footer_button.call(())
+                        >
+                            {move || cancel_label_text.get()}
+                        </button>
+                        <button
+                            type="button"
+                            class=confirm_button_class
+                            disabled=move || confirm_disabled.get()
+                            on:click=move |_| confirm_on_footer_button.call(())
+                        >
+                            {move || confirm_label_text.get()}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Show>
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod host_tests {
+    use super::*;
+    use crate::test_support::ssr::render_to_string;
+
+    #[test]
+    fn confirm_dialog_renders_with_default_labels() {
+        let html = render_to_string(move || {
+            let is_open = Signal::derive(|| true);
+            view! {
+                <ConfirmDialog
+                    is_open=is_open
+                    title="確認"
+                    message="本当に実行しますか？"
+                    on_confirm=Callback::new(|_| {})
+                    on_cancel=Callback::new(|_| {})
+                />
+            }
+        });
+        assert!(html.contains("role=\"dialog\""));
+        assert!(html.contains("aria-modal=\"true\""));
+        assert!(html.contains("本当に実行しますか？"));
+        assert!(html.contains("はい"));
+        assert!(html.contains("いいえ"));
+    }
+}

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -1,5 +1,6 @@
 pub mod cards;
 pub mod common;
+pub mod confirm_dialog;
 pub mod empty_state;
 pub mod error;
 pub mod forms;

--- a/frontend/src/pages/requests/components/list.rs
+++ b/frontend/src/pages/requests/components/list.rs
@@ -1,6 +1,7 @@
 use crate::api::ApiError;
 use crate::components::{
-    empty_state::EmptyState, error::InlineErrorMessage, layout::LoadingSpinner,
+    confirm_dialog::ConfirmDialog, empty_state::EmptyState, error::InlineErrorMessage,
+    layout::LoadingSpinner,
 };
 use crate::pages::requests::components::status_label::request_status_label;
 use crate::pages::requests::types::{RequestKind, RequestSummary};
@@ -17,6 +18,17 @@ pub fn RequestsList(
     on_cancel: Callback<RequestSummary>,
     message: RwSignal<crate::pages::requests::utils::MessageState>,
 ) -> impl IntoView {
+    let pending_cancel_request = create_rw_signal(None::<RequestSummary>);
+    let confirm_cancel_request = Callback::new({
+        move |_| {
+            if let Some(summary) = pending_cancel_request.get_untracked() {
+                on_cancel.call(summary);
+                pending_cancel_request.set(None);
+            }
+        }
+    });
+    let dismiss_cancel_dialog = Callback::new(move |_| pending_cancel_request.set(None));
+
     view! {
         <div class="bg-surface-elevated shadow-premium rounded-3xl overflow-hidden border border-border">
             <div class="px-8 py-6 border-b border-border">
@@ -148,7 +160,7 @@ pub fn RequestsList(
                                                             class="text-action-danger-bg hover:text-action-danger-bg-hover font-bold flex items-center gap-1 transition-colors"
                                                             on:click=move |ev| {
                                                                 ev.stop_propagation();
-                                                                on_cancel.call(summary.get_value());
+                                                                pending_cancel_request.set(Some(summary.get_value()));
                                                             }
                                                         >
                                                             <i class="fas fa-times-circle text-xs"></i>
@@ -170,6 +182,15 @@ pub fn RequestsList(
                     </table>
                 </div>
             </Show>
+
+            <ConfirmDialog
+                is_open=Signal::derive(move || pending_cancel_request.get().is_some())
+                title="申請取消の確認"
+                message="本当にこの申請を取り消しますか？"
+                on_confirm=confirm_cancel_request
+                on_cancel=dismiss_cancel_dialog
+                destructive=true
+            />
         </div>
     }
 }


### PR DESCRIPTION
## Summary
- add a shared `ConfirmDialog` component for destructive actions with modal semantics and default `はい/いいえ` choices
- apply confirm flow to request cancellation in `RequestsList` so cancel API is called only after explicit confirmation
- replace inline delete confirmation blocks in admin user drawers with the shared dialog for soft delete / hard delete and archived-user hard delete

## Testing
- cargo test -p timekeeper-frontend --lib confirm_dialog_renders_with_default_labels -- --nocapture
- cargo test -p timekeeper-frontend --lib requests_list_renders_rows -- --nocapture
- cargo test -p timekeeper-frontend --lib user_detail_drawer_renders -- --nocapture
- cargo test -p timekeeper-frontend --lib archived_detail_drawer_renders -- --nocapture

Closes #366
