### PR TITLE
feat(ui): add mobile card views for requests and audit logs

### DIFF
--- a/frontend/src/pages/admin_audit_logs/panel.rs
+++ b/frontend/src/pages/admin_audit_logs/panel.rs
@@ -196,6 +196,86 @@ fn render_logs_content(
     }
 }
 
+fn render_log_card(log: AuditLog, selected_metadata: RwSignal<Option<serde_json::Value>>) -> View {
+    let occurred_at = log.occurred_at.format("%Y-%m-%d %H:%M:%S").to_string();
+    let actor = actor_label(log.actor_id);
+    let target = target_label(log.target_type, log.target_id);
+    let result_text = log.result;
+    let result_class = result_badge_class(&result_text);
+    let error_code_text = log.error_code.unwrap_or_default();
+    let has_error_code = !error_code_text.is_empty();
+    let metadata_payload = metadata_button_payload(log.metadata, 80);
+    let has_metadata = metadata_payload.is_some();
+    let metadata_display = metadata_payload
+        .as_ref()
+        .map(|(display, _)| display.clone())
+        .unwrap_or_default();
+    let metadata_value = store_value(
+        metadata_payload
+            .as_ref()
+            .map(|(_, metadata)| metadata.clone()),
+    );
+
+    view! {
+        <div class="rounded-xl border border-border bg-surface-elevated p-4 space-y-2">
+            <div class="flex items-center justify-between">
+                <span class="text-sm font-semibold text-fg">{log.event_type}</span>
+                <span class=result_class>{result_text}</span>
+            </div>
+            <div class="space-y-1 text-sm">
+                <div><span class="text-fg-muted">{"日時: "}</span><span class="text-fg">{occurred_at}</span></div>
+                <div><span class="text-fg-muted">{"ユーザー: "}</span><span class="text-fg">{actor}</span></div>
+                <div><span class="text-fg-muted">{"対象: "}</span><span class="text-fg">{target}</span></div>
+                <div><span class="text-fg-muted">{"リクエストID: "}</span><span class="text-fg">{log.request_id.unwrap_or_else(|| "-".to_string())}</span></div>
+                <Show when=move || has_error_code>
+                    <div><span class="text-fg-muted">{"エラー: "}</span><span class="text-status-error-text">{error_code_text.clone()}</span></div>
+                </Show>
+                <Show when=move || has_metadata>
+                    <div>
+                        <span class="text-fg-muted">{"詳細: "}</span>
+                        <button
+                            class="text-link hover:text-link-hover hover:underline text-left font-mono text-xs"
+                            on:click=move |_| selected_metadata.set(metadata_value.get_value())
+                        >
+                            {metadata_display.clone()}
+                        </button>
+                    </div>
+                </Show>
+            </div>
+        </div>
+    }
+    .into_view()
+}
+
+fn render_logs_mobile_content(
+    result: Result<AuditLogListResponse, ApiError>,
+    selected_metadata: RwSignal<Option<serde_json::Value>>,
+) -> View {
+    match result {
+        Ok(response) => {
+            if response.items.is_empty() {
+                view! {
+                    <EmptyState
+                        title="ログがありません"
+                        description="検索条件に一致する監査ログは見つかりませんでした。"
+                    />
+                }
+                .into_view()
+            } else {
+                view! {
+                    <div class="space-y-3">
+                        {response.items.into_iter().map(|log| render_log_card(log, selected_metadata)).collect_view()}
+                    </div>
+                }
+                .into_view()
+            }
+        }
+        Err(error) => {
+            view! { <div class="p-4 text-center text-status-error-text">{error}</div> }.into_view()
+        }
+    }
+}
+
 #[component]
 pub fn AdminAuditLogsPage() -> impl IntoView {
     let vm = use_audit_log_view_model();
@@ -361,7 +441,13 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
                         </div>
                     </div>
 
-                    <div class="bg-surface-elevated shadow overflow-hidden sm:rounded-lg overflow-x-auto">
+                    <div class="space-y-3 lg:hidden">
+                        <Suspense fallback=move || view! { <div class="p-4 text-center">"読み込み中..."</div> }>
+                            {move || vm.logs_resource.get().map(|res| render_logs_mobile_content(res, selected_metadata))}
+                        </Suspense>
+                    </div>
+
+                    <div class="hidden lg:block bg-surface-elevated shadow overflow-hidden sm:rounded-lg overflow-x-auto">
                         <table class="min-w-full divide-y divide-border">
                             <thead class="bg-surface-muted">
                                 <tr>
@@ -687,5 +773,29 @@ mod host_tests {
 
         let error_html = render_logs_html(Err(ApiError::unknown("fetch failed")));
         assert!(error_html.contains("fetch failed"));
+    }
+
+    #[test]
+    fn render_logs_mobile_content_renders_cards() {
+        let html = with_runtime(|| {
+            let selected_metadata = create_rw_signal(None::<serde_json::Value>);
+            render_logs_mobile_content(
+                Ok(sample_log_response(
+                    vec![sample_audit_log(
+                        Some("admin-1"),
+                        "success",
+                        None,
+                        Some(serde_json::json!({"key":"value"})),
+                    )],
+                    1,
+                    20,
+                )),
+                selected_metadata,
+            )
+            .render_to_string()
+            .to_string()
+        });
+        assert!(html.contains("リクエストID"));
+        assert!(html.contains("admin-1"));
     }
 }

