### PR TITLE
refactor(admin): unify subject request errors and filter helpers

### DIFF
--- a/backend/src/handlers/admin/audit_logs.rs
+++ b/backend/src/handlers/admin/audit_logs.rs
@@ -9,12 +9,15 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utoipa::{IntoParams, ToSchema};
 
 use crate::{
+    handlers::admin::common::{
+        normalize_filter, parse_filter_datetime, parse_from_datetime, parse_to_datetime,
+    },
     models::{audit_log::AuditLog, user::User},
     repositories::{
         audit_log::{self, AuditLogFilters},
@@ -262,10 +265,10 @@ fn validate_list_query(q: AuditLogListQuery) -> Result<(i64, i64, AuditLogFilter
 const MAX_EXPORT_DAYS: i64 = 31;
 
 fn validate_export_query(q: AuditLogExportQuery) -> Result<AuditLogFilters, AppError> {
-    let from = parse_datetime_value(&q.from, true).ok_or_else(|| {
+    let from = parse_filter_datetime(&q.from, false).ok_or_else(|| {
         AppError::BadRequest("`from` must be a valid datetime (RFC3339 or YYYY-MM-DD)".into())
     })?;
-    let to = parse_datetime_value(&q.to, false).ok_or_else(|| {
+    let to = parse_filter_datetime(&q.to, true).ok_or_else(|| {
         AppError::BadRequest("`to` must be a valid datetime (RFC3339 or YYYY-MM-DD)".into())
     })?;
 
@@ -361,52 +364,4 @@ fn build_filters(input: AuditLogFilterInput) -> Result<AuditLogFilters, AppError
         target_id: normalize_filter(input.target_id),
         result,
     })
-}
-
-fn normalize_filter(value: Option<String>) -> Option<String> {
-    value
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-}
-
-fn parse_from_datetime(raw: Option<&str>) -> Result<Option<DateTime<Utc>>, &'static str> {
-    match raw {
-        Some(value) => parse_datetime_value(value, true)
-            .ok_or("`from` must be a valid datetime (RFC3339 or YYYY-MM-DD)")
-            .map(Some),
-        None => Ok(None),
-    }
-}
-
-fn parse_to_datetime(raw: Option<&str>) -> Result<Option<DateTime<Utc>>, &'static str> {
-    match raw {
-        Some(value) => parse_datetime_value(value, false)
-            .ok_or("`to` must be a valid datetime (RFC3339 or YYYY-MM-DD)")
-            .map(Some),
-        None => Ok(None),
-    }
-}
-
-fn parse_datetime_value(value: &str, is_start: bool) -> Option<DateTime<Utc>> {
-    if let Ok(dt) = DateTime::parse_from_rfc3339(value) {
-        return Some(dt.with_timezone(&Utc));
-    }
-    if let Ok(dt) = NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S") {
-        return Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc));
-    }
-    if let Ok(dt) = NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S") {
-        return Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc));
-    }
-    if let Ok(date) = NaiveDate::parse_from_str(value, "%Y-%m-%d") {
-        let time = if is_start {
-            NaiveTime::from_hms_opt(0, 0, 0)
-        } else {
-            NaiveTime::from_hms_opt(23, 59, 59)
-        }?;
-        return Some(DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDateTime::new(date, time),
-            Utc,
-        ));
-    }
-    None
 }

