### PR TITLE
fix: encode dynamic URL path segments in frontend API client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5124,6 +5124,7 @@ dependencies = [
  "leptos_reactive",
  "leptos_router",
  "log",
+ "percent-encoding",
  "qrcode",
  "reqwest",
  "serde",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -46,6 +46,7 @@ console_log = "1.0"
 log = "0.4"
 console_error_panic_hook = "0.1"
 qrcode = { version = "0.13", features = ["svg"] }
+percent-encoding = "2.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/frontend/src/api/attendance.rs
+++ b/frontend/src/api/attendance.rs
@@ -2,7 +2,7 @@ use chrono::NaiveDate;
 use serde_json::{json, Value};
 
 use super::{
-    client::ApiClient,
+    client::{encode_path_segment, ApiClient},
     types::{
         AdminAttendanceUpsert, ApiError, AttendanceResponse, AttendanceStatusResponse,
         AttendanceSummary, BreakRecordResponse,
@@ -273,11 +273,13 @@ impl ApiClient {
         break_id: &str,
     ) -> Result<BreakRecordResponse, ApiError> {
         let base_url = self.resolved_base_url().await;
+        let encoded_break_id = encode_path_segment(break_id);
         let response = self
             .send_with_refresh(|| {
-                Ok(self
-                    .http_client()
-                    .put(format!("{}/admin/breaks/{}/force-end", base_url, break_id)))
+                Ok(self.http_client().put(format!(
+                    "{}/admin/breaks/{}/force-end",
+                    base_url, encoded_break_id
+                )))
             })
             .await?;
         let status = response.status();

--- a/frontend/src/api/subject_requests.rs
+++ b/frontend/src/api/subject_requests.rs
@@ -1,7 +1,7 @@
 use serde_json::json;
 
 use super::{
-    client::ApiClient,
+    client::{encode_path_segment, ApiClient},
     types::{
         ApiError, CreateDataSubjectRequest, DataSubjectRequestResponse, SubjectRequestListResponse,
     },
@@ -40,11 +40,12 @@ impl ApiClient {
 
     pub async fn cancel_subject_request(&self, id: &str) -> Result<(), ApiError> {
         let base_url = self.resolved_base_url().await;
+        let encoded_id = encode_path_segment(id);
         let response = self
             .send_with_refresh(|| {
                 Ok(self
                     .http_client()
-                    .delete(format!("{}/subject-requests/{}", base_url, id)))
+                    .delete(format!("{}/subject-requests/{}", base_url, encoded_id)))
             })
             .await?;
         map_empty_response(response).await
@@ -127,13 +128,15 @@ impl ApiClient {
         comment: &str,
     ) -> Result<(), ApiError> {
         let base_url = self.resolved_base_url().await;
+        let encoded_id = encode_path_segment(id);
+        let encoded_action = encode_path_segment(action);
         let response = self
             .send_with_refresh(|| {
                 Ok(self
                     .http_client()
                     .put(format!(
                         "{}/admin/subject-requests/{}/{}",
-                        base_url, id, action
+                        base_url, encoded_id, encoded_action
                     ))
                     .json(&json!({ "comment": comment })))
             })

--- a/frontend/src/api/tests.rs
+++ b/frontend/src/api/tests.rs
@@ -609,6 +609,33 @@ async fn api_client_subject_request_and_audit_log_endpoints_succeed() {
 }
 
 #[tokio::test]
+async fn api_client_encodes_dynamic_path_segments_for_breaks_and_subject_requests() {
+    let server = MockServer::start_async().await;
+
+    server.mock(|when, then| {
+        when.method(PUT).path("/api/admin/breaks/br%2F1/force-end");
+        then.status(200).json_body(break_record_json("br/1"));
+    });
+    server.mock(|when, then| {
+        when.method(DELETE).path("/api/subject-requests/sr%2F1");
+        then.status(200).json_body(json!({}));
+    });
+    server.mock(|when, then| {
+        when.method(PUT)
+            .path("/api/admin/subject-requests/sr%2F1/approve");
+        then.status(200).json_body(json!({}));
+    });
+
+    let client = api_client(&server);
+    client.admin_force_end_break("br/1").await.unwrap();
+    client.cancel_subject_request("sr/1").await.unwrap();
+    client
+        .admin_approve_subject_request("sr/1", "ok")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
 async fn api_client_auth_login_and_refresh_use_test_overrides() {
     let server = MockServer::start_async().await;
 


### PR DESCRIPTION
## Summary
- add `encode_path_segment` helper in `frontend/src/api/client.rs` using `percent-encoding`
- apply path-segment encoding before URL interpolation for dynamic IDs in admin API methods (`users`, `archived-users`, `holidays`, `weekly holidays`)
- apply path-segment encoding in request APIs for dynamic `id` and `action` values (`admin_mutate_request`, update/cancel request, attendance-corrections update/cancel)
- add unit test to verify delimiter escaping behavior (`/` and `?`)

## Testing
- cargo test -p timekeeper-frontend --lib admin_request_params_includes_filters -- --nocapture
- cargo test -p timekeeper-frontend --lib encode_path_segment_escapes_path_delimiters -- --nocapture

Closes #375
