### PR TITLE
feat(audit-log): support selectable page size

### DIFF
--- a/docs/generated/exec-plans/active/EP-20260310-open-issue-124.md
+++ b/docs/generated/exec-plans/active/EP-20260310-open-issue-124.md
@@ -1,0 +1,33 @@
+# ExecPlan: Open Issue Flow for #124
+
+## Goal
+
+監査ログ一覧画面で 1 ページあたりの表示件数を `10 / 20 / 50` から選択できるようにし、選択値が API リクエストとページネーションに反映される状態で PR 作成まで完了する。
+
+## Steps
+
+- [completed] `view_model.rs` に `per_page` シグナルを追加し、監査ログ取得リクエストへ渡した
+- [completed] `panel.rs` に表示件数セレクトボックスと page reset ロジックを追加した
+- [completed] host test / helper test を更新して focused validation を実行した
+- [in_progress] `jj commit` を作成し、push と GitHub PR 作成まで完了する
+
+## Validation
+
+- `cargo test -p timekeeper-frontend --lib admin_audit_logs -- --nocapture`
+- `cargo fmt --all`
+- `cargo clippy -p timekeeper-frontend --all-targets -- -D warnings`
+
+## Validation Log
+
+- `cargo test -p timekeeper-frontend --lib admin_audit_logs -- --nocapture`
+  - 14 passed
+- `cargo fmt --all`
+- `cargo clippy -p timekeeper-frontend --all-targets -- -D warnings`
+  - 既存の `frontend/src/components/layout.rs`, `frontend/src/api/audit_log.rs`, `frontend/src/api/client.rs`, `frontend/src/api/subject_requests.rs` 由来の warning/error で失敗。今回差分起因の clippy error は解消済み
+
+## Done Criteria
+
+- 監査ログ一覧で `10 / 20 / 50` 件を選択できる
+- 選択値が `list_audit_logs_with_policy(..., per_page, ...)` に渡る
+- 表示件数変更時にページ番号が 1 に戻る
+- focused validation が成功し、issue `#124` の PR が作成されている

--- a/frontend/src/pages/admin_audit_logs/panel.rs
+++ b/frontend/src/pages/admin_audit_logs/panel.rs
@@ -1,3 +1,5 @@
+#[cfg(all(test, not(target_arch = "wasm32")))]
+use super::view_model::DEFAULT_AUDIT_LOGS_PER_PAGE;
 use super::view_model::{use_audit_log_view_model, AuditLogFilters, AUDIT_EVENT_TYPES};
 use crate::api::{ApiError, AuditLog, AuditLogListResponse};
 use crate::components::common::{Button, ButtonVariant};
@@ -59,6 +61,20 @@ fn page_summary_label(total: i64, per_page: i64) -> String {
 fn apply_filter_change(filters: &mut AuditLogFilters, page: &mut i64, field: &str, value: String) {
     update_filter_value(filters, field, value);
     *page = 1;
+}
+
+fn parse_per_page_value(raw: &str) -> Option<i64> {
+    match raw.parse::<i64>().ok()? {
+        value @ (10 | 20 | 50) => Some(value),
+        _ => None,
+    }
+}
+
+fn apply_per_page_change(per_page: &mut i64, page: &mut i64, raw: &str) {
+    if let Some(value) = parse_per_page_value(raw) {
+        *per_page = value;
+        *page = 1;
+    }
 }
 
 fn clear_filters_and_reset_page(filters: &mut AuditLogFilters, page: &mut i64) {
@@ -302,6 +318,13 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
         });
         vm.page.set(page);
     };
