### PR TITLE
refactor(ui): unify card radius and shadow styles

### DIFF
--- a/frontend/src/pages/attendance/components/history.rs
+++ b/frontend/src/pages/attendance/components/history.rs
@@ -17,7 +17,7 @@ pub fn HistorySection(
     error: Signal<Option<crate::api::ApiError>>,
 ) -> impl IntoView {
     view! {
-        <div class="bg-surface-elevated shadow-premium rounded-3xl overflow-hidden border border-border">
+        <div class="bg-surface-elevated rounded-2xl shadow-sm overflow-hidden border border-border">
             <div class="px-6 py-4 border-b border-border flex items-center justify-between">
                 <h3 class="text-lg font-display font-bold text-fg">{"勤怠履歴"}</h3>
                 <Show when=move || loading.get()>

--- a/frontend/src/pages/dashboard/components/activities.rs
+++ b/frontend/src/pages/dashboard/components/activities.rs
@@ -13,9 +13,9 @@ pub fn ActivitiesSection(
     >,
 ) -> impl IntoView {
     view! {
-        <div class="bg-surface-elevated shadow rounded-lg p-6 space-y-4">
+        <div class="bg-surface-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4">
             <div>
-                <h3 class="text-base font-semibold text-fg">{"申請・活動のサマリー"}</h3>
+                <h3 class="text-base font-display font-bold text-fg">{"申請・活動のサマリー"}</h3>
                 <p class="text-sm text-fg-muted">{"承認待ちの申請数や最新の状態を確認できます"}</p>
             </div>
             {move || match activities.get() {

--- a/frontend/src/pages/dashboard/components/alerts.rs
+++ b/frontend/src/pages/dashboard/components/alerts.rs
@@ -13,9 +13,9 @@ type AlertsResource = Resource<
 #[component]
 pub fn AlertsSection(alerts: AlertsResource) -> impl IntoView {
     view! {
-        <div class="bg-surface-elevated shadow rounded-lg p-6 space-y-4">
+        <div class="bg-surface-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4">
             <div class="flex flex-col gap-2">
-                <h3 class="text-base font-semibold text-fg">{"アラート"}</h3>
+                <h3 class="text-base font-display font-bold text-fg">{"アラート"}</h3>
                 <p class="text-sm text-fg-muted">{"勤務や申請に関する注意事項"}</p>
             </div>
             {move || match alerts.get() {

--- a/frontend/src/pages/dashboard/components/summary.rs
+++ b/frontend/src/pages/dashboard/components/summary.rs
@@ -13,9 +13,9 @@ pub fn SummarySection(
     summary: Resource<(), Result<DashboardSummary, crate::api::ApiError>>,
 ) -> impl IntoView {
     view! {
-        <div class="bg-surface-elevated shadow rounded-lg p-6 space-y-4">
+        <div class="bg-surface-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4">
             <div>
-                <h3 class="text-base font-semibold text-fg">{"勤務サマリー"}</h3>
+                <h3 class="text-base font-display font-bold text-fg">{"勤務サマリー"}</h3>
                 <p class="text-sm text-fg-muted">{"今月の勤務時間と日数のスナップショット"}</p>
             </div>
             <div>

--- a/frontend/src/pages/requests/components/leave_form.rs
+++ b/frontend/src/pages/requests/components/leave_form.rs
@@ -57,9 +57,9 @@ pub fn LeaveRequestForm(
     let end_signal = state.end_signal();
     let reason_signal = state.reason_signal();
     view! {
-        <div class="bg-surface-elevated shadow rounded-lg p-6 space-y-4">
+        <div class="bg-surface-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4">
             <div>
-                <h3 class="text-lg font-medium text-fg">{"休暇申請"}</h3>
+                <h3 class="text-lg font-display font-bold text-fg">{"休暇申請"}</h3>
                 <p class="text-sm text-fg-muted">{"休暇の種類と期間を入力して申請を送信します。"} </p>
                 <Show
                     when=move || {

--- a/frontend/src/pages/requests/components/list.rs
+++ b/frontend/src/pages/requests/components/list.rs
@@ -30,7 +30,7 @@ pub fn RequestsList(
     let dismiss_cancel_dialog = Callback::new(move |_| pending_cancel_request.set(None));
 
     view! {
-        <div class="bg-surface-elevated shadow-premium rounded-3xl overflow-hidden border border-border">
+        <div class="bg-surface-elevated rounded-2xl shadow-sm overflow-hidden border border-border">
             <div class="px-8 py-6 border-b border-border">
                 <h3 class="text-xl font-display font-bold text-fg">{"申請一覧"}</h3>
                 <Show when=move || message.get().error.is_some()>

--- a/frontend/src/pages/settings/panel.rs
+++ b/frontend/src/pages/settings/panel.rs
@@ -559,8 +559,8 @@ pub fn SettingsPage() -> impl IntoView {
             <div class="mx-auto max-w-3xl space-y-8">
 
                 // --- Password Change Section ---
-                <div class="bg-surface-elevated shadow rounded-lg p-6 space-y-4">
-                    <h2 class="text-xl font-semibold text-fg border-b border-border pb-2">"パスワード変更"</h2>
+                <div class="bg-surface-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4">
+                    <h2 class="text-xl font-display font-bold text-fg border-b border-border pb-2">"パスワード変更"</h2>
 
                     <Show when=move || password_success_msg.get().is_some() fallback=|| ()>
                         <SuccessMessage message={password_success_msg.get().unwrap_or_default()} />
@@ -636,8 +636,8 @@ pub fn SettingsPage() -> impl IntoView {
                 </div>
 
                 // --- Subject Request Section ---
-                <div class="bg-surface-elevated shadow rounded-lg p-6 space-y-4">
-                    <h2 class="text-xl font-semibold text-fg border-b border-border pb-2">"本人対応申請"</h2>
+                <div class="bg-surface-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4">
+                    <h2 class="text-xl font-display font-bold text-fg border-b border-border pb-2">"本人対応申請"</h2>
                     <Show when=move || subject_success_msg.get().is_some() fallback=|| ()>
                         <SuccessMessage message={subject_success_msg.get().unwrap_or_default()} />
                     </Show>


### PR DESCRIPTION
## Summary
- standardize dashboard, attendance, requests, and settings section containers to rounded-2xl shadow-sm border border-border
- keep premium metric cards as-is while aligning surrounding sections for consistent hierarchy
- unify section header typography across updated sections to font-display font-bold
- apply the same visual token set to HistorySection and RequestsList wrappers

## Testing
- cargo fmt --all
- cargo test -p timekeeper-frontend summary_section_renders
- cargo test -p timekeeper-frontend alerts_section_renders
- cargo test -p timekeeper-frontend activities_section_renders
- cargo test -p timekeeper-frontend history_section_renders
- cargo test -p timekeeper-frontend requests_list_renders
- cargo test -p timekeeper-frontend leave_request_form_renders_editing_state
- cargo test -p timekeeper-frontend settings::panel::

Closes #367