### PR TITLE
fix(frontend): protect mfa register route

### DIFF
--- a/frontend/src/api/client.rs
+++ b/frontend/src/api/client.rs
@@ -250,13 +250,7 @@ impl ApiClient {
             let location = window.location();
             if let Ok(pathname) = location.pathname() {
                 // Public paths where 401 is expected (not logged in) and should not trigger redirect
-                let public_paths = [
-                    "/",
-                    "/login",
-                    "/forgot-password",
-                    "/reset-password",
-                    "/mfa/register",
-                ];
+                let public_paths = ["/", "/login", "/forgot-password", "/reset-password"];
                 if public_paths.contains(&pathname.as_str()) {
                     return;
                 }

--- a/frontend/src/router.rs
+++ b/frontend/src/router.rs
@@ -33,6 +33,7 @@ pub const PROTECTED_ROUTE_PATHS: &[&str] = &[
     "/dashboard",
     "/attendance",
     "/requests",
+    "/mfa/register",
     "/settings",
     "/admin",
     "/admin/users",
@@ -40,13 +41,7 @@ pub const PROTECTED_ROUTE_PATHS: &[&str] = &[
     "/admin/audit-logs",
 ];
 
-pub const PUBLIC_ROUTE_PATHS: &[&str] = &[
-    "/",
-    "/login",
-    "/mfa/register",
-    "/forgot-password",
-    "/reset-password",
-];
+pub const PUBLIC_ROUTE_PATHS: &[&str] = &["/", "/login", "/forgot-password", "/reset-password"];
 
 pub fn mount_app() {
     mount_to_body(app_root);
@@ -65,7 +60,7 @@ pub fn app_root() -> impl IntoView {
                     <Route path="/dashboard" view=ProtectedDashboard/>
                     <Route path="/attendance" view=ProtectedAttendance/>
                     <Route path="/requests" view=ProtectedRequests/>
-                    <Route path="/mfa/register" view=MfaRegisterPage/> // Keeping for direct access if needed, or redirect?
+                    <Route path="/mfa/register" view=ProtectedMfaRegister/>
                     <Route path="/settings" view=ProtectedSettings/>
                     <Route path="/admin" view=ProtectedAdmin/>
                     <Route path="/admin/users" view=ProtectedAdminUsers/>
@@ -90,6 +85,11 @@ fn ProtectedAttendance() -> impl IntoView {
 #[component]
 fn ProtectedRequests() -> impl IntoView {
     view! { <RequireAuth><RequestsPage/></RequireAuth> }
+}
+
+#[component]
+fn ProtectedMfaRegister() -> impl IntoView {
+    view! { <RequireAuth><MfaRegisterPage/></RequireAuth> }
 }
 
 #[component]
@@ -154,6 +154,12 @@ mod tests {
     }
 
     #[test]
+    fn mfa_register_route_is_protected() {
+        assert!(PROTECTED_ROUTE_PATHS.contains(&"/mfa/register"));
+        assert!(!PUBLIC_ROUTE_PATHS.contains(&"/mfa/register"));
+    }
+
+    #[test]
     fn public_routes_are_subset_of_all() {
         let all: HashSet<&str> = ROUTE_PATHS.iter().copied().collect();
         for path in PUBLIC_ROUTE_PATHS {
@@ -201,6 +207,7 @@ mod host_tests {
                         <ProtectedDashboard />
                         <ProtectedAttendance />
                         <ProtectedRequests />
+                        <ProtectedMfaRegister />
                         <ProtectedSettings />
                         <ProtectedAdmin />
                         <ProtectedAdminUsers />


### PR DESCRIPTION
## Summary
- move \/mfa\/register from public routes to protected routes
- wrap the route with RequireAuth and align the unauthorized redirect allowlist
- add a router regression test that keeps \/mfa\/register protected

## Testing
- cargo test -p timekeeper-frontend --lib mfa_register_route_is_protected -- --nocapture
- cargo test -p timekeeper-frontend --lib protected_views_render_with_auth_context -- --nocapture
- cargo fmt --all

Closes #382