--- a/backend/src/handlers/admin/common.rs
+++ b/backend/src/handlers/admin/common.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, NaiveDate, NaiveDateTime};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use sqlx::{Postgres, QueryBuilder};
 
 pub fn parse_date_value(value: &str) -> Option<NaiveDate> {
@@ -15,6 +15,54 @@ pub fn parse_optional_date(raw: Option<&str>) -> Result<Option<NaiveDate>, &'sta
     match raw {
         Some(value) => parse_date_value(value)
             .ok_or("`from`/`to` must be a valid date (YYYY-MM-DD or RFC3339)")
+            .map(Some),
+        None => Ok(None),
+    }
+}
+
+pub fn normalize_filter(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+pub fn parse_filter_datetime(value: &str, end_of_day: bool) -> Option<DateTime<Utc>> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(value) {
+        return Some(dt.with_timezone(&Utc));
+    }
+    if let Ok(dt) = NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S") {
+        return Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc));
+    }
+    if let Ok(dt) = NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S") {
+        return Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc));
+    }
+    if let Ok(date) = NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+        let time = if end_of_day {
+            NaiveTime::from_hms_opt(23, 59, 59)
+        } else {
+            NaiveTime::from_hms_opt(0, 0, 0)
+        }?;
+        return Some(DateTime::<Utc>::from_naive_utc_and_offset(
+            NaiveDateTime::new(date, time),
+            Utc,
+        ));
+    }
+    None
+}
+
+pub fn parse_from_datetime(raw: Option<&str>) -> Result<Option<DateTime<Utc>>, &'static str> {
+    match raw {
+        Some(value) => parse_filter_datetime(value, false)
+            .ok_or("`from` must be a valid datetime (RFC3339 or YYYY-MM-DD)")
+            .map(Some),
+        None => Ok(None),
+    }
+}
+
+pub fn parse_to_datetime(raw: Option<&str>) -> Result<Option<DateTime<Utc>>, &'static str> {
+    match raw {
+        Some(value) => parse_filter_datetime(value, true)
+            .ok_or("`to` must be a valid datetime (RFC3339 or YYYY-MM-DD)")
             .map(Some),
         None => Ok(None),
     }
@@ -69,6 +117,31 @@ mod tests {
             .expect("valid optional date")
             .is_some());
         assert!(parse_optional_date(Some("invalid")).is_err());
+    }
+
+    #[test]
+    fn normalize_filter_trims_and_drops_empty_values() {
+        assert_eq!(
+            normalize_filter(Some("  user-1  ".to_string())),
+            Some("user-1".to_string())
+        );
+        assert_eq!(normalize_filter(Some("   ".to_string())), None);
+        assert_eq!(normalize_filter(None), None);
+    }
+
+    #[test]
+    fn parse_filter_datetime_supports_rfc3339_sql_iso_and_date_only() {
+        assert!(parse_filter_datetime("2026-02-04T10:11:12+09:00", false).is_some());
+        assert!(parse_filter_datetime("2026-02-04 10:11:12", false).is_some());
+        assert!(parse_filter_datetime("2026-02-04T10:11:12", false).is_some());
+
+        let from = parse_filter_datetime("2026-02-04", false).expect("from");
+        assert_eq!(from.time(), NaiveTime::from_hms_opt(0, 0, 0).expect("time"));
+        let to = parse_filter_datetime("2026-02-04", true).expect("to");
+        assert_eq!(
+            to.time(),
+            NaiveTime::from_hms_opt(23, 59, 59).expect("time")
+        );
     }
 
     #[test]

--- a/backend/src/handlers/admin/requests.rs
+++ b/backend/src/handlers/admin/requests.rs
@@ -2,7 +2,6 @@ use axum::{
     extract::{Extension, Path, Query, State},
     Json,
 };
-use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::str::FromStr;
@@ -10,6 +9,7 @@ use utoipa::{IntoParams, ToSchema};
 
 use crate::{
     error::AppError,
+    handlers::admin::common::parse_filter_datetime,
     models::{
         leave_request::LeaveRequestResponse, overtime_request::OvertimeRequestResponse, user::User,
     },
@@ -295,27 +295,6 @@ pub async fn get_request_detail(
     }
 
     Err(AppError::NotFound("Request not found".into()))
-}
-
-fn parse_filter_datetime(value: &str, end_of_day: bool) -> Option<DateTime<Utc>> {
-    if let Ok(dt) = DateTime::parse_from_rfc3339(value) {
-        return Some(dt.with_timezone(&Utc));
-    }
-    if let Ok(dt) = NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S") {
-        return Some(Utc.from_utc_datetime(&dt));
-    }
-    if let Ok(dt) = NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S") {
-        return Some(Utc.from_utc_datetime(&dt));
-    }
-    if let Ok(date) = NaiveDate::parse_from_str(value, "%Y-%m-%d") {
-        let dt = if end_of_day {
-            date.and_hms_opt(23, 59, 59)?
-        } else {
-            date.and_hms_opt(0, 0, 0)?
-        };
-        return Some(Utc.from_utc_datetime(&dt));
-    }
-    None
 }
 
 #[cfg(test)]

