### PR TITLE
fix: add role-based authorization guard for admin routes

### DIFF
--- a/frontend/src/components/guard.rs
+++ b/frontend/src/components/guard.rs
@@ -1,4 +1,4 @@
-use crate::{components::layout::LoadingSpinner, state::auth::use_auth};
+use crate::{api::UserResponse, components::layout::LoadingSpinner, state::auth::use_auth};
 use leptos::*;
 
 #[component]
@@ -35,9 +35,59 @@ fn should_render_children(is_authenticated: bool, is_loading: bool) -> bool {
     is_authenticated && !is_loading
 }
 
+#[component]
+pub fn RequireAdmin(children: ChildrenFn) -> impl IntoView {
+    let (auth, _) = use_auth();
+    let is_authenticated = create_memo(move |_| auth.get().is_authenticated);
+    let is_loading = create_memo(move |_| auth.get().loading);
+    let is_admin = create_memo(move |_| is_admin_user(auth.get().user.as_ref()));
+    create_effect(move |_| {
+        let state = auth.get();
+        if state.loading {
+            return;
+        }
+        let target = if !state.is_authenticated {
+            "/login"
+        } else if !is_admin_user(state.user.as_ref()) {
+            "/dashboard"
+        } else {
+            return;
+        };
+        if let Some(win) = web_sys::window() {
+            let _ = win.location().set_href(target);
+        }
+    });
+    view! {
+        <Show
+            when=move || {
+                should_render_admin_children(is_authenticated.get(), is_loading.get(), is_admin.get())
+            }
+            fallback=move || {
+                if is_loading.get() {
+                    view! { <LoadingSpinner /> }.into_view()
+                } else {
+                    ().into_view()
+                }
+            }
+        >
+            {children()}
+        </Show>
+    }
+}
+
+fn is_admin_user(user: Option<&UserResponse>) -> bool {
+    user.map(|u| u.is_system_admin || u.role.eq_ignore_ascii_case("admin"))
+        .unwrap_or(false)
+}
+
+fn should_render_admin_children(is_authenticated: bool, is_loading: bool, is_admin: bool) -> bool {
+    is_authenticated && is_admin && !is_loading
+}
+
 #[cfg(test)]
 mod tests {
-    use super::should_render_children;
+    use super::{is_admin_user, should_render_admin_children, should_render_children};
+    use crate::api::UserResponse;
 
     #[test]
     fn guard_blocks_until_authenticated() {
@@ -46,13 +96,55 @@ mod tests {
         assert!(!should_render_children(true, true));
         assert!(should_render_children(true, false));
     }
+
+    #[test]
+    fn admin_guard_requires_admin_role_or_system_admin() {
+        let regular = UserResponse {
+            id: "u1".into(),
+            username: "employee".into(),
+            full_name: "Employee".into(),
+            role: "employee".into(),
+            is_system_admin: false,
+            mfa_enabled: true,
+            is_locked: false,
+            locked_until: None,
+            failed_login_attempts: 0,
+        };
+        let admin = UserResponse {
+            role: "admin".into(),
+            ..regular.clone()
+        };
+        let mixed_case_admin = UserResponse {
+            role: "Admin".into(),
+            ..regular.clone()
+        };
+        let system_admin = UserResponse {
+            role: "employee".into(),
+            is_system_admin: true,
+            ..regular.clone()
+        };
+        assert!(!is_admin_user(None));
+        assert!(!is_admin_user(Some(&regular)));
+        assert!(is_admin_user(Some(&admin)));
+        assert!(is_admin_user(Some(&mixed_case_admin)));
+        assert!(is_admin_user(Some(&system_admin)));
+    }
+
+    #[test]
+    fn admin_guard_blocks_non_admins() {
+        assert!(!should_render_admin_children(false, true, false));
+        assert!(!should_render_admin_children(false, false, true));
+        assert!(!should_render_admin_children(true, true, true));
+        assert!(!should_render_admin_children(true, false, false));
+        assert!(should_render_admin_children(true, false, true));
+    }
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod host_tests {
-    use super::RequireAuth;
+    use super::{RequireAdmin, RequireAuth};
     use crate::state::auth::AuthState;
-    use crate::test_support::helpers::regular_user;
+    use crate::test_support::helpers::{admin_user, regular_user};
     use crate::test_support::ssr::render_to_string;
     use leptos::*;
 
@@ -106,5 +198,41 @@ mod host_tests {
             }
         });
         assert!(html.contains("animate-spin"));
+    }
+
+    #[test]
+    fn require_admin_renders_children_for_admin_user() {
+        let html = render_to_string(move || {
+            let (auth, set_auth) = create_signal(AuthState {
+                user: Some(admin_user(true)),
+                is_authenticated: true,
+                loading: false,
+            });
+            provide_context((auth, set_auth));
+            view! {
+                <RequireAdmin>
+                    {|| view! { <div>"admin-protected"</div> }}
+                </RequireAdmin>
+            }
+        });
+        assert!(html.contains("admin-protected"));
+    }
+
+    #[test]
+    fn require_admin_hides_children_for_regular_user() {
+        let html = render_to_string(move || {
+            let (auth, set_auth) = create_signal(AuthState {
+                user: Some(regular_user()),
+                is_authenticated: true,
+                loading: false,
+            });
+            provide_context((auth, set_auth));
+            view! {
+                <RequireAdmin>
+                    {|| view! { <div>"admin-protected"</div> }}
+                </RequireAdmin>
+            }
+        });
+        assert!(!html.contains("admin-protected"));
     }
 }