+    let on_per_page_change = move |ev: web_sys::Event| {
+        let mut page = vm.page.get_untracked();
+        vm.per_page.update(|per_page| {
+            apply_per_page_change(per_page, &mut page, &event_target_value(&ev));
+        });
+        vm.page.set(page);
+    };
     let on_metadata_modal_keydown = move |ev: KeyboardEvent| match ev.key().as_str() {
         "Escape" => {
             ev.prevent_default();
@@ -370,7 +393,7 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
                     </Show>
 
                     <div class="bg-surface-elevated p-4 rounded-lg shadow space-y-4">
-                        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+                        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
                             <div>
                                 <label class="block text-sm font-medium text-fg-muted">"日時 (From)"</label>
                                 <input type="datetime-local" class="mt-1 block w-full rounded-md border-form-control-border bg-form-control-bg text-form-control-text shadow-sm sm:text-sm border px-2 py-1"
@@ -413,6 +436,18 @@ pub fn AdminAuditLogsPage() -> impl IntoView {
                                     <option value="">"すべて"</option>
                                     <option value="success">"成功"</option>
                                     <option value="failure">"失敗"</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-fg-muted">"表示件数"</label>
+                                <select
+                                    class="mt-1 block w-full rounded-md border-form-control-border bg-form-control-bg text-form-control-text shadow-sm sm:text-sm border px-2 py-1"
+                                    prop:value=move || vm.per_page.get().to_string()
+                                    on:change=on_per_page_change
+                                >
+                                    <option value="10">"10件"</option>
+                                    <option value="20">"20件"</option>
+                                    <option value="50">"50件"</option>
                                 </select>
                             </div>
                         </div>
@@ -645,6 +680,8 @@ mod host_tests {
         });
         assert!(html.contains("監査ログ"));
         assert!(html.contains("JSONエクスポート"));
+        assert!(html.contains("表示件数"));
+        assert!(html.contains("20件"));
     }
 
     #[test]
@@ -672,10 +709,25 @@ mod host_tests {
         assert!(!can_go_next(1, 10, 0));
         assert_eq!(page_summary_label(41, 20), " / 3");
         assert_eq!(page_summary_label(10, 0), " / 1");
+        assert_eq!(parse_per_page_value("10"), Some(10));
+        assert_eq!(parse_per_page_value("20"), Some(20));
+        assert_eq!(parse_per_page_value("50"), Some(50));
+        assert_eq!(parse_per_page_value("5"), None);
+        assert_eq!(parse_per_page_value("bad"), None);
 
         apply_filter_change(&mut filters, &mut page, "actor_id", "admin-2".into());
         assert_eq!(filters.actor_id, "admin-2");
         assert_eq!(page, 1);
+
+        let mut per_page = DEFAULT_AUDIT_LOGS_PER_PAGE;
+        page = 4;
+        apply_per_page_change(&mut per_page, &mut page, "50");
+        assert_eq!(per_page, 50);
+        assert_eq!(page, 1);
+        page = 3;
+        apply_per_page_change(&mut per_page, &mut page, "bad");
+        assert_eq!(per_page, 50);
+        assert_eq!(page, 3);
 
         clear_filters_and_reset_page(&mut filters, &mut page);
         assert_eq!(filters, AuditLogFilters::default());

--- a/frontend/src/pages/admin_audit_logs/view_model.rs
+++ b/frontend/src/pages/admin_audit_logs/view_model.rs
@@ -2,6 +2,8 @@ use crate::api::{ApiClient, ApiError, AuditLogListResponse};
 use leptos::*;
 use wasm_bindgen::JsCast;
 
+pub const DEFAULT_AUDIT_LOGS_PER_PAGE: i64 = 20;
+
 pub const AUDIT_EVENT_TYPES: &[(&str, &str)] = &[
     // 認証・アカウント
     ("auth_login", "ログイン"),
@@ -97,8 +99,10 @@ impl AuditLogFilters {
 
 #[derive(Clone)]
 pub struct AuditLogViewModel {
-    pub logs_resource: Resource<(i64, AuditLogFilters), Result<AuditLogListResponse, ApiError>>,
+    pub logs_resource:
+        Resource<(i64, i64, AuditLogFilters), Result<AuditLogListResponse, ApiError>>,
     pub page: RwSignal<i64>,
+    pub per_page: RwSignal<i64>,
     pub filters: RwSignal<AuditLogFilters>,
     pub pii_masked: RwSignal<bool>,
     pub export_action: Action<(), Result<(), ApiError>>,
@@ -107,19 +111,22 @@ pub struct AuditLogViewModel {
 pub fn use_audit_log_view_model() -> AuditLogViewModel {
     let api_client = use_context::<ApiClient>().unwrap_or_else(ApiClient::new);
     let page = create_rw_signal(1);
+    let per_page = create_rw_signal(DEFAULT_AUDIT_LOGS_PER_PAGE);
     let filters = create_rw_signal(AuditLogFilters::default());
     let pii_masked = create_rw_signal(false);
 
     let api = api_client.clone();
     let logs_resource = create_resource(
-        move || (page.get(), filters.get()),
-        move |(p, f)| {
+        move || (page.get(), per_page.get(), filters.get()),
+        move |(p, per_page, f)| {
             let api = api.clone();
             let pii_masked = pii_masked;
             async move {
                 let (from, to, actor_id, event_type, result) = f.into_query_params();
                 let response = api
-                    .list_audit_logs_with_policy(p, 20, from, to, actor_id, event_type, result)
+                    .list_audit_logs_with_policy(
+                        p, per_page, from, to, actor_id, event_type, result,
+                    )
                     .await?;
                 pii_masked.set(response.pii_masked);
                 Ok(response.data)
@@ -170,6 +177,7 @@ pub fn use_audit_log_view_model() -> AuditLogViewModel {
     AuditLogViewModel {
         logs_resource,
         page,
+        per_page,
         filters,
         pii_masked,
         export_action,
@@ -254,6 +262,11 @@ mod tests {
     #[test]
     fn optional_param_keeps_whitespace_input_as_some() {
         assert_eq!(optional_param(" ".to_string()), Some(" ".to_string()));
+    }
+
+    #[test]
+    fn default_per_page_matches_current_ui_default() {
+        assert_eq!(DEFAULT_AUDIT_LOGS_PER_PAGE, 20);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a selectable per-page signal to the admin audit log view model
- add a 10/20/50 page-size selector that resets pagination to page 1
- cover the new selector and pagination helper behavior with host tests

Closes #124

## Validation
- cargo test -p timekeeper-frontend --lib admin_audit_logs -- --nocapture
- cargo fmt --all
- cargo clippy -p timekeeper-frontend --all-targets -- -D warnings (fails on pre-existing frontend warnings in layout/api modules)