### PR TITLE
fix(repo): cap find_all query sizes

### DIFF
--- a/backend/src/repositories/attendance_repository.rs
+++ b/backend/src/repositories/attendance_repository.rs
@@ -100,14 +100,16 @@ impl AttendanceRepository {
     }
 }
 
+const MAX_FIND_ALL_ROWS: i64 = 1_000;
+
 #[async_trait]
 impl AttendanceRepositoryTrait for AttendanceRepository {
     async fn find_all(&self, db: &PgPool) -> Result<Vec<Attendance>, AppError> {
         const SELECT_COLUMNS: &str =
             "id, user_id, date, clock_in_time, clock_out_time, status, total_work_hours, created_at, updated_at";
         let query = format!(
-            "SELECT {} FROM attendance ORDER BY date DESC",
-            SELECT_COLUMNS
+            "SELECT {} FROM attendance ORDER BY date DESC LIMIT {}",
+            SELECT_COLUMNS, MAX_FIND_ALL_ROWS
         );
         let rows = sqlx::query_as::<_, Attendance>(&query)
             .fetch_all(db)

--- a/backend/src/repositories/leave_request_repository.rs
+++ b/backend/src/repositories/leave_request_repository.rs
@@ -98,14 +98,17 @@ impl LeaveRequestRepository {
     }
 }
 
+const MAX_FIND_ALL_ROWS: i64 = 1_000;
+
 #[async_trait]
 impl LeaveRequestRepositoryTrait for LeaveRequestRepository {
     async fn find_all(&self, db: &PgPool) -> Result<Vec<LeaveRequest>, AppError> {
         let query = format!(
-            "SELECT {} FROM {} ORDER BY start_date DESC",
+            "SELECT {} FROM {} ORDER BY start_date DESC LIMIT {}",
             "id, user_id, leave_type, start_date, end_date, reason, status, \
              approved_by, approved_at, rejected_by, rejected_at, cancelled_at, decision_comment, created_at, updated_at",
-            "leave_requests"
+            "leave_requests",
+            MAX_FIND_ALL_ROWS
         );
         let rows = sqlx::query_as::<_, LeaveRequest>(&query)
             .fetch_all(db)

--- a/backend/src/repositories/overtime_request_repository.rs
+++ b/backend/src/repositories/overtime_request_repository.rs
@@ -110,14 +110,17 @@ impl OvertimeRequestRepository {
     }
 }
 
+const MAX_FIND_ALL_ROWS: i64 = 1_000;
+
 #[async_trait]
 impl OvertimeRequestRepositoryTrait for OvertimeRequestRepository {
     async fn find_all(&self, db: &PgPool) -> Result<Vec<OvertimeRequest>, AppError> {
         let query = format!(
-            "SELECT {} FROM {} ORDER BY date DESC",
+            "SELECT {} FROM {} ORDER BY date DESC LIMIT {}",
             "id, user_id, date, planned_hours, reason, status, approved_by, \
              approved_at, rejected_by, rejected_at, cancelled_at, decision_comment, created_at, updated_at",
-            "overtime_requests"
+            "overtime_requests",
+            MAX_FIND_ALL_ROWS
         );
         let rows = sqlx::query_as::<_, OvertimeRequest>(&query)
             .fetch_all(db)

--- a/backend/tests/attendance_repository.rs
+++ b/backend/tests/attendance_repository.rs
@@ -29,7 +29,7 @@ async fn attendance_repository_roundtrip() {
         .run(&pool)
         .await
         .expect("run migrations");
-    sqlx::query("TRUNCATE break_records, attendance")
+    sqlx::query("TRUNCATE attendance, break_records CASCADE")
         .execute(&pool)
         .await
         .expect("truncate attendance tables");
@@ -65,6 +65,39 @@ async fn attendance_repository_roundtrip() {
 }
 
 #[tokio::test]
+async fn attendance_repository_find_all_is_capped() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    sqlx::query("TRUNCATE attendance, break_records CASCADE")
+        .execute(&pool)
+        .await
+        .expect("truncate attendance tables");
+
+    let user = support::seed_user(&pool, UserRole::Employee, false).await;
+    let repo = AttendanceRepository::new();
+    let now = Utc::now();
+    let base_date = NaiveDate::from_ymd_opt(2024, 1, 1).expect("date");
+
+    for day_offset in 0..1_005_i64 {
+        let date = base_date
+            .checked_add_signed(chrono::Duration::days(day_offset))
+            .expect("date offset");
+        let attendance = Attendance::new(user.id, date, now);
+        repo.create(&pool, &attendance)
+            .await
+            .expect("create attendance");
+    }
+
+    let rows = repo.find_all(&pool).await.expect("find all");
+    assert_eq!(rows.len(), 1_000);
+    assert_eq!(rows[0].date, base_date + chrono::Duration::days(1_004));
+}
+
+#[tokio::test]
 async fn break_record_repository_roundtrip() {
     let _guard = integration_guard().await;
     let pool = support::test_pool().await;
@@ -72,7 +105,7 @@ async fn break_record_repository_roundtrip() {
         .run(&pool)
         .await
         .expect("run migrations");
-    sqlx::query("TRUNCATE break_records, attendance")
+    sqlx::query("TRUNCATE attendance, break_records CASCADE")
         .execute(&pool)
         .await
         .expect("truncate attendance tables");

--- a/backend/tests/request_repository_impls.rs
+++ b/backend/tests/request_repository_impls.rs
@@ -183,6 +183,37 @@ async fn leave_request_repository_impl_covers_crud_and_state_changes() {
 }
 
 #[tokio::test]
+async fn leave_request_repository_find_all_is_capped() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    reset_tables(&pool).await;
+
+    let user = support::seed_user(&pool, UserRole::Employee, false).await;
+    let repo = LeaveRequestRepository::new();
+    let base_date = NaiveDate::from_ymd_opt(2026, 1, 1).expect("date");
+
+    for day_offset in 0..1_005_i64 {
+        let start = base_date
+            .checked_add_signed(chrono::Duration::days(day_offset))
+            .expect("date offset");
+        let end = start;
+        let request = LeaveRequest::new(user.id, LeaveType::Annual, start, end, None);
+        repo.create(&pool, &request).await.expect("create leave");
+    }
+
+    let rows = repo.find_all(&pool).await.expect("find all");
+    assert_eq!(rows.len(), 1_000);
+    assert_eq!(
+        rows[0].start_date,
+        base_date + chrono::Duration::days(1_004)
+    );
+}
+
+#[tokio::test]
 async fn overtime_request_repository_impl_covers_crud_and_state_changes() {
     let _guard = integration_guard().await;
     let pool = support::test_pool().await;
@@ -326,4 +357,31 @@ async fn overtime_request_repository_impl_covers_crud_and_state_changes() {
         ),
         "deleted request should be not found"
     );
+}
+
+#[tokio::test]
+async fn overtime_request_repository_find_all_is_capped() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+    reset_tables(&pool).await;
+
+    let user = support::seed_user(&pool, UserRole::Employee, false).await;
+    let repo = OvertimeRequestRepository::new();
+    let base_date = NaiveDate::from_ymd_opt(2026, 1, 1).expect("date");
+
+    for day_offset in 0..1_005_i64 {
+        let date = base_date
+            .checked_add_signed(chrono::Duration::days(day_offset))
+            .expect("date offset");
+        let request = OvertimeRequest::new(user.id, date, 1.5, None);
+        repo.create(&pool, &request).await.expect("create overtime");
+    }
+
+    let rows = repo.find_all(&pool).await.expect("find all");
+    assert_eq!(rows.len(), 1_000);
+    assert_eq!(rows[0].date, base_date + chrono::Duration::days(1_004));
 }

--- a/docs/generated/exec-plans/active/EP-20260310-open-issue-324.md
+++ b/docs/generated/exec-plans/active/EP-20260310-open-issue-324.md
@@ -1,0 +1,35 @@
+# ExecPlan: Open Issue Flow for #324
+
+## Goal
+
+`attendance`, `leave_request`, `overtime_request` repository の `find_all()` に安全な件数上限を追加し、`#324` を current `main` から単独 PR として出す。
+
+## Decision
+
+- 上限は repository 内部定数 `MAX_FIND_ALL_ROWS = 1000` とする
+- 既存シグネチャは変えず、`ORDER BY ... LIMIT 1000` を追加する
+
+## Steps
+
+- [completed] 3 repository の `find_all()` に件数上限を追加した
+- [completed] 上限制御を検証する focused test を追加した
+- [completed] focused validation を実行した
+- [in_progress] `jj` snapshot と PR 作成を行う
+
+## Validation
+
+- `cargo test -p timekeeper-backend --test attendance_repository -- --nocapture`
+- `cargo test -p timekeeper-backend --test request_repository_impls -- --nocapture`
+- `cargo fmt --all`
+
+## Done Criteria
+
+- 3 repository の `find_all()` が `LIMIT 1000` つきで動作する
+- limit を超える件数でも 1000 件で打ち止めになるテストがある
+- PR が作成されている
+
+## Validation Log
+
+- `cargo test -p timekeeper-backend --test attendance_repository -- --nocapture`
+- `cargo test -p timekeeper-backend --test request_repository_impls -- --nocapture`
+- `cargo fmt --all`


### PR DESCRIPTION
## Summary
- add a hard `LIMIT 1000` cap to the attendance / leave / overtime repository `find_all()` queries
- add repository tests that prove `find_all()` stops at 1000 rows
- update the attendance repository test cleanup to match the current FK graph

## Validation
- cargo test -p timekeeper-backend --test attendance_repository -- --nocapture
- cargo test -p timekeeper-backend --test request_repository_impls -- --nocapture
- cargo fmt --all

Closes #324
