### PR TITLE
refactor(auth): remove duplicated handler and helper logic

### DIFF
--- a/backend/src/handlers/attendance_utils.rs
+++ b/backend/src/handlers/attendance_utils.rs
@@ -78,12 +78,14 @@ pub async fn insert_attendance_record(
 }
 
 pub async fn update_clock_in(pool: &PgPool, attendance: &Attendance) -> Result<(), AppError> {
-    let repo = AttendanceRepository::new();
-    repo.update(pool, attendance).await?;
-    Ok(())
+    update_attendance_record(pool, attendance).await
 }
 
 pub async fn update_clock_out(pool: &PgPool, attendance: &Attendance) -> Result<(), AppError> {
+    update_attendance_record(pool, attendance).await
+}
+
+async fn update_attendance_record(pool: &PgPool, attendance: &Attendance) -> Result<(), AppError> {
     let repo = AttendanceRepository::new();
     repo.update(pool, attendance).await?;
     Ok(())

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -534,7 +534,7 @@ pub async fn update_profile(
     Ok(Json(UserResponse::from(updated_user)))
 }
 
-pub async fn mfa_register(
+async fn begin_mfa_setup(
     State(state): State<AppState>,
     headers: HeaderMap,
     Extension(user): Extension<User>,
@@ -544,14 +544,20 @@ pub async fn mfa_register(
     Ok(Json(response))
 }
 
-pub async fn mfa_setup(
-    State(state): State<AppState>,
+pub async fn mfa_register(
+    state: State<AppState>,
     headers: HeaderMap,
-    Extension(user): Extension<User>,
+    user: Extension<User>,
 ) -> HandlerResult<Json<MfaSetupResponse>> {
-    crate::utils::security::verify_request_origin(&headers, &state.config)?;
-    let response = begin_mfa_enrollment(&state.write_pool, &state.config, &user).await?;
-    Ok(Json(response))
+    begin_mfa_setup(state, headers, user).await
+}
+
+pub async fn mfa_setup(
+    state: State<AppState>,
+    headers: HeaderMap,
+    user: Extension<User>,
+) -> HandlerResult<Json<MfaSetupResponse>> {
+    begin_mfa_setup(state, headers, user).await
 }
 
 pub async fn mfa_activate(
@@ -806,7 +812,7 @@ pub async fn reset_password(
     .await
     .map_err(|_| internal_error("Failed to invalidate other reset tokens"))?;
 
-    auth_repo::delete_all_refresh_tokens_for_user(&state.write_pool, user.id)
+    auth_repo::delete_refresh_tokens_for_user(&state.write_pool, user.id)
         .await
         .map_err(|_| internal_error("Failed to revoke refresh tokens"))?;
 

--- a/backend/src/repositories/audit_log.rs
+++ b/backend/src/repositories/audit_log.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Postgres, QueryBuilder};
 
 use crate::models::audit_log::AuditLog;
+use crate::repositories::common::push_clause;
 use crate::types::{AuditLogId, UserId};
 
 #[derive(Debug, Clone, Default)]
@@ -168,15 +169,6 @@ fn apply_audit_log_filters(
     if let Some(result) = filters.result.as_ref() {
         push_clause(builder, has_clause);
         builder.push("result = ").push_bind(result.to_string());
-    }
-}
-
-fn push_clause(builder: &mut QueryBuilder<'_, Postgres>, has_clause: &mut bool) {
-    if *has_clause {
-        builder.push(" AND ");
-    } else {
-        builder.push(" WHERE ");
-        *has_clause = true;
     }
 }
 

--- a/backend/src/repositories/auth.rs
+++ b/backend/src/repositories/auth.rs
@@ -402,18 +402,6 @@ pub async fn fetch_recent_password_hashes(
     .await
 }
 
-/// Deletes all refresh tokens for a specific user (alias).
-pub async fn delete_all_refresh_tokens_for_user(
-    pool: &PgPool,
-    user_id: UserId,
-) -> Result<(), sqlx::Error> {
-    sqlx::query("DELETE FROM refresh_tokens WHERE user_id = $1")
-        .bind(user_id.to_string())
-        .execute(pool)
-        .await
-        .map(|_| ())
-}
-
 fn lockout_duration_minutes(lockout_count: i32, policy: LockoutPolicy) -> i64 {
     let base = policy.duration_minutes.max(1);
     if !policy.backoff_enabled {

--- a/backend/src/repositories/subject_request.rs
+++ b/backend/src/repositories/subject_request.rs
@@ -5,6 +5,7 @@ use crate::models::{
     request::RequestStatus,
     subject_request::{DataSubjectRequest, DataSubjectRequestType},
 };
+use crate::repositories::common::push_clause;
 
 #[derive(Debug, Clone, Default)]
 pub struct SubjectRequestFilters {
@@ -209,15 +210,6 @@ fn apply_subject_request_filters<'a>(
     if let Some(to) = filters.to.as_ref() {
         push_clause(builder, has_clause);
         builder.push("created_at <= ").push_bind(to.to_owned());
-    }
-}
-
-fn push_clause<'a>(builder: &mut QueryBuilder<'a, Postgres>, has_clause: &mut bool) {
-    if *has_clause {
-        builder.push(" AND ");
-    } else {
-        builder.push(" WHERE ");
-        *has_clause = true;
     }
 }
 

--- a/docs/generated/exec-plans/active/EP-20260310-open-issues-317-320.md
+++ b/docs/generated/exec-plans/active/EP-20260310-open-issues-317-320.md
@@ -1,0 +1,35 @@
+# ExecPlan: Open Issue Flow for #317, #318, #319, #320
+
+## Goal
+
+認証・勤怠・repository utility にある小規模な重複実装を current `main` 上で整理し、`#317`, `#318`, `#319`, `#320` をまとめて 1 本の低リスク PR にする。
+
+## Steps
+
+- [completed] issue `#317` の `mfa_register` / `mfa_setup` 重複を統合した
+- [completed] issue `#318` の refresh token 削除 alias を統合した
+- [completed] issue `#319` の `update_clock_in` / `update_clock_out` 重複を統合した
+- [completed] issue `#320` の `push_clause` 重複定義を共通 helper に統一した
+- [completed] focused validation を実行した
+- [in_progress] `jj` snapshot と PR 作成を行う
+
+## Validation
+
+- `cargo test -p timekeeper-backend --test auth_flow_api -- --nocapture`
+- `cargo test -p timekeeper-backend --test request_repositories -- --nocapture`
+- `cargo test -p timekeeper-backend --test audit_log_repo -- --nocapture`
+- `cargo fmt --all`
+
+## Done Criteria
+
+- 上記 4 issue の重複実装が除去されている
+- 変更 seam の focused test が成功している
+- PR が作成されている
+
+## Validation Log
+
+- `cargo test -p timekeeper-backend --test mfa_api -- --nocapture`
+- `cargo test -p timekeeper-backend --test subject_request_repo -- --nocapture`
+- `cargo test -p timekeeper-backend --test audit_log_repo -- --nocapture`
+- `cargo test -p timekeeper-backend --lib handlers::attendance_utils::tests -- --nocapture`
+- `cargo fmt --all`


### PR DESCRIPTION
## Summary
- deduplicate `mfa_register` / `mfa_setup` behind a shared setup helper
- remove the duplicate refresh-token deletion alias and reuse the canonical repository function
- unify attendance update helpers behind a shared `update_attendance_record`
- switch duplicate `push_clause` implementations to `repositories::common::push_clause`

## Validation
- cargo test -p timekeeper-backend --test mfa_api -- --nocapture
- cargo test -p timekeeper-backend --test subject_request_repo -- --nocapture
- cargo test -p timekeeper-backend --test audit_log_repo -- --nocapture
- cargo test -p timekeeper-backend --lib handlers::attendance_utils::tests -- --nocapture
- cargo fmt --all

Closes #317
Closes #318
Closes #319
Closes #320
