### PR TITLE
fix(i18n): localize dashboard alert and export labels

### DIFF
--- a/frontend/src/pages/admin_export/panel.rs
+++ b/frontend/src/pages/admin_export/panel.rs
@@ -160,11 +160,11 @@ fn AdminExportPanel() -> impl IntoView {
                         </div>
                     </div>
                     <DatePicker
-                        label=Some("From")
+                        label=Some("開始日")
                         value=vm.from_date
                     />
                     <DatePicker
-                        label=Some("To")
+                        label=Some("終了日")
                         value=vm.to_date
                     />
                 </div>
@@ -233,5 +233,7 @@ mod host_tests {
         });
         assert!(html.contains("データエクスポート"));
         assert!(html.contains("CSVをエクスポート"));
+        assert!(html.contains("開始日"));
+        assert!(html.contains("終了日"));
     }
 }

--- a/frontend/src/pages/dashboard/components/alerts.rs
+++ b/frontend/src/pages/dashboard/components/alerts.rs
@@ -53,9 +53,9 @@ pub fn AlertsSection(alerts: AlertsResource) -> impl IntoView {
 
 fn render_badge(level: &DashboardAlertLevel) -> View {
     let (color, text) = match level {
-        DashboardAlertLevel::Info => ("bg-status-info-bg text-status-info-text", "INFO"),
-        DashboardAlertLevel::Warning => ("bg-status-warning-bg text-status-warning-text", "WARN"),
-        DashboardAlertLevel::Error => ("bg-status-error-bg text-status-error-text", "ERROR"),
+        DashboardAlertLevel::Info => ("bg-status-info-bg text-status-info-text", "情報"),
+        DashboardAlertLevel::Warning => ("bg-status-warning-bg text-status-warning-text", "警告"),
+        DashboardAlertLevel::Error => ("bg-status-error-bg text-status-error-text", "エラー"),
     };
     view! {
         <span class=format!("px-2 py-0.5 rounded-full text-xs font-semibold {}", color)>
@@ -92,7 +92,7 @@ mod host_tests {
         });
         assert!(html.contains("アラート"));
         assert!(html.contains("注意"));
-        assert!(html.contains("WARN"));
+        assert!(html.contains("警告"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- localize dashboard alert badge labels from INFO/WARN/ERROR to 情報/警告/エラー
- localize admin export date filter labels from From/To to 開始日/終了日
- update host tests to assert the Japanese labels

## Testing
- cargo fmt --all
- cargo test -p timekeeper-frontend alerts_section_renders
- cargo test -p timekeeper-frontend admin_export_page_renders_panel_for_admin

Closes #368