### PR TITLE
feat(admin): improve force-end break UX with active break selector

### DIFF
--- a/frontend/src/api/attendance.rs
+++ b/frontend/src/api/attendance.rs
@@ -4,8 +4,8 @@ use serde_json::{json, Value};
 use super::{
     client::{encode_path_segment, ApiClient},
     types::{
-        AdminAttendanceUpsert, ApiError, AttendanceResponse, AttendanceStatusResponse,
-        AttendanceSummary, BreakRecordResponse,
+        ActiveBreakResponse, AdminAttendanceUpsert, ApiError, AttendanceResponse,
+        AttendanceStatusResponse, AttendanceSummary, BreakRecordResponse,
     },
 };
 
@@ -280,6 +280,31 @@ impl ApiClient {
                     "{}/admin/breaks/{}/force-end",
                     base_url, encoded_break_id
                 )))
+            })
+            .await?;
+        let status = response.status();
+        Self::handle_unauthorized_status(status);
+        if status.is_success() {
+            response
+                .json()
+                .await
+                .map_err(|e| ApiError::unknown(format!("Failed to parse response: {}", e)))
+        } else {
+            let error: ApiError = response
+                .json()
+                .await
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
+            Err(error)
+        }
+    }
+
+    pub async fn admin_list_active_breaks(&self) -> Result<Vec<ActiveBreakResponse>, ApiError> {
+        let base_url = self.resolved_base_url().await;
+        let response = self
+            .send_with_refresh(|| {
+                Ok(self
+                    .http_client()
+                    .get(format!("{}/admin/breaks/active", base_url)))
             })
             .await?;
         let status = response.status();

--- a/frontend/src/api/tests.rs
+++ b/frontend/src/api/tests.rs
@@ -395,6 +395,17 @@ async fn api_client_attendance_and_requests_endpoints_succeed() {
         then.status(200).json_body(break_record_json("br-1"));
     });
     server.mock(|when, then| {
+        when.method(GET).path("/api/admin/breaks/active");
+        then.status(200).json_body(json!([{
+            "break_id": "br-1",
+            "attendance_id": "att-1",
+            "user_id": "u1",
+            "username": "alice",
+            "full_name": "Alice Example",
+            "break_start_time": "2025-01-02T12:00:00"
+        }]));
+    });
+    server.mock(|when, then| {
         when.method(GET).path("/api/attendance/me/summary");
         then.status(200).json_body(attendance_summary_json());
     });
@@ -476,6 +487,7 @@ async fn api_client_attendance_and_requests_endpoints_succeed() {
         .await
         .unwrap();
     client.admin_force_end_break("br-1").await.unwrap();
+    assert_eq!(client.admin_list_active_breaks().await.unwrap().len(), 1);
     let summary = client.get_my_summary(Some(2025), Some(1)).await.unwrap();
     assert_eq!(summary.total_work_days, 20);
     let export = client

--- a/frontend/src/api/types.rs
+++ b/frontend/src/api/types.rs
@@ -319,6 +319,16 @@ pub struct AdminBreakItem {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActiveBreakResponse {
+    pub break_id: String,
+    pub attendance_id: String,
+    pub user_id: String,
+    pub username: String,
+    pub full_name: Option<String>,
+    pub break_start_time: NaiveDateTime,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateUser {
     pub username: String,
     pub password: String,


### PR DESCRIPTION
## Summary\n- replace manual Break ID input in Admin > 勤怠ツール > 休憩の強制終了 with a selectable active-break dropdown\n- add reload support and disable force-end action until an active break is selected\n- add backend endpoint  and frontend repository/client wiring\n\n## Why\n- manual Break ID entry is hard to understand and error-prone for operators\n\n## Verification\n- cargo check -p timekeeper-backend\n- cargo check -p timekeeper-frontend\n- cargo test -p timekeeper-frontend helper_force_break_selection_validation -- --nocapture\n- cargo test -p timekeeper-frontend api_client_attendance_and_requests_endpoints_succeed -- --nocapture