### PR TITLE
refactor(frontend): unify pii masked header parser

### DIFF
--- a/frontend/src/api/audit_log.rs
+++ b/frontend/src/api/audit_log.rs
@@ -46,15 +46,6 @@ fn audit_log_params(
 }
 
 impl ApiClient {
-    fn pii_masked_from_response(response: &reqwest::Response) -> bool {
-        response
-            .headers()
-            .get("X-PII-Masked")
-            .and_then(|value| value.to_str().ok())
-            .map(|value| value.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
-    }
-
     pub async fn list_audit_logs(
         &self,
         page: i64,
@@ -101,7 +92,7 @@ impl ApiClient {
             .await?;
 
         let status = response.status();
-        let pii_masked = Self::pii_masked_from_response(&response);
+        let pii_masked = Self::parse_pii_masked_header(response.headers());
         Self::handle_unauthorized_status(status);
         if status.is_success() {
             let data = response
@@ -152,7 +143,7 @@ impl ApiClient {
             .await?;
 
         let status = response.status();
-        let pii_masked = Self::pii_masked_from_response(&response);
+        let pii_masked = Self::parse_pii_masked_header(response.headers());
         Self::handle_unauthorized_status(status);
         if status.is_success() {
             let data = response

--- a/frontend/src/api/client.rs
+++ b/frontend/src/api/client.rs
@@ -102,7 +102,7 @@ impl ApiClient {
         "セッションが期限切れです。再度ログインしてください。";
     const SESSION_EXPIRED_CODE: &'static str = "SESSION_EXPIRED";
 
-    fn parse_pii_masked_header(headers: &reqwest::header::HeaderMap) -> bool {
+    pub(super) fn parse_pii_masked_header(headers: &reqwest::header::HeaderMap) -> bool {
         headers
             .get("X-PII-Masked")
             .and_then(|value| value.to_str().ok())

--- a/frontend/src/api/tests.rs
+++ b/frontend/src/api/tests.rs
@@ -654,6 +654,19 @@ async fn api_client_encodes_dynamic_path_segments_for_breaks_and_subject_request
         .unwrap();
 }
 
+#[test]
+fn api_client_audit_log_with_policy_reads_pii_masked_header() {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert("X-PII-Masked", "TRUE".parse().unwrap());
+    assert!(ApiClient::parse_pii_masked_header(&headers));
+
+    headers.insert("X-PII-Masked", "false".parse().unwrap());
+    assert!(!ApiClient::parse_pii_masked_header(&headers));
+
+    headers.remove("X-PII-Masked");
+    assert!(!ApiClient::parse_pii_masked_header(&headers));
+}
+
 #[tokio::test]
 async fn api_client_auth_login_and_refresh_use_test_overrides() {
     let server = MockServer::start_async().await;


### PR DESCRIPTION
## Summary
- remove duplicated X-PII-Masked parsing from audit_log API methods
- reuse ApiClient::parse_pii_masked_header from client.rs for audit log list/export policy responses
- add a regression test that validates the shared parser behavior

## Testing
- cargo test -p timekeeper-frontend api_client_

Closes #380