--- a/backend/src/handlers/admin/subject_requests.rs
+++ b/backend/src/handlers/admin/subject_requests.rs
@@ -1,13 +1,12 @@
 use axum::{
     extract::{Extension, Path, Query, State},
-    http::StatusCode,
     Json,
 };
-use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use utoipa::{IntoParams, ToSchema};
 
+use super::common::{normalize_filter, parse_from_datetime, parse_to_datetime};
 use super::requests::validate_decision_comment;
 use crate::{
     error::AppError,
@@ -55,9 +54,9 @@ pub async fn list_subject_requests(
     State(state): State<AppState>,
     Extension(user): Extension<User>,
     Query(q): Query<SubjectRequestListQuery>,
-) -> Result<Json<SubjectRequestListResponse>, (StatusCode, Json<Value>)> {
+) -> Result<Json<SubjectRequestListResponse>, AppError> {
     if !user.is_admin() {
-        return Err((StatusCode::FORBIDDEN, Json(json!({"error":"Forbidden"}))));
+        return Err(AppError::Forbidden("Forbidden".into()));
     }
 
     let (page, per_page, filters) = validate_list_query(q)?;
@@ -65,13 +64,7 @@ pub async fn list_subject_requests(
     let (items, total) =
         subject_request::list_subject_requests(&state.write_pool, &filters, per_page, offset)
             .await
-            .map_err(|err| {
-                tracing::error!(error = %err, "failed to list subject requests");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({"error": "Database error"})),
-                )
-            })?;
+            .map_err(|err| AppError::InternalServerError(err.into()))?;
 
     Ok(Json(SubjectRequestListResponse {
         page,
@@ -89,11 +82,11 @@ pub async fn approve_subject_request(
     Extension(user): Extension<User>,
     Path(request_id): Path<String>,
     Json(body): Json<DecisionPayload>,
-) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+) -> Result<Json<Value>, AppError> {
     if !user.is_admin() {
-        return Err((StatusCode::FORBIDDEN, Json(json!({"error":"Forbidden"}))));
+        return Err(AppError::Forbidden("Forbidden".into()));
     }
-    validate_decision_comment(&body.comment).map_err(map_app_error)?;
+    validate_decision_comment(&body.comment)?;
     ensure_pending_request(&state.write_pool, &request_id).await?;
     let now = time::now_utc(&state.config.time_zone);
     let approver_id = user.id.to_string();
@@ -106,18 +99,11 @@ pub async fn approve_subject_request(
         now,
     )
     .await
-    .map_err(|err| {
-        tracing::error!(error = %err, "failed to approve subject request");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "Database error"})),
-        )
-    })?;
+    .map_err(|err| AppError::InternalServerError(err.into()))?;
 
     if rows == 0 {
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "Request not found or already processed"})),
+        return Err(AppError::NotFound(
+            "Request not found or already processed".into(),
         ));
     }
 
@@ -129,11 +115,11 @@ pub async fn reject_subject_request(
     Extension(user): Extension<User>,
     Path(request_id): Path<String>,
     Json(body): Json<DecisionPayload>,
-) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+) -> Result<Json<Value>, AppError> {
     if !user.is_admin() {
-        return Err((StatusCode::FORBIDDEN, Json(json!({"error":"Forbidden"}))));
+        return Err(AppError::Forbidden("Forbidden".into()));
     }
-    validate_decision_comment(&body.comment).map_err(map_app_error)?;
+    validate_decision_comment(&body.comment)?;
     ensure_pending_request(&state.write_pool, &request_id).await?;
     let now = time::now_utc(&state.config.time_zone);
     let approver_id = user.id.to_string();
@@ -146,62 +132,48 @@ pub async fn reject_subject_request(
         now,
     )
     .await
-    .map_err(|err| {
-        tracing::error!(error = %err, "failed to reject subject request");
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({"error": "Database error"})),
-        )
-    })?;
+    .map_err(|err| AppError::InternalServerError(err.into()))?;
 
     if rows == 0 {
-        return Err((
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "Request not found or already processed"})),
+        return Err(AppError::NotFound(
+            "Request not found or already processed".into(),
         ));
     }
 
     Ok(Json(json!({"message": "Subject request rejected"})))
 }
 
