### PR TITLE
fix(frontend): sanitize error payload parse failures

### DIFF
--- a/frontend/src/api/attendance.rs
+++ b/frontend/src/api/attendance.rs
@@ -62,7 +62,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -89,7 +89,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -115,7 +115,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -141,7 +141,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -176,7 +176,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -209,7 +209,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -234,7 +234,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -263,7 +263,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -293,7 +293,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -328,7 +328,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -374,7 +374,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }

--- a/frontend/src/api/audit_log.rs
+++ b/frontend/src/api/audit_log.rs
@@ -104,7 +104,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -155,7 +155,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }

--- a/frontend/src/api/auth.rs
+++ b/frontend/src/api/auth.rs
@@ -29,7 +29,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -67,7 +67,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -116,7 +116,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -143,7 +143,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -167,7 +167,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -196,7 +196,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }

--- a/frontend/src/api/client.rs
+++ b/frontend/src/api/client.rs
@@ -101,6 +101,7 @@ impl ApiClient {
     const SESSION_EXPIRED_ERROR: &'static str =
         "セッションが期限切れです。再度ログインしてください。";
     const SESSION_EXPIRED_CODE: &'static str = "SESSION_EXPIRED";
+    const GENERIC_SERVER_ERROR: &'static str = "サーバーエラーが発生しました。";
 
     pub(super) fn parse_pii_masked_header(headers: &reqwest::header::HeaderMap) -> bool {
         headers
@@ -108,6 +109,11 @@ impl ApiClient {
             .and_then(|value| value.to_str().ok())
             .map(|value| value.eq_ignore_ascii_case("true"))
             .unwrap_or(false)
+    }
+
+    pub(super) fn map_error_payload_parse_failure(error: reqwest::Error) -> ApiError {
+        log::error!("Failed to parse error response payload: {}", error);
+        ApiError::unknown(Self::GENERIC_SERVER_ERROR)
     }
 
     pub fn new() -> Self {
@@ -276,7 +282,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -308,7 +314,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -335,7 +341,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -358,7 +364,7 @@ impl ApiClient {
             let error: ApiError = resp
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -386,7 +392,7 @@ impl ApiClient {
             let error: ApiError = resp
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -410,7 +416,7 @@ impl ApiClient {
             let error: ApiError = resp
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -435,7 +441,7 @@ impl ApiClient {
             let error: ApiError = resp
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -460,7 +466,7 @@ impl ApiClient {
             let error: ApiError = resp
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -485,7 +491,7 @@ impl ApiClient {
             let error: ApiError = resp
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -529,7 +535,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -559,7 +565,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -583,7 +589,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -613,7 +619,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -644,7 +650,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -670,7 +676,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -700,7 +706,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -724,7 +730,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -758,7 +764,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -821,7 +827,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -847,7 +853,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -880,7 +886,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }

--- a/frontend/src/api/requests.rs
+++ b/frontend/src/api/requests.rs
@@ -223,7 +223,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }
@@ -248,7 +248,7 @@ impl ApiClient {
             let error: ApiError = response
                 .json()
                 .await
-                .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
             Err(error)
         }
     }

--- a/frontend/src/api/subject_requests.rs
+++ b/frontend/src/api/subject_requests.rs
@@ -160,7 +160,7 @@ where
         let error: ApiError = response
             .json()
             .await
-            .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+            .map_err(ApiClient::map_error_payload_parse_failure)?;
         Err(error)
     }
 }
@@ -174,7 +174,7 @@ async fn map_empty_response(response: reqwest::Response) -> Result<(), ApiError>
         let error: ApiError = response
             .json()
             .await
-            .map_err(|e| ApiError::unknown(format!("Failed to parse error: {}", e)))?;
+            .map_err(ApiClient::map_error_payload_parse_failure)?;
         Err(error)
     }
 }

--- a/frontend/src/api/tests.rs
+++ b/frontend/src/api/tests.rs
@@ -832,6 +832,21 @@ async fn api_client_login_surfaces_api_error_payload() {
 }
 
 #[tokio::test]
+async fn api_client_get_me_masks_parse_error_details() {
+    let server = MockServer::start_async().await;
+
+    server.mock(|when, then| {
+        when.method(GET).path("/api/auth/me");
+        then.status(500);
+    });
+
+    let client = api_client(&server);
+    let err = client.get_me().await.expect_err("get_me should fail");
+    assert_eq!(err.code, "UNKNOWN");
+    assert_eq!(err.error, "サーバーエラーが発生しました。");
+}
+
+#[tokio::test]
 async fn api_client_refresh_override_can_return_error() {
     let client = ApiClient::new_with_base_url("http://127.0.0.1:9/api");
     super::auth::queue_refresh_override(


### PR DESCRIPTION
## Summary
- add a shared ApiClient fallback mapper for error-payload parse failures
- replace raw "Failed to parse error: {details}" surfaces across API modules with a generic user-facing message
- log parse-failure details via log::error! for debugging without leaking internals to the UI
- add regression coverage for non-JSON error response handling on get_me

## Testing
- cargo test -p timekeeper-frontend api_client_

Closes #381