### PR TITLE
fix(auth): reduce login timing side-channel

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -57,6 +57,9 @@ use crate::{
 
 pub type HandlerResult<T> = Result<T, AppError>;
 
+const DUMMY_LOGIN_PASSWORD_HASH: &str =
+    "$argon2id$v=19$m=19456,t=2,p=1$SHjkBewYpN0AqfNJtz4BCQ$Q6EKet0GGAKSbQ5hQFsXf+6WG+AX8Z91wi5hlimtYew";
+
 #[derive(Debug)]
 pub struct AuthSession {
     pub access_token: String,
@@ -73,10 +76,13 @@ pub async fn login(
 ) -> HandlerResult<impl axum::response::IntoResponse> {
     payload.validate()?;
 
-    let mut user = auth_repo::find_user_by_username(&state.write_pool, &payload.username)
+    let Some(mut user) = auth_repo::find_user_by_username(&state.write_pool, &payload.username)
         .await
         .map_err(|_| internal_error("Database error"))?
-        .ok_or_else(|| unauthorized("Invalid username or password"))?;
+    else {
+        verify_missing_user_login(&payload.password).await?;
+        return Err(unauthorized("Invalid username or password"));
+    };
     user.full_name = decrypt_pii(&user.full_name, &state.config)
         .map_err(|_| internal_error("Failed to decrypt user profile"))?;
     user.email = decrypt_pii(&user.email, &state.config)
@@ -1286,6 +1292,15 @@ fn cookie_header_value(headers: &HeaderMap) -> Option<&str> {
     headers.get(header::COOKIE).and_then(|v| v.to_str().ok())
 }
 
+async fn verify_missing_user_login(candidate: &str) -> HandlerResult<()> {
+    ensure_password_matches(
+        candidate,
+        DUMMY_LOGIN_PASSWORD_HASH,
+        "Invalid username or password",
+    )
+    .await
+}
+
 fn bad_request(message: impl Into<String>) -> AppError {
     AppError::BadRequest(message.into())
 }
@@ -1587,6 +1602,16 @@ mod tests {
             .await
             .expect_err("should fail");
         assert!(matches!(err, AppError::Unauthorized(_)));
+    }
+
+    #[tokio::test]
+    async fn verify_missing_user_login_returns_unauthorized() {
+        let err = verify_missing_user_login("wrong-password")
+            .await
+            .expect_err("missing user verification should fail");
+        assert!(
+            matches!(err, AppError::Unauthorized(message) if message == "Invalid username or password")
+        );
     }
 
     #[test]

--- a/backend/tests/auth_flow_api.rs
+++ b/backend/tests/auth_flow_api.rs
@@ -213,6 +213,66 @@ async fn login_rejects_invalid_password() {
 }
 
 #[tokio::test]
+async fn login_rejects_unknown_username() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    migrate_db(&pool).await;
+
+    let app = auth_router(pool.clone());
+    let refresh_token_count_before =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM refresh_tokens")
+            .fetch_one(&pool)
+            .await
+            .expect("count refresh tokens before");
+    let access_token_count_before =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM active_access_tokens")
+            .fetch_one(&pool)
+            .await
+            .expect("count active access tokens before");
+    let active_session_count_before =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM active_sessions")
+            .fetch_one(&pool)
+            .await
+            .expect("count active sessions before");
+
+    let payload = json!({
+        "username": "missing-user",
+        "password": "Wrong123!",
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/auth/login")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(payload.to_string()))
+                .expect("build login request"),
+        )
+        .await
+        .expect("login request");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let refresh_token_count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM refresh_tokens")
+        .fetch_one(&pool)
+        .await
+        .expect("count refresh tokens");
+    let access_token_count =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM active_access_tokens")
+            .fetch_one(&pool)
+            .await
+            .expect("count active access tokens");
+    let active_session_count = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM active_sessions")
+        .fetch_one(&pool)
+        .await
+        .expect("count active sessions");
+
+    assert_eq!(refresh_token_count, refresh_token_count_before);
+    assert_eq!(access_token_count, access_token_count_before);
+    assert_eq!(active_session_count, active_session_count_before);
+}
+
+#[tokio::test]
 async fn login_locks_account_after_reaching_failure_threshold() {
     let _guard = integration_guard().await;
     let pool = support::test_pool().await;


### PR DESCRIPTION
## Summary
- verify a dummy Argon2 hash for unknown usernames to reduce login timing differences
- keep the existing `Invalid username or password` response intact
- add regression coverage for unknown-username login attempts

## Validation
- cargo test -p timekeeper-backend --test auth_flow_api -- --nocapture
- cargo test -p timekeeper-backend --test auth_api -- --nocapture
- cargo test -p timekeeper-backend --lib verify_missing_user_login_returns_unauthorized -- --nocapture