-async fn ensure_pending_request(
-    pool: &sqlx::PgPool,
-    request_id: &str,
-) -> Result<(), (StatusCode, Json<Value>)> {
+async fn ensure_pending_request(pool: &sqlx::PgPool, request_id: &str) -> Result<(), AppError> {
     let existing = subject_request::fetch_subject_request(pool, request_id)
         .await
-        .map_err(|err| {
-            tracing::error!(error = %err, "failed to fetch subject request");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({"error": "Database error"})),
-            )
-        })?;
+        .map_err(|err| AppError::InternalServerError(err.into()))?;
 
     match existing {
         Some(request) if matches!(request.status, RequestStatus::Pending) => Ok(()),
-        _ => Err((
-            StatusCode::NOT_FOUND,
-            Json(json!({"error": "Request not found or already processed"})),
+        _ => Err(AppError::NotFound(
+            "Request not found or already processed".into(),
         )),
     }
 }
 
 fn validate_list_query(
     q: SubjectRequestListQuery,
-) -> Result<(i64, i64, SubjectRequestFilters), (StatusCode, Json<Value>)> {
+) -> Result<(i64, i64, SubjectRequestFilters), AppError> {
     let page = q.page.unwrap_or(DEFAULT_PAGE).clamp(1, MAX_PAGE);
     let per_page = q
         .per_page
         .unwrap_or(DEFAULT_PER_PAGE)
         .clamp(1, MAX_PER_PAGE);
 
-    let from = parse_from_datetime(q.from.as_deref()).map_err(bad_request_helper)?;
-    let to = parse_to_datetime(q.to.as_deref()).map_err(bad_request_helper)?;
+    let from =
+        parse_from_datetime(q.from.as_deref()).map_err(|e| AppError::BadRequest(e.into()))?;
+    let to = parse_to_datetime(q.to.as_deref()).map_err(|e| AppError::BadRequest(e.into()))?;
 
     if let (Some(from), Some(to)) = (from, to) {
         if from > to {
-            return Err(bad_request_helper("`from` must be before or equal to `to`"));
+            return Err(AppError::BadRequest(
+                "`from` must be before or equal to `to`".into(),
+            ));
         }
     }
 
@@ -223,118 +195,45 @@ fn validate_list_query(
     ))
 }
 