--- a/frontend/src/pages/requests/components/list.rs
+++ b/frontend/src/pages/requests/components/list.rs
@@ -68,7 +68,88 @@ pub fn RequestsList(
             </Show>
 
             <Show when=move || !summaries.get().is_empty()>
-                <div class="overflow-x-auto">
+                <div class="space-y-3 p-4 lg:hidden">
+                    <For
+                        each=move || summaries.get()
+                        key=|summary| summary.id.clone()
+                        children=move |summary: RequestSummary| {
+                            let summary = store_value(summary);
+                            let summary_value = summary.get_value();
+                            let status = summary_value.status.clone();
+                            let status_for_pending = status.clone();
+                            let status_for_not_pending = status.clone();
+                            let status_label = request_status_label(&status);
+                            let primary_label =
+                                summary_value.primary_label.clone().unwrap_or_else(|| "-".into());
+                            let secondary_label =
+                                summary_value.secondary_label.clone().unwrap_or_else(|| "-".into());
+                            let submitted_at =
+                                summary_value.submitted_at.clone().unwrap_or_else(|| "-".into());
+
+                            let status_style = match status.as_str() {
+                                "approved" => "bg-status-success-bg text-status-success-text",
+                                "rejected" => "bg-status-error-bg text-status-error-text",
+                                "pending" => "bg-status-warning-bg text-status-warning-text",
+                                _ => "bg-status-neutral-bg text-status-neutral-text",
+                            };
+
+                            view! {
+                                <div class="rounded-xl border border-border bg-surface-elevated p-4 space-y-3">
+                                    <div class="flex items-center justify-between">
+                                        <span class="inline-flex items-center px-2 py-0.5 rounded-md text-[10px] font-bold bg-status-neutral-bg text-status-neutral-text uppercase">
+                                            {match summary_value.kind {
+                                                RequestKind::Leave => "休暇",
+                                                RequestKind::Overtime => "残業",
+                                                RequestKind::AttendanceCorrection => "勤怠修正",
+                                            }}
+                                        </span>
+                                        <span class=format!("inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-black uppercase tracking-wider {}", status_style)>
+                                            {status_label.clone()}
+                                        </span>
+                                    </div>
+                                    <div class="grid grid-cols-1 gap-2 text-sm">
+                                        <div><span class="text-fg-muted">{"申請ID: "}</span><span class="text-fg">{summary_value.id.clone()}</span></div>
+                                        <div><span class="text-fg-muted">{"期間 / 日付: "}</span><span class="text-fg font-bold">{primary_label.clone()}</span></div>
+                                        <div><span class="text-fg-muted">{"補足: "}</span><span class="text-fg">{secondary_label.clone()}</span></div>
+                                        <div><span class="text-fg-muted">{"提出日: "}</span><span class="text-fg">{submitted_at.clone()}</span></div>
+                                    </div>
+                                    <div class="pt-1 flex items-center justify-between">
+                                        <button
+                                            class="text-link hover:text-link-hover font-bold text-sm"
+                                            on:click=move |_| on_select.call(summary.get_value())
+                                        >
+                                            {"詳細"}
+                                        </button>
+                                        <Show when=move || status_for_pending == "pending">
+                                            <div class="flex gap-4">
+                                                <button
+                                                    class="text-link hover:text-link-hover font-bold flex items-center gap-1 transition-colors"
+                                                    on:click=move |_| on_edit.call(summary.get_value())
+                                                >
+                                                    <i class="fas fa-edit text-xs"></i>
+                                                    {"編集"}
+                                                </button>
+                                                <button
+                                                    class="text-action-danger-bg hover:text-action-danger-bg-hover font-bold flex items-center gap-1 transition-colors"
+                                                    on:click=move |_| on_cancel.call(summary.get_value())
+                                                >
+                                                    <i class="fas fa-times-circle text-xs"></i>
+                                                    {"取消"}
+                                                </button>
+                                            </div>
+                                        </Show>
+                                        <Show when=move || status_for_not_pending != "pending">
+                                            <span class="text-fg-muted text-sm">
+                                                <i class="fas fa-lock text-xs"></i>
+                                            </span>
+                                        </Show>
+                                    </div>
+                                </div>
+                            }
+                        }
+                    />
+                </div>
+                <div class="hidden lg:block overflow-x-auto">
                     <table class="min-w-full divide-y divide-border">
                         <thead>
                             <tr class="bg-surface-muted">


### PR DESCRIPTION
## Summary
- add mobile card layout for requests list and keep table view on large screens
- add mobile card layout for admin audit logs and keep existing table view on large screens
- keep loading/error/empty handling aligned across mobile and desktop render paths
- add/update host tests for mobile card rendering labels

## Testing
- cargo fmt --all
- cargo test -p timekeeper-frontend requests_list_renders
- cargo test -p timekeeper-frontend admin_audit_logs::panel::

Closes #371