### PR TITLE
fix(auth): harden password reset token lifecycle

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -840,6 +840,16 @@ pub async fn reset_password(
     .map_err(|_| internal_error("Task join error"))?
     .map_err(|_| internal_error("Failed to hash password"))?;
 
+    let consumed_reset =
+        password_reset_repo::consume_valid_reset_by_token(&state.write_pool, &payload.token)
+            .await
+            .map_err(|_| internal_error("Database error"))?
+            .ok_or_else(|| bad_request("Invalid or already-used reset token"))?;
+
+    if consumed_reset.user_id != user.id {
+        return Err(internal_error("Password reset token user mismatch"));
+    }
+
     let user = auth_repo::update_user_password(
         &state.write_pool,
         user.id,
@@ -850,9 +860,13 @@ pub async fn reset_password(
     .await
     .map_err(|_| internal_error("Failed to update password"))?;
 
-    password_reset_repo::mark_token_as_used(&state.write_pool, &reset_record.id)
-        .await
-        .map_err(|_| internal_error("Failed to mark token as used"))?;
+    password_reset_repo::invalidate_unused_tokens_for_user(
+        &state.write_pool,
+        user.id,
+        Some(&consumed_reset.id),
+    )
+    .await
+    .map_err(|_| internal_error("Failed to invalidate other reset tokens"))?;
 
     auth_repo::delete_all_refresh_tokens_for_user(&state.write_pool, user.id)
         .await

--- a/backend/src/repositories/password_reset.rs
+++ b/backend/src/repositories/password_reset.rs
@@ -15,6 +15,15 @@ pub async fn create_password_reset(
     let reset_id = Uuid::new_v4().to_string();
     let token_hash = hash_token(token);
     let expires_at = Utc::now() + Duration::hours(1);
+    let mut tx = pool.begin().await?;
+    let now = Utc::now();
+
+    sqlx::query("SELECT id FROM users WHERE id = $1 FOR UPDATE")
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+
+    invalidate_unused_tokens_for_user_tx(&mut *tx, user_id, now, None).await?;
 
     let record = sqlx::query_as::<_, PasswordReset>(
         r#"
@@ -27,8 +36,10 @@ pub async fn create_password_reset(
     .bind(user_id)
     .bind(&token_hash)
     .bind(expires_at)
-    .fetch_one(pool)
+    .fetch_one(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     Ok(record)
 }
@@ -57,6 +68,7 @@ pub async fn find_valid_reset_by_token(
     Ok(record)
 }
 
+#[allow(dead_code)]
 pub async fn mark_token_as_used(pool: &PgPool, reset_id: &str) -> Result<(), AppError> {
     let now = Utc::now();
 
@@ -73,6 +85,40 @@ pub async fn mark_token_as_used(pool: &PgPool, reset_id: &str) -> Result<(), App
     .await?;
 
     Ok(())
+}
+
+pub async fn consume_valid_reset_by_token(
+    pool: &PgPool,
+    token: &str,
+) -> Result<Option<PasswordReset>, AppError> {
+    let token_hash = hash_token(token);
+    let now = Utc::now();
+
+    let record = sqlx::query_as::<_, PasswordReset>(
+        r#"
+        UPDATE password_resets
+        SET used_at = $2
+        WHERE token_hash = $1
+          AND expires_at > $2
+          AND used_at IS NULL
+        RETURNING id, user_id, token_hash, expires_at, created_at, used_at
+        "#,
+    )
+    .bind(&token_hash)
+    .bind(now)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(record)
+}
+
+pub async fn invalidate_unused_tokens_for_user(
+    pool: &PgPool,
+    user_id: UserId,
+    exclude_reset_id: Option<&str>,
+) -> Result<u64, AppError> {
+    let now = Utc::now();
+    invalidate_unused_tokens_for_user_tx(pool, user_id, now, exclude_reset_id).await
 }
 
 #[allow(dead_code)]
@@ -96,6 +142,33 @@ fn hash_token(token: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+async fn invalidate_unused_tokens_for_user_tx<'e, E>(
+    executor: E,
+    user_id: UserId,
+    now: chrono::DateTime<Utc>,
+    exclude_reset_id: Option<&str>,
+) -> Result<u64, AppError>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let result = sqlx::query(
+        r#"
+        UPDATE password_resets
+        SET used_at = $1
+        WHERE user_id = $2
+          AND used_at IS NULL
+          AND ($3::TEXT IS NULL OR id <> $3)
+        "#,
+    )
+    .bind(now)
+    .bind(user_id)
+    .bind(exclude_reset_id)
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected())
 }
 
 #[cfg(test)]

--- a/backend/tests/password_reset_api.rs
+++ b/backend/tests/password_reset_api.rs
@@ -245,6 +245,62 @@ async fn request_password_reset_creates_token_record() {
 }
 
 #[tokio::test]
+async fn create_password_reset_invalidates_previous_unused_tokens() {
+    let _guard = integration_guard().await;
+    configure_email_skip();
+    let pool = support::test_pool().await;
+    migrate_db(&pool).await;
+    reset_password_resets(&pool).await;
+
+    let user = create_test_user(&pool, "reset-rotate@example.com", "Pass123!").await;
+    let first_token = generate_token(32);
+    let second_token = generate_token(32);
+
+    let first_record = password_reset_repo::create_password_reset(&pool, user.id, &first_token)
+        .await
+        .expect("create first reset token");
+    let second_record = password_reset_repo::create_password_reset(&pool, user.id, &second_token)
+        .await
+        .expect("create second reset token");
+
+    let first_used_at: Option<chrono::DateTime<Utc>> =
+        sqlx::query_scalar("SELECT used_at FROM password_resets WHERE id = $1")
+            .bind(&first_record.id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch first used_at");
+    let second_used_at: Option<chrono::DateTime<Utc>> =
+        sqlx::query_scalar("SELECT used_at FROM password_resets WHERE id = $1")
+            .bind(&second_record.id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch second used_at");
+    let unused_count = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM password_resets WHERE user_id = $1 AND used_at IS NULL",
+    )
+    .bind(user.id)
+    .fetch_one(&pool)
+    .await
+    .expect("count unused tokens");
+
+    assert!(first_used_at.is_some());
+    assert!(second_used_at.is_none());
+    assert_eq!(unused_count, 1);
+    assert!(
+        password_reset_repo::find_valid_reset_by_token(&pool, &first_token)
+            .await
+            .expect("query first token")
+            .is_none()
+    );
+    assert!(
+        password_reset_repo::find_valid_reset_by_token(&pool, &second_token)
+            .await
+            .expect("query second token")
+            .is_some()
+    );
+}
+
+#[tokio::test]
 async fn reset_password_endpoint_marks_token_used_and_rejects_reuse() {
     let _guard = integration_guard().await;
     configure_email_skip();
@@ -314,4 +370,73 @@ async fn reset_password_endpoint_marks_token_used_and_rejects_reuse() {
         .expect("call app");
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn reset_password_endpoint_allows_only_one_concurrent_success() {
+    let _guard = integration_guard().await;
+    configure_email_skip();
+    let pool = support::test_pool().await;
+    migrate_db(&pool).await;
+    reset_password_resets(&pool).await;
+
+    let user = create_test_user(&pool, "reset-race@example.com", "Pass123!").await;
+    let token = generate_token(32);
+    password_reset_repo::create_password_reset(&pool, user.id, &token)
+        .await
+        .expect("create reset record");
+
+    let state = AppState::new(pool.clone(), None, None, None, support::test_config());
+    let app = Router::new()
+        .route(
+            "/api/auth/reset-password",
+            post(handlers::auth::reset_password),
+        )
+        .with_state(state);
+
+    let request_1 = Request::builder()
+        .method("POST")
+        .uri("/api/auth/reset-password")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({ "token": token, "new_password": "NewPassword123!" }).to_string(),
+        ))
+        .expect("build request 1");
+    let request_2 = Request::builder()
+        .method("POST")
+        .uri("/api/auth/reset-password")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            json!({ "token": token, "new_password": "OtherPassword123!" }).to_string(),
+        ))
+        .expect("build request 2");
+
+    let (response_1, response_2) =
+        tokio::join!(app.clone().oneshot(request_1), app.oneshot(request_2));
+    let statuses = [
+        response_1.expect("response 1").status(),
+        response_2.expect("response 2").status(),
+    ];
+    let success_count = statuses
+        .iter()
+        .filter(|status| **status == StatusCode::OK)
+        .count();
+    let failure_count = statuses
+        .iter()
+        .filter(|status| **status == StatusCode::BAD_REQUEST)
+        .count();
+
+    assert_eq!(success_count, 1);
+    assert_eq!(failure_count, 1);
+
+    let updated_user = auth_repo::find_user_by_id(&pool, user.id)
+        .await
+        .expect("fetch user")
+        .expect("user exists");
+    let matches_first = verify_password("NewPassword123!", &updated_user.password_hash)
+        .expect("verify first password");
+    let matches_second = verify_password("OtherPassword123!", &updated_user.password_hash)
+        .expect("verify second password");
+
+    assert_ne!(matches_first, matches_second);
 }


### PR DESCRIPTION
## Summary
- invalidate any previous unused password reset tokens before issuing a new one
- consume reset tokens atomically inside a transaction before updating the password
- add regression coverage for old-token invalidation and concurrent token reuse

## Validation
- cargo test -p timekeeper-backend --test password_reset_api -- --nocapture