-fn normalize_filter(value: Option<String>) -> Option<String> {
-    value
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-}
-
-fn parse_request_status(value: &str) -> Result<RequestStatus, (StatusCode, Json<Value>)> {
+fn parse_request_status(value: &str) -> Result<RequestStatus, AppError> {
     match value.to_ascii_lowercase().as_str() {
         "pending" => Ok(RequestStatus::Pending),
         "approved" => Ok(RequestStatus::Approved),
         "rejected" => Ok(RequestStatus::Rejected),
         "cancelled" => Ok(RequestStatus::Cancelled),
-        _ => Err(bad_request_helper(
-            "`status` must be pending, approved, rejected, or cancelled",
+        _ => Err(AppError::BadRequest(
+            "`status` must be pending, approved, rejected, or cancelled".into(),
         )),
     }
 }
 
-fn parse_request_type(value: &str) -> Result<DataSubjectRequestType, (StatusCode, Json<Value>)> {
+fn parse_request_type(value: &str) -> Result<DataSubjectRequestType, AppError> {
     match value.to_ascii_lowercase().as_str() {
         "access" => Ok(DataSubjectRequestType::Access),
         "rectify" => Ok(DataSubjectRequestType::Rectify),
         "delete" => Ok(DataSubjectRequestType::Delete),
         "stop" => Ok(DataSubjectRequestType::Stop),
-        _ => Err(bad_request_helper(
-            "`type` must be access, rectify, delete, or stop",
+        _ => Err(AppError::BadRequest(
+            "`type` must be access, rectify, delete, or stop".into(),
         )),
     }
-}
-
-fn parse_from_datetime(raw: Option<&str>) -> Result<Option<DateTime<Utc>>, &'static str> {
-    match raw {
-        Some(value) => parse_datetime_value(value, true)
-            .ok_or("`from` must be a valid datetime (RFC3339 or YYYY-MM-DD)")
-            .map(Some),
-        None => Ok(None),
-    }
-}
-
-fn parse_to_datetime(raw: Option<&str>) -> Result<Option<DateTime<Utc>>, &'static str> {
-    match raw {
-        Some(value) => parse_datetime_value(value, false)
-            .ok_or("`to` must be a valid datetime (RFC3339 or YYYY-MM-DD)")
-            .map(Some),
-        None => Ok(None),
-    }
-}
-
-fn parse_datetime_value(value: &str, is_start: bool) -> Option<DateTime<Utc>> {
-    if let Ok(dt) = DateTime::parse_from_rfc3339(value) {
-        return Some(dt.with_timezone(&Utc));
-    }
-    if let Ok(dt) = NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S") {
-        return Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc));
-    }
-    if let Ok(dt) = NaiveDateTime::parse_from_str(value, "%Y-%m-%d %H:%M:%S") {
-        return Some(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc));
-    }
-    if let Ok(date) = NaiveDate::parse_from_str(value, "%Y-%m-%d") {
-        let time = if is_start {
-            NaiveTime::from_hms_opt(0, 0, 0)
-        } else {
-            NaiveTime::from_hms_opt(23, 59, 59)
-        }?;
-        return Some(DateTime::<Utc>::from_naive_utc_and_offset(
-            NaiveDateTime::new(date, time),
-            Utc,
-        ));
-    }
-    None
-}
-
-fn map_app_error(err: AppError) -> (StatusCode, Json<Value>) {
-    match err {
-        AppError::BadRequest(message) => bad_request_helper(&message),
-        AppError::Forbidden(message) => (StatusCode::FORBIDDEN, Json(json!({ "error": message }))),
-        AppError::Unauthorized(message) => {
-            (StatusCode::UNAUTHORIZED, Json(json!({ "error": message })))
-        }
-        AppError::Conflict(message) => (StatusCode::CONFLICT, Json(json!({ "error": message }))),
-        AppError::NotFound(message) => (StatusCode::NOT_FOUND, Json(json!({ "error": message }))),
-        AppError::Validation(errors) => (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": "Validation failed", "details": { "errors": errors } })),
-        ),
-        AppError::InternalServerError(err) => {
-            tracing::error!(error = %err, "internal server error");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({ "error": "Internal server error" })),
-            )
-        }
-    }
-}
-
-fn bad_request_helper(message: &str) -> (StatusCode, Json<Value>) {
-    (StatusCode::BAD_REQUEST, Json(json!({ "error": message })))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::holiday::HolidayReason;
     use chrono::{TimeZone, Timelike};
 
-    fn err_message(err: &(StatusCode, Json<Value>)) -> String {
-        err.1
-             .0
-            .get("error")
-            .and_then(|value| value.as_str())
-            .unwrap_or_default()
-            .to_string()
+    fn app_error_message(err: AppError) -> String {
+        match err {
+            AppError::BadRequest(message)
+            | AppError::Forbidden(message)
+            | AppError::Unauthorized(message)
+            | AppError::Conflict(message)
+            | AppError::NotFound(message) => message,
+            AppError::Validation(errors) => errors.join(", "),
+            AppError::InternalServerError(err) => err.to_string(),
+        }
     }
 
     #[test]
@@ -370,8 +269,8 @@ mod tests {
     #[test]
     fn parse_request_status_rejects_unknown_value() {
         let err = parse_request_status("unknown").expect_err("invalid status");
-        assert_eq!(err.0, StatusCode::BAD_REQUEST);
-        assert!(err_message(&err).contains("`status`"));
+        assert!(matches!(err, AppError::BadRequest(_)));
+        assert!(app_error_message(err).contains("`status`"));
     }
 
     #[test]
@@ -397,30 +296,30 @@ mod tests {
     #[test]
     fn parse_request_type_rejects_unknown_value() {
         let err = parse_request_type("archive").expect_err("invalid type");
-        assert_eq!(err.0, StatusCode::BAD_REQUEST);
-        assert!(err_message(&err).contains("`type`"));
+        assert!(matches!(err, AppError::BadRequest(_)));
+        assert!(app_error_message(err).contains("`type`"));
     }
 
     #[test]
     fn parse_datetime_value_supports_rfc3339_and_sql_formats() {
-        let rfc = parse_datetime_value("2026-02-04T10:11:12+09:00", true).expect("rfc3339");
+        let rfc = parse_filter_datetime("2026-02-04T10:11:12+09:00", false).expect("rfc3339");
         assert_eq!(rfc, Utc.with_ymd_and_hms(2026, 2, 4, 1, 11, 12).unwrap());
 
-        let iso = parse_datetime_value("2026-02-04T10:11:12", true).expect("iso local");
+        let iso = parse_filter_datetime("2026-02-04T10:11:12", false).expect("iso local");
         assert_eq!(iso, Utc.with_ymd_and_hms(2026, 2, 4, 10, 11, 12).unwrap());
 
-        let sql = parse_datetime_value("2026-02-04 10:11:12", true).expect("sql datetime");
+        let sql = parse_filter_datetime("2026-02-04 10:11:12", false).expect("sql datetime");
         assert_eq!(sql, Utc.with_ymd_and_hms(2026, 2, 4, 10, 11, 12).unwrap());
     }
 
     #[test]
     fn parse_datetime_value_supports_date_only_for_range_edges() {
-        let from = parse_datetime_value("2026-02-04", true).expect("from date");
+        let from = parse_filter_datetime("2026-02-04", false).expect("from date");
         assert_eq!(from.time().hour(), 0);
         assert_eq!(from.time().minute(), 0);
         assert_eq!(from.time().second(), 0);
 
-        let to = parse_datetime_value("2026-02-04", false).expect("to date");
+        let to = parse_filter_datetime("2026-02-04", true).expect("to date");
         assert_eq!(to.time().hour(), 23);
         assert_eq!(to.time().minute(), 59);
         assert_eq!(to.time().second(), 59);
@@ -428,8 +327,8 @@ mod tests {
 
     #[test]
     fn parse_datetime_value_returns_none_for_invalid_input() {
-        assert!(parse_datetime_value("invalid", true).is_none());
-        assert!(parse_datetime_value("2026-13-01", true).is_none());
+        assert!(parse_filter_datetime("invalid", false).is_none());
+        assert!(parse_filter_datetime("2026-13-01", false).is_none());
     }
 
     #[test]
@@ -511,7 +410,7 @@ mod tests {
             per_page: None,
         })
         .expect_err("invalid status");
-        assert_eq!(bad_status.0, StatusCode::BAD_REQUEST);
+        assert!(matches!(bad_status, AppError::BadRequest(_)));
 
         let bad_type = validate_list_query(SubjectRequestListQuery {
             status: None,
@@ -523,7 +422,7 @@ mod tests {
             per_page: None,
         })
         .expect_err("invalid type");
-        assert_eq!(bad_type.0, StatusCode::BAD_REQUEST);
+        assert!(matches!(bad_type, AppError::BadRequest(_)));
     }
 
     #[test]
@@ -539,49 +438,7 @@ mod tests {
         })
         .expect_err("invalid date range");
 
-        assert_eq!(err.0, StatusCode::BAD_REQUEST);
-        assert!(err_message(&err).contains("`from`"));
-    }
-
-    #[test]
-    fn map_app_error_maps_each_variant() {
-        let bad = map_app_error(AppError::BadRequest("bad".to_string()));
-        assert_eq!(bad.0, StatusCode::BAD_REQUEST);
-        assert_eq!(err_message(&bad), "bad");
-
-        let forbidden = map_app_error(AppError::Forbidden("forbidden".to_string()));
-        assert_eq!(forbidden.0, StatusCode::FORBIDDEN);
-        assert_eq!(err_message(&forbidden), "forbidden");
-
-        let unauthorized = map_app_error(AppError::Unauthorized("unauthorized".to_string()));
-        assert_eq!(unauthorized.0, StatusCode::UNAUTHORIZED);
-        assert_eq!(err_message(&unauthorized), "unauthorized");
-
-        let conflict = map_app_error(AppError::Conflict("conflict".to_string()));
-        assert_eq!(conflict.0, StatusCode::CONFLICT);
-        assert_eq!(err_message(&conflict), "conflict");
-
-        let not_found = map_app_error(AppError::NotFound("missing".to_string()));
-        assert_eq!(not_found.0, StatusCode::NOT_FOUND);
-        assert_eq!(err_message(&not_found), "missing");
-
-        let validation = map_app_error(AppError::Validation(vec!["field: code".to_string()]));
-        assert_eq!(validation.0, StatusCode::BAD_REQUEST);
-        assert_eq!(err_message(&validation), "Validation failed");
-        assert_eq!(
-            validation.1 .0["details"]["errors"][0],
-            json!("field: code")
-        );
-
-        let internal = map_app_error(AppError::InternalServerError(anyhow::anyhow!("boom")));
-        assert_eq!(internal.0, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(err_message(&internal), "Internal server error");
-    }
-
-    #[test]
-    fn bad_request_helper_builds_error_payload() {
-        let err = bad_request_helper(HolidayReason::None.label());
-        assert_eq!(err.0, StatusCode::BAD_REQUEST);
-        assert_eq!(err_message(&err), "working day");
+        assert!(matches!(err, AppError::BadRequest(_)));
+        assert!(app_error_message(err).contains("`from`"));
     }
 }

--- a/docs/generated/exec-plans/active/EP-20260310-open-issues-321-322.md
+++ b/docs/generated/exec-plans/active/EP-20260310-open-issues-321-322.md
@@ -1,0 +1,32 @@
+# ExecPlan: Open Issue Flow for #321 and #322
+
+## Goal
+
+`handlers/admin` 配下に重複している日時フィルタ utility を共通化しつつ、`subject_requests.rs` のエラー返却を `AppError` に統一して `#321` と `#322` をまとめて解決する。
+
+## Steps
+
+- [completed] `handlers/admin/common.rs` に日時フィルタ utility を追加し、`requests.rs` / `audit_logs.rs` / `subject_requests.rs` から利用する
+- [completed] `subject_requests.rs` の戻り値を `AppError` に統一した
+- [completed] focused validation を実行した
+- [in_progress] `jj` snapshot と PR 作成を行う
+
+## Validation
+
+- `cargo test -p timekeeper-backend --test admin_subject_requests_api -- --nocapture`
+- `cargo test -p timekeeper-backend --test audit_log_repo -- --nocapture`
+- `cargo test -p timekeeper-backend --test admin_audit_logs_api -- --nocapture`
+- `cargo fmt --all`
+
+## Done Criteria
+
+- `#321` の重複 utility が `handlers/admin/common.rs` に集約されている
+- `#322` の `subject_requests.rs` が `AppError` を返す
+- 変更 seam の focused test が成功している
+- PR が作成されている
+
+## Validation Log
+
+- `cargo test -p timekeeper-backend --test admin_subject_requests_api -- --nocapture`
+- `cargo test -p timekeeper-backend --test admin_audit_logs_api -- --nocapture`
+- `cargo fmt --all`


### PR DESCRIPTION
## Summary
- move shared admin datetime/filter helpers into `handlers/admin/common.rs`
- reuse those helpers from `requests.rs`, `audit_logs.rs`, and `subject_requests.rs`
- convert `admin/subject_requests.rs` to return `AppError` consistently instead of tuple responses

## Validation
- cargo test -p timekeeper-backend --test admin_subject_requests_api -- --nocapture
- cargo test -p timekeeper-backend --test admin_audit_logs_api -- --nocapture
- cargo fmt --all

Closes #321
Closes #322