--- a/frontend/src/router.rs
+++ b/frontend/src/router.rs
@@ -2,7 +2,7 @@ use leptos::*;
 use leptos_router::*;
 
 use crate::{
-    components::guard::RequireAuth,
+    components::guard::{RequireAdmin, RequireAuth},
     pages::{
         admin::AdminPage, admin_audit_logs::AdminAuditLogsPage, admin_export::AdminExportPage,
         admin_users::AdminUsersPage, attendance::AttendancePage, dashboard::DashboardPage,
@@ -99,22 +99,22 @@ fn ProtectedSettings() -> impl IntoView {
 
 #[component]
 fn ProtectedAdmin() -> impl IntoView {
-    view! { <RequireAuth><AdminPage/></RequireAuth> }
+    view! { <RequireAdmin><AdminPage/></RequireAdmin> }
 }
 
 #[component]
 fn ProtectedAdminUsers() -> impl IntoView {
-    view! { <RequireAuth><AdminUsersPage/></RequireAuth> }
+    view! { <RequireAdmin><AdminUsersPage/></RequireAdmin> }
 }
 
 #[component]
 fn ProtectedAdminExport() -> impl IntoView {
-    view! { <RequireAuth><AdminExportPage/></RequireAuth> }
+    view! { <RequireAdmin><AdminExportPage/></RequireAdmin> }
 }
 
 #[component]
 fn ProtectedAdminAuditLogs() -> impl IntoView {
-    view! { <RequireAuth><AdminAuditLogsPage/></RequireAuth> }
+    view! { <RequireAdmin><AdminAuditLogsPage/></RequireAdmin> }
 }
 
 #[cfg(test)]
@@ -196,16 +196,18 @@ mod host_tests {
             }));
             provide_auth(Some(admin_user(true)));
             view! {
-                <div>
-                    <ProtectedDashboard />
-                    <ProtectedAttendance />
-                    <ProtectedRequests />
-                    <ProtectedSettings />
-                    <ProtectedAdmin />
-                    <ProtectedAdminUsers />
-                    <ProtectedAdminExport />
-                    <ProtectedAdminAuditLogs />
-                </div>
+                <Router>
+                    <div>
+                        <ProtectedDashboard />
+                        <ProtectedAttendance />
+                        <ProtectedRequests />
+                        <ProtectedSettings />
+                        <ProtectedAdmin />
+                        <ProtectedAdminUsers />
+                        <ProtectedAdminExport />
+                        <ProtectedAdminAuditLogs />
+                    </div>
+                </Router>
             }
         });
         assert!(!html.is_empty());


### PR DESCRIPTION
## Summary
- add a new `RequireAdmin` guard that checks both authentication and admin authorization (`role == "admin"` or `is_system_admin`)
- redirect unauthenticated access to `/login` and authenticated non-admin access to `/dashboard`
- wrap all `/admin/*` protected routes with `RequireAdmin` instead of `RequireAuth`
- add unit/host tests for admin authorization helper behavior and rendering guard behavior

## Testing
- cargo test -p timekeeper-frontend --lib guard_blocks_until_authenticated -- --nocapture
- cargo test -p timekeeper-frontend --lib admin_guard_blocks_non_admins -- --nocapture
- cargo test -p timekeeper-frontend --lib require_admin_hides_children_for_regular_user -- --nocapture
- cargo test -p timekeeper-frontend --lib protected_views_render_with_auth_context -- --nocapture

Closes #374
