### PR TITLE
refactor: make request update payloads type-safe

### DIFF
--- a/docs/generated/exec-plans/active/EP-20260310-pr393-type-safe-request-updates.md
+++ b/docs/generated/exec-plans/active/EP-20260310-pr393-type-safe-request-updates.md
@@ -1,0 +1,40 @@
+# EP-20260310-pr393-type-safe-request-updates
+
+## Goal
+- PR #393 の request update payload 型安全化を current `main` に整合する形で取り込み、無関係差分なしで merge する
+
+## Scope
+- In: `frontend/src/api/*`, `frontend/src/pages/requests/*`, 関連 frontend host tests
+- Out: backend 変更、request create/cancel の仕様変更、path encoding の巻き戻し
+
+## Done Criteria (Observable)
+- [x] leave/overtime 更新 API が `Value` ではなく専用型で呼ばれる
+- [x] `frontend` の request repository/view model/form が型付き update payload を使う
+- [x] current `main` の path segment encoding を維持したまま関連テストが成功する
+- [ ] PR #393 branch を push し、問題なければ merge する
+
+## Constraints / Non-goals
+- PR branch に混入している無関係変更は取り込まない
+- `frontend/src/api/requests.rs` の current `main` 挙動を壊さない
+
+## Task Breakdown
+1. [x] typed update payload を API 層へ追加し、encoded path を維持した update メソッドへ差し替える
+2. [x] repository / view model / form を typed payload ベースへ更新する
+3. [x] API / repository / view model テストを更新して leave と overtime の update 経路を確認する
+4. [ ] fmt と focused frontend tests を実行し、PR branch へ push して merge する
+
+## Validation Plan
+- [x] `cargo test -p timekeeper-frontend --lib requests_repository_calls_api -- --nocapture`
+- [x] `cargo test -p timekeeper-frontend --lib requests_view_model_actions_update_messages -- --nocapture`
+- [x] `cargo test -p timekeeper-frontend --lib api_client_attendance_and_requests_endpoints_succeed -- --nocapture`
+- [x] `cargo fmt --all`
+- [x] `cargo clippy -p timekeeper-frontend --all-targets -- -D warnings` は既存の [`frontend/src/components/layout.rs`](/home/mrabbit/Documents/timekeeper/frontend/src/components/layout.rs) の unused import で失敗することを確認
+
+## JJ Snapshot Log
+- [x] `jj status`
+- [x] frontend focused tests pass
+- [ ] `jj commit -m "refactor: make request update payloads type-safe"`
+
+## Progress Notes
+- 2026-03-10: 計画作成。PR #393 の古い branch 差分を current `main` に clean に移植する方針を確定。
+- 2026-03-10: `UpdateLeaveRequest` / `UpdateOvertimeRequest` を API, repository, view model, forms に導入。focused frontend tests と `cargo fmt --all` は成功。`cargo clippy -p timekeeper-frontend --all-targets -- -D warnings` は既存の `frontend/src/components/layout.rs` unused import で失敗。

--- a/frontend/src/api/requests.rs
+++ b/frontend/src/api/requests.rs
@@ -5,6 +5,7 @@ use super::{
     types::{
         ApiError, CreateAttendanceCorrectionRequest, CreateLeaveRequest, CreateOvertimeRequest,
         LeaveRequestResponse, OvertimeRequestResponse, UpdateAttendanceCorrectionRequest,
+        UpdateLeaveRequest, UpdateOvertimeRequest,
     },
 };
 
@@ -85,7 +86,26 @@ impl ApiClient {
         self.map_json_response(response).await
     }
 
