### PR TITLE
refactor(repo): simplify request status bindings

### DIFF
--- a/backend/src/repositories/leave_request_repository.rs
+++ b/backend/src/repositories/leave_request_repository.rs
@@ -297,12 +297,7 @@ impl LeaveRequestRepositoryTrait for LeaveRequestRepository {
             "leave_requests"
         );
         let result = sqlx::query(&query)
-            .bind(match RequestStatus::Cancelled {
-                RequestStatus::Pending => "pending",
-                RequestStatus::Approved => "approved",
-                RequestStatus::Rejected => "rejected",
-                RequestStatus::Cancelled => "cancelled",
-            })
+            .bind(RequestStatus::Cancelled.db_value())
             .bind(timestamp)
             .bind(timestamp)
             .bind(id)
@@ -328,12 +323,7 @@ impl LeaveRequestRepositoryTrait for LeaveRequestRepository {
             "leave_requests"
         );
         let result = sqlx::query(&query)
-            .bind(match RequestStatus::Approved {
-                RequestStatus::Pending => "pending",
-                RequestStatus::Approved => "approved",
-                RequestStatus::Rejected => "rejected",
-                RequestStatus::Cancelled => "cancelled",
-            })
+            .bind(RequestStatus::Approved.db_value())
             .bind(approver_id)
             .bind(timestamp)
             .bind(comment)
@@ -360,12 +350,7 @@ impl LeaveRequestRepositoryTrait for LeaveRequestRepository {
             "leave_requests"
         );
         let result = sqlx::query(&query)
-            .bind(match RequestStatus::Rejected {
-                RequestStatus::Pending => "pending",
-                RequestStatus::Approved => "approved",
-                RequestStatus::Rejected => "rejected",
-                RequestStatus::Cancelled => "cancelled",
-            })
+            .bind(RequestStatus::Rejected.db_value())
             .bind(approver_id)
             .bind(timestamp)
             .bind(comment)

--- a/backend/src/repositories/overtime_request_repository.rs
+++ b/backend/src/repositories/overtime_request_repository.rs
@@ -306,12 +306,7 @@ impl OvertimeRequestRepositoryTrait for OvertimeRequestRepository {
             "overtime_requests"
         );
         let result = sqlx::query(&query)
-            .bind(match RequestStatus::Cancelled {
-                RequestStatus::Pending => "pending",
-                RequestStatus::Approved => "approved",
-                RequestStatus::Rejected => "rejected",
-                RequestStatus::Cancelled => "cancelled",
-            })
+            .bind(RequestStatus::Cancelled.db_value())
             .bind(timestamp)
             .bind(timestamp)
             .bind(id)
@@ -337,12 +332,7 @@ impl OvertimeRequestRepositoryTrait for OvertimeRequestRepository {
             "overtime_requests"
         );
         let result = sqlx::query(&query)
-            .bind(match RequestStatus::Approved {
-                RequestStatus::Pending => "pending",
-                RequestStatus::Approved => "approved",
-                RequestStatus::Rejected => "rejected",
-                RequestStatus::Cancelled => "cancelled",
-            })
+            .bind(RequestStatus::Approved.db_value())
             .bind(approver_id)
             .bind(timestamp)
             .bind(comment)
@@ -369,12 +359,7 @@ impl OvertimeRequestRepositoryTrait for OvertimeRequestRepository {
             "overtime_requests"
         );
         let result = sqlx::query(&query)
-            .bind(match RequestStatus::Rejected {
-                RequestStatus::Pending => "pending",
-                RequestStatus::Approved => "approved",
-                RequestStatus::Rejected => "rejected",
-                RequestStatus::Cancelled => "cancelled",
-            })
+            .bind(RequestStatus::Rejected.db_value())
             .bind(approver_id)
             .bind(timestamp)
             .bind(comment)

--- a/backend/src/repositories/user_repository.rs
+++ b/backend/src/repositories/user_repository.rs
@@ -19,25 +19,26 @@ use crate::types::UserId;
 #[allow(dead_code)]
 pub trait UserRepository: Send + Sync {
     /// Find all users
-    async fn find_all(&self, db: PgPool) -> Result<Vec<User>, AppError>;
+    async fn find_all(&self, db: &PgPool) -> Result<Vec<User>, AppError>;
 
     /// Find a user by ID
-    async fn find_by_id(&self, db: PgPool, id: UserId) -> Result<User, AppError>;
+    async fn find_by_id(&self, db: &PgPool, id: UserId) -> Result<User, AppError>;
 
     /// Create a new user
-    async fn create(&self, db: PgPool, user: &User) -> Result<User, AppError>;
+    async fn create(&self, db: &PgPool, user: &User) -> Result<User, AppError>;
 
     /// Update an existing user
-    async fn update(&self, db: PgPool, user: &User) -> Result<User, AppError>;
+    async fn update(&self, db: &PgPool, user: &User) -> Result<User, AppError>;
 
     /// Delete a user by ID
-    async fn delete(&self, db: PgPool, id: UserId) -> Result<(), AppError>;
+    async fn delete(&self, db: &PgPool, id: UserId) -> Result<(), AppError>;
 
     /// Find user by username
-    async fn find_by_username(&self, db: PgPool, username: &str) -> Result<Option<User>, AppError>;
+    async fn find_by_username(&self, db: &PgPool, username: &str)
+        -> Result<Option<User>, AppError>;
 
     /// Find user by email
-    async fn find_by_email(&self, db: PgPool, email: &str) -> Result<Option<User>, AppError>;
+    async fn find_by_email(&self, db: &PgPool, email: &str) -> Result<Option<User>, AppError>;
 }
 
 #[cfg(test)]

--- a/docs/generated/exec-plans/active/EP-20260310-open-issues-326-325.md
+++ b/docs/generated/exec-plans/active/EP-20260310-open-issues-326-325.md
@@ -1,0 +1,32 @@
+# ExecPlan: Open Issue Flow for #326 and #325
+
+## Goal
+
+低リスクな repository cleanup issue `#326` と `#325` を current `main` から独立 PR として処理する。
+
+## Steps
+
+- [completed] issue `#326` の leave/overtime repository で定数 `match` を `db_value()` に置き換えた
+- [completed] issue `#325` の `UserRepository` trait を `&PgPool` 参照渡しへ統一した
+- [completed] focused validation を実行した
+- [in_progress] `jj` snapshot を作成して branch を push する
+- [pending] GitHub PR を作成する
+
+## Validation
+
+- `cargo test -p timekeeper-backend --test request_repository_impls -- --nocapture`
+- `cargo test -p timekeeper-backend --test request_repositories -- --nocapture`
+- `cargo fmt --all`
+
+## Done Criteria
+
+- `#326` の該当 `match` が `RequestStatus::*.db_value()` に簡素化されている
+- `#325` の `UserRepository` trait が他 repository と同じ `&PgPool` を受け取る
+- 変更 seam の focused validation が成功している
+- PR が作成されている
+
+## Validation Log
+
+- `cargo test -p timekeeper-backend --test request_repository_impls -- --nocapture`
+- `cargo test -p timekeeper-backend --test request_repositories -- --nocapture`
+- `cargo fmt --all`


### PR DESCRIPTION
## Summary
- replace exhaustive constant `match` blocks in leave/overtime repository status updates with `RequestStatus::db_value()`
- align the mockable `UserRepository` trait with the rest of the repository layer by taking `&PgPool`

## Validation
- cargo test -p timekeeper-backend --test request_repository_impls -- --nocapture
- cargo test -p timekeeper-backend --test request_repositories -- --nocapture
- cargo fmt --all

Closes #325
Closes #326