-    pub async fn update_request(&self, id: &str, payload: Value) -> Result<Value, ApiError> {
+    pub async fn update_leave_request(
+        &self,
+        id: &str,
+        payload: UpdateLeaveRequest,
+    ) -> Result<Value, ApiError> {
+        self.update_request_payload(id, payload).await
+    }
+
+    pub async fn update_overtime_request(
+        &self,
+        id: &str,
+        payload: UpdateOvertimeRequest,
+    ) -> Result<Value, ApiError> {
+        self.update_request_payload(id, payload).await
+    }
+
+    async fn update_request_payload<T>(&self, id: &str, payload: T) -> Result<Value, ApiError>
+    where
+        T: serde::Serialize,
+    {
         let base_url = self.resolved_base_url().await;
         let encoded_id = encode_path_segment(id);
         let response = self

--- a/frontend/src/api/tests.rs
+++ b/frontend/src/api/tests.rs
@@ -491,7 +491,26 @@ async fn api_client_attendance_and_requests_endpoints_succeed() {
     client.admin_approve_request("req-1", "ok").await.unwrap();
     client.admin_reject_request("req-1", "no").await.unwrap();
     client
-        .update_request("req-1", json!({ "status": "updated" }))
+        .update_leave_request(
+            "req-1",
+            UpdateLeaveRequest {
+                leave_type: "annual".into(),
+                start_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 10).unwrap(),
+                end_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 12).unwrap(),
+                reason: Some("updated".into()),
+            },
+        )
+        .await
+        .unwrap();
+    client
+        .update_overtime_request(
+            "req-1",
+            UpdateOvertimeRequest {
+                date: chrono::NaiveDate::from_ymd_opt(2025, 1, 11).unwrap(),
+                planned_hours: 2.5,
+                reason: Some("updated".into()),
+            },
+        )
         .await
         .unwrap();
     client.cancel_request("req-1").await.unwrap();

--- a/frontend/src/api/types.rs
+++ b/frontend/src/api/types.rs
@@ -183,6 +183,14 @@ pub struct CreateLeaveRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateLeaveRequest {
+    pub leave_type: String,
+    pub start_date: NaiveDate,
+    pub end_date: NaiveDate,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LeaveRequestResponse {
     pub id: String,
     pub user_id: String,
@@ -202,6 +210,13 @@ pub struct LeaveRequestResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateOvertimeRequest {
+    pub date: NaiveDate,
+    pub planned_hours: f64,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateOvertimeRequest {
     pub date: NaiveDate,
     pub planned_hours: f64,
     pub reason: Option<String>,

--- a/frontend/src/pages/requests/components/leave_form.rs
+++ b/frontend/src/pages/requests/components/leave_form.rs
@@ -1,4 +1,4 @@
-use crate::api::{ApiError, CreateLeaveRequest};
+use crate::api::{ApiError, CreateLeaveRequest, UpdateLeaveRequest};
 use crate::components::error::InlineErrorMessage;
 use crate::components::forms::DatePicker;
 use crate::components::layout::SuccessMessage;
@@ -8,7 +8,6 @@ use crate::pages::requests::{
     view_model::EditPayload,
 };
 use leptos::*;
-use serde_json::to_value;
 
 #[component]
 pub fn LeaveRequestForm(
@@ -30,8 +29,18 @@ pub fn LeaveRequestForm(
                 Ok(payload) => {
                     message.update(|msg| msg.clear());
                     if let Some(target) = editing.get() {
-                        update_action
-                            .dispatch((target.id, to_value(payload).unwrap_or_default()).into());
+                        update_action.dispatch(
+                            (
+                                target.id,
+                                UpdateLeaveRequest {
+                                    leave_type: payload.leave_type,
+                                    start_date: payload.start_date,
+                                    end_date: payload.end_date,
+                                    reason: payload.reason,
+                                },
+                            )
+                                .into(),
+                        );
                     } else {
                         action.dispatch(payload);
                     }

--- a/frontend/src/pages/requests/components/overtime_form.rs
+++ b/frontend/src/pages/requests/components/overtime_form.rs
@@ -1,4 +1,4 @@
-use crate::api::{ApiError, CreateOvertimeRequest};
+use crate::api::{ApiError, CreateOvertimeRequest, UpdateOvertimeRequest};
 use crate::components::error::InlineErrorMessage;
 use crate::components::forms::DatePicker;
 use crate::components::layout::SuccessMessage;
@@ -8,7 +8,6 @@ use crate::pages::requests::{
     view_model::EditPayload,
 };
 use leptos::*;
-use serde_json::to_value;
 
 #[component]
 pub fn OvertimeRequestForm(
@@ -30,8 +29,17 @@ pub fn OvertimeRequestForm(
                 Ok(payload) => {
                     message.update(|msg| msg.clear());
                     if let Some(target) = editing.get() {
-                        update_action
-                            .dispatch((target.id, to_value(payload).unwrap_or_default()).into());
+                        update_action.dispatch(
+                            (
+                                target.id,
+                                UpdateOvertimeRequest {
+                                    date: payload.date,
+                                    planned_hours: payload.planned_hours,
+                                    reason: payload.reason,
+                                },
+                            )
+                                .into(),
+                        );
                     } else {
                         action.dispatch(payload);
                     }

--- a/frontend/src/pages/requests/repository.rs
+++ b/frontend/src/pages/requests/repository.rs
@@ -1,7 +1,7 @@
 use crate::api::{
     ApiClient, ApiError, CreateAttendanceCorrectionRequest, CreateLeaveRequest,
     CreateOvertimeRequest, LeaveRequestResponse, OvertimeRequestResponse,
-    UpdateAttendanceCorrectionRequest,
+    UpdateAttendanceCorrectionRequest, UpdateLeaveRequest, UpdateOvertimeRequest,
 };
 use serde_json::Value;
 use std::rc::Rc;
@@ -44,8 +44,26 @@ impl RequestsRepository {
             .map(|_| ())
     }
 
-    pub async fn update_request(&self, id: &str, payload: Value) -> Result<(), ApiError> {
-        self.client.update_request(id, payload).await.map(|_| ())
+    pub async fn update_leave(
+        &self,
+        id: &str,
+        payload: UpdateLeaveRequest,
+    ) -> Result<(), ApiError> {
+        self.client
+            .update_leave_request(id, payload)
+            .await
+            .map(|_| ())
+    }
+
+    pub async fn update_overtime(
+        &self,
+        id: &str,
+        payload: UpdateOvertimeRequest,
+    ) -> Result<(), ApiError> {
+        self.client
+            .update_overtime_request(id, payload)
+            .await
+            .map(|_| ())
     }
 
     pub async fn cancel_request(&self, id: &str) -> Result<(), ApiError> {
@@ -161,9 +179,27 @@ mod host_tests {
         })
         .await
         .unwrap();
-        repo.update_request("req-1", serde_json::json!({ "status": "updated" }))
-            .await
-            .unwrap();
+        repo.update_leave(
+            "req-1",
+            UpdateLeaveRequest {
+                leave_type: "annual".into(),
+                start_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 10).unwrap(),
+                end_date: chrono::NaiveDate::from_ymd_opt(2025, 1, 12).unwrap(),
+                reason: Some("updated".into()),
+            },
+        )
+        .await
+        .unwrap();
+        repo.update_overtime(
+            "req-1",
+            UpdateOvertimeRequest {
+                date: chrono::NaiveDate::from_ymd_opt(2025, 1, 11).unwrap(),
+                planned_hours: 2.5,
+                reason: Some("updated".into()),
+            },
+        )
+        .await
+        .unwrap();
         repo.cancel_request("req-1").await.unwrap();
         repo.list_my_requests().await.unwrap();
     }

--- a/frontend/src/pages/requests/view_model.rs
+++ b/frontend/src/pages/requests/view_model.rs
@@ -1,6 +1,7 @@
 use crate::api::{
     ApiClient, ApiError, CreateAttendanceCorrectionRequest, CreateLeaveRequest,
-    CreateOvertimeRequest, UpdateAttendanceCorrectionRequest,
+    CreateOvertimeRequest, UpdateAttendanceCorrectionRequest, UpdateLeaveRequest,
+    UpdateOvertimeRequest,
 };
 use crate::pages::requests::types::MyRequestsResponse;
 use crate::pages::requests::{
@@ -45,9 +46,15 @@ pub enum RequestFormKind {
 }
 
 #[derive(Clone)]
-pub struct EditPayload {
-    pub id: String,
-    pub body: serde_json::Value,
+pub enum EditPayload {
+    Leave {
+        id: String,
+        payload: UpdateLeaveRequest,
+    },
+    Overtime {
+        id: String,
+        payload: UpdateOvertimeRequest,
+    },
 }
 
 #[derive(Clone)]
@@ -65,11 +72,20 @@ impl From<(String, UpdateAttendanceCorrectionRequest)> for AttendanceCorrectionE
     }
 }
 
-impl From<(String, serde_json::Value)> for EditPayload {
-    fn from(value: (String, serde_json::Value)) -> Self {
-        Self {
+impl From<(String, UpdateLeaveRequest)> for EditPayload {
+    fn from(value: (String, UpdateLeaveRequest)) -> Self {
+        Self::Leave {
             id: value.0,
-            body: value.1,
+            payload: value.1,
+        }
+    }
+}
+
+impl From<(String, UpdateOvertimeRequest)> for EditPayload {
+    fn from(value: (String, UpdateOvertimeRequest)) -> Self {
+        Self::Overtime {
+            id: value.0,
+            payload: value.1,
         }
     }
 }
@@ -258,7 +274,14 @@ impl RequestsViewModel {
         let update_action = create_action(move |payload: &EditPayload| {
             let repo = repository.get_value();
             let payload = payload.clone();
-            async move { repo.update_request(&payload.id, payload.body.clone()).await }
+            async move {
+                match payload {
+                    EditPayload::Leave { id, payload } => repo.update_leave(&id, payload).await,
+                    EditPayload::Overtime { id, payload } => {
+                        repo.update_overtime(&id, payload).await
+                    }
+                }
+            }
         });
 
         let correction_update_action =
@@ -656,7 +679,12 @@ mod host_tests {
             }));
             vm.update_action.dispatch(EditPayload::from((
                 "req-1".to_string(),
-                json!({ "status": "updated" }),
+                UpdateLeaveRequest {
+                    leave_type: "annual".into(),
+                    start_date: NaiveDate::from_ymd_opt(2025, 1, 10).unwrap(),
+                    end_date: NaiveDate::from_ymd_opt(2025, 1, 12).unwrap(),
+                    reason: Some("updated".into()),
+                },
             )));
             assert!(
                 wait_until(|| vm.update_action.value().get().is_some()).await,
@@ -665,6 +693,24 @@ mod host_tests {
             assert!(matches!(vm.update_action.value().get(), Some(Ok(()))));
             let _ = vm.editing_request.get();
             let _ = vm.list_message.get();
+
+            vm.editing_request.set(Some(EditTarget {
+                id: "req-1".into(),
+                kind: crate::pages::requests::types::RequestKind::Overtime,
+            }));
+            vm.update_action.dispatch(EditPayload::from((
+                "req-1".to_string(),
+                UpdateOvertimeRequest {
+                    date: NaiveDate::from_ymd_opt(2025, 1, 11).unwrap(),
+                    planned_hours: 2.5,
+                    reason: Some("updated".into()),
+                },
+            )));
+            assert!(
+                wait_until(|| vm.update_action.value().get().is_some()).await,
+                "overtime update action should complete"
+            );
+            assert!(matches!(vm.update_action.value().get(), Some(Ok(()))));
 
             vm.editing_request.set(Some(EditTarget {
                 id: "corr-1".into(),


### PR DESCRIPTION
## Summary
- add typed update payloads `UpdateLeaveRequest` and `UpdateOvertimeRequest` in `frontend/src/api/types.rs`
- replace untyped `update_request(id, Value)` API with typed methods:
  - `update_leave_request(id, UpdateLeaveRequest)`
  - `update_overtime_request(id, UpdateOvertimeRequest)`
- update requests repository and view model edit flow to dispatch typed payload variants instead of arbitrary JSON
- update leave/overtime form edit submission paths to construct typed update payloads directly
- adjust API and repository tests to use typed update requests

## Testing
- cargo test -p timekeeper-frontend --lib requests_repository_calls_api -- --nocapture
- cargo test -p timekeeper-frontend --lib requests_view_model_actions_update_messages -- --nocapture
- cargo test -p timekeeper-frontend --lib api_client_attendance_and_requests_endpoints_succeed -- --nocapture

Closes #376
