### PR TITLE
feat(auth): add active session management ui

### DIFF
--- a/docs/generated/exec-plans/active/EP-20260310-open-issue-149.md
+++ b/docs/generated/exec-plans/active/EP-20260310-open-issue-149.md
@@ -1,0 +1,39 @@
+# ExecPlan: Open Issue Flow for #149
+
+## Goal
+
+既存 backend session API を frontend へ接続し、設定画面でアクティブセッション一覧と他デバイスのログアウトを行え、管理者ユーザー詳細でも対象ユーザーのセッション一覧と強制ログアウトを行える状態で PR 作成まで完了する。
+
+## Steps
+
+- [completed] frontend API/type に session list/revoke の入口を追加した
+- [completed] settings 画面に自分のアクティブセッション一覧と revoke 操作を追加した
+- [completed] admin user detail に対象ユーザーの session list/revoke を追加した
+- [completed] focused frontend tests と format を実行した
+- [in_progress] `jj commit` を作成し、push と GitHub PR 作成まで完了する
+
+## Validation
+
+- `cargo test -p timekeeper-frontend --lib settings -- --nocapture`
+- `cargo test -p timekeeper-frontend --lib admin_users -- --nocapture`
+- `cargo test -p timekeeper-frontend --lib api_client_admin_and_auth_endpoints_succeed -- --nocapture`
+- `cargo fmt --all`
+
+## Validation Log
+
+- `cargo test -p timekeeper-frontend --lib settings -- --nocapture`
+  - 17 passed
+- `cargo test -p timekeeper-frontend --lib admin_users -- --nocapture`
+  - 20 passed
+- `cargo test -p timekeeper-frontend --lib api_client_admin_and_auth_endpoints_succeed -- --nocapture`
+  - 1 passed
+- `cargo fmt --all`
+- `cargo clippy -p timekeeper-frontend --all-targets -- -D warnings`
+  - `frontend/src/components/layout.rs` と既存の `frontend/src/api/*`, `frontend/src/pages/*` にある pre-existing clippy violations で失敗。今回変更起因の `detail.rs` clone-on-copy は解消済み
+
+## Done Criteria
+
+- `/settings` にアクティブセッション一覧と他セッションログアウト UI がある
+- 管理者のユーザー詳細ドロワーから対象ユーザーのセッション一覧を見て revoke できる
+- frontend は既存 backend の `/auth/sessions`, `/admin/users/{id}/sessions`, `/admin/sessions/{id}` を利用している
+- focused validation が成功し、issue `#149` の PR が作成されている

--- a/frontend/src/api/auth.rs
+++ b/frontend/src/api/auth.rs
@@ -1,8 +1,11 @@
 use serde_json::json;
 
 use super::{
-    client::{ensure_device_label, ApiClient},
-    types::{ApiError, LoginRequest, LoginResponse, MfaSetupResponse, MfaStatusResponse},
+    client::{encode_path_segment, ensure_device_label, ApiClient},
+    types::{
+        AdminSessionResponse, ApiError, LoginRequest, LoginResponse, MfaSetupResponse,
+        MfaStatusResponse, SessionResponse,
+    },
 };
 
 impl ApiClient {
@@ -185,6 +188,112 @@ impl ApiClient {
                     .http_client()
                     .put(format!("{}/auth/change-password", base_url))
                     .json(&payload))
+            })
+            .await?;
+
+        let status = response.status();
+        Self::handle_unauthorized_status(status);
+        if status.is_success() {
+            Ok(())
+        } else {
+            let error: ApiError = response
+                .json()
+                .await
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
+            Err(error)
+        }
+    }
+
+    pub async fn list_sessions(&self) -> Result<Vec<SessionResponse>, ApiError> {
+        let base_url = self.resolved_base_url().await;
+        let response = self
+            .send_with_refresh(|| {
+                Ok(self
+                    .http_client()
+                    .get(format!("{}/auth/sessions", base_url)))
+            })
+            .await?;
+
+        let status = response.status();
+        Self::handle_unauthorized_status(status);
+        if status.is_success() {
+            response
+                .json()
+                .await
+                .map_err(|e| ApiError::unknown(format!("Failed to parse response: {}", e)))
+        } else {
+            let error: ApiError = response
+                .json()
+                .await
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
+            Err(error)
+        }
+    }
+
+    pub async fn revoke_session(&self, session_id: &str) -> Result<(), ApiError> {
+        let base_url = self.resolved_base_url().await;
+        let encoded_session_id = encode_path_segment(session_id);
+        let response = self
+            .send_with_refresh(|| {
+                Ok(self
+                    .http_client()
+                    .delete(format!("{}/auth/sessions/{}", base_url, encoded_session_id)))
+            })
+            .await?;
+
+        let status = response.status();
+        Self::handle_unauthorized_status(status);
+        if status.is_success() {
+            Ok(())
+        } else {
+            let error: ApiError = response
+                .json()
+                .await
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
+            Err(error)
+        }
+    }
+
+    pub async fn admin_list_user_sessions(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<AdminSessionResponse>, ApiError> {
+        let base_url = self.resolved_base_url().await;
+        let encoded_user_id = encode_path_segment(user_id);
+        let response = self
+            .send_with_refresh(|| {
+                Ok(self.http_client().get(format!(
+                    "{}/admin/users/{}/sessions",
+                    base_url, encoded_user_id
+                )))
+            })
+            .await?;
+
+        let status = response.status();
+        Self::handle_unauthorized_status(status);
+        if status.is_success() {
+            response
+                .json()
+                .await
+                .map_err(|e| ApiError::unknown(format!("Failed to parse response: {}", e)))
+        } else {
+            let error: ApiError = response
+                .json()
+                .await
+                .map_err(ApiClient::map_error_payload_parse_failure)?;
+            Err(error)
+        }
+    }
+
+    pub async fn admin_revoke_session(&self, session_id: &str) -> Result<(), ApiError> {
+        let base_url = self.resolved_base_url().await;
+        let encoded_session_id = encode_path_segment(session_id);
+        let response = self
+            .send_with_refresh(|| {
+                Ok(self.http_client().delete(format!(
+                    "{}/admin/sessions/{}",
+                    base_url, encoded_session_id
+                )))
             })
             .await?;
 

--- a/frontend/src/api/tests.rs
+++ b/frontend/src/api/tests.rs
@@ -60,6 +60,21 @@ fn attendance_status_json(status: &str) -> serde_json::Value {
     })
 }
 
+fn session_json(id: &str, user_id: Option<&str>, is_current: bool) -> serde_json::Value {
+    let mut value = json!({
+        "id": id,
+        "device_label": "Chrome on macOS",
+        "created_at": "2026-03-10T10:00:00Z",
+        "last_seen_at": "2026-03-10T10:30:00Z",
+        "expires_at": "2026-03-17T10:00:00Z",
+        "is_current": is_current
+    });
+    if let Some(user_id) = user_id {
+        value["user_id"] = json!(user_id);
+    }
+    value
+}
+
 fn attendance_summary_json() -> serde_json::Value {
     json!({
         "month": 1,
@@ -186,11 +201,29 @@ async fn api_client_admin_and_auth_endpoints_succeed() {
         then.status(200).json_body(json!({}));
     });
     server.mock(|when, then| {
+        when.method(GET).path("/api/auth/sessions");
+        then.status(200)
+            .json_body(json!([session_json("session-1", None, true)]));
+    });
+    server.mock(|when, then| {
+        when.method(DELETE).path("/api/auth/sessions/session-1");
+        then.status(200).json_body(json!({}));
+    });
+    server.mock(|when, then| {
         when.method(DELETE).path("/api/admin/users/u1");
         then.status(200).json_body(json!({}));
     });
     server.mock(|when, then| {
         when.method(POST).path("/api/admin/users/u1/unlock");
+        then.status(200).json_body(json!({}));
+    });
+    server.mock(|when, then| {
+        when.method(GET).path("/api/admin/users/u1/sessions");
+        then.status(200)
+            .json_body(json!([session_json("session-1", Some("u1"), false)]));
+    });
+    server.mock(|when, then| {
+        when.method(DELETE).path("/api/admin/sessions/session-1");
         then.status(200).json_body(json!({}));
     });
     server.mock(|when, then| {
@@ -290,8 +323,15 @@ async fn api_client_admin_and_auth_endpoints_succeed() {
         "u2"
     );
     client.admin_reset_mfa("u1").await.unwrap();
+    assert_eq!(client.list_sessions().await.unwrap().len(), 1);
+    client.revoke_session("session-1").await.unwrap();
     client.admin_delete_user("u1", false).await.unwrap();
     client.admin_unlock_user("u1").await.unwrap();
+    assert_eq!(
+        client.admin_list_user_sessions("u1").await.unwrap().len(),
+        1
+    );
+    client.admin_revoke_session("session-1").await.unwrap();
     assert_eq!(client.admin_get_archived_users().await.unwrap().len(), 1);
     client.admin_restore_archived_user("a1").await.unwrap();
     client.admin_delete_archived_user("a1").await.unwrap();

--- a/frontend/src/api/types.rs
+++ b/frontend/src/api/types.rs
@@ -54,6 +54,27 @@ pub struct MfaStatusResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionResponse {
+    pub id: String,
+    pub device_label: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub last_seen_at: Option<DateTime<Utc>>,
+    pub expires_at: DateTime<Utc>,
+    pub is_current: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdminSessionResponse {
+    pub id: String,
+    pub user_id: String,
+    pub device_label: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub last_seen_at: Option<DateTime<Utc>>,
+    pub expires_at: DateTime<Utc>,
+    pub is_current: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AttendanceResponse {
     pub id: String,
     pub user_id: String,

--- a/frontend/src/pages/admin_users/components/detail.rs
+++ b/frontend/src/pages/admin_users/components/detail.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{ApiError, UserResponse},
+    api::{AdminSessionResponse, ApiError, UserResponse},
     components::{
         confirm_dialog::ConfirmDialog, error::InlineErrorMessage, layout::SuccessMessage,
     },
@@ -21,18 +21,38 @@ fn delete_confirm_message(hard_delete_mode: bool) -> &'static str {
     }
 }
 
+fn session_device_label(label: Option<&str>) -> &str {
+    label.unwrap_or("不明なデバイス")
+}
+
+fn format_session_datetime(value: chrono::DateTime<chrono::Utc>) -> String {
+    value.format("%Y-%m-%d %H:%M").to_string()
+}
+
+fn format_optional_session_datetime(value: Option<chrono::DateTime<chrono::Utc>>) -> String {
+    value
+        .map(format_session_datetime)
+        .unwrap_or_else(|| "未記録".to_string())
+}
+
 #[component]
 pub fn UserDetailDrawer(
     selected_user: RwSignal<Option<UserResponse>>,
+    user_sessions_resource: Resource<
+        (bool, Option<String>),
+        Result<Vec<AdminSessionResponse>, ApiError>,
+    >,
     messages: MessageState,
     reset_mfa_action: Action<String, Result<(), ApiError>>,
     unlock_user_action: Action<String, Result<(), ApiError>>,
+    revoke_session_action: Action<String, Result<(), ApiError>>,
     delete_user_action: Action<(String, bool), Result<(), ApiError>>,
     /// Current user's ID to prevent self-deletion
     current_user_id: Signal<Option<String>>,
 ) -> impl IntoView {
     let pending = reset_mfa_action.pending();
     let unlock_pending = unlock_user_action.pending();
+    let revoke_pending = revoke_session_action.pending();
     let delete_pending = delete_user_action.pending();
 
     // State for delete confirmation
@@ -165,6 +185,67 @@ pub fn UserDetailDrawer(
                                                 {move || if unlock_pending.get() { "ロック解除中..." } else { "ロックを解除" }}
                                             </button>
                                         </Show>
+                                        <div class="border-t pt-4 mt-4 space-y-3">
+                                            <div>
+                                                <p class="text-sm text-fg-muted">{"アクティブセッション"}</p>
+                                                <p class="text-xs text-fg-muted">{"対象ユーザーのログイン中デバイスを確認し、必要に応じて強制ログアウトできます。"}</p>
+                                            </div>
+                                            {move || {
+                                                match user_sessions_resource.get() {
+                                                    Some(Ok(sessions)) if sessions.is_empty() => view! {
+                                                        <div class="rounded-lg border border-dashed border-border px-3 py-4 text-sm text-fg-muted">
+                                                            {"アクティブなセッションはありません。"}
+                                                        </div>
+                                                    }.into_view(),
+                                                    Some(Ok(sessions)) => view! {
+                                                        <div class="space-y-2">
+                                                            {sessions.into_iter().map(|session| {
+                                                                let session_id = session.id.clone();
+                                                                let is_current = session.is_current;
+                                                                let device_label = session_device_label(session.device_label.as_deref()).to_string();
+                                                                let created_at = format_session_datetime(session.created_at);
+                                                                let last_seen_at = format_optional_session_datetime(session.last_seen_at);
+                                                                let expires_at = format_session_datetime(session.expires_at);
+                                                                view! {
+                                                                    <div class="rounded-lg border border-border bg-surface-muted px-3 py-3 space-y-2">
+                                                                        <div class="flex items-center justify-between gap-3">
+                                                                            <div>
+                                                                                <div class="text-sm font-medium text-fg">{device_label}</div>
+                                                                                <div class="text-xs text-fg-muted">
+                                                                                    {if is_current { "現在のセッション" } else { "他のデバイス" }}
+                                                                                </div>
+                                                                            </div>
+                                                                            <button
+                                                                                class="px-3 py-2 rounded bg-action-danger-bg text-action-danger-text hover:bg-action-danger-bg-hover disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                                                                                disabled=move || is_current || revoke_pending.get()
+                                                                                on:click=move |_| revoke_session_action.dispatch(session_id.clone())
+                                                                            >
+                                                                                {if is_current { "このセッションです" } else { "強制ログアウト" }}
+                                                                            </button>
+                                                                        </div>
+                                                                        <dl class="grid grid-cols-1 gap-1 text-xs text-fg-muted">
+                                                                            <div><dt class="inline font-medium">{"開始: "}</dt><dd class="inline text-fg">{created_at}</dd></div>
+                                                                            <div><dt class="inline font-medium">{"最終利用: "}</dt><dd class="inline text-fg">{last_seen_at}</dd></div>
+                                                                            <div><dt class="inline font-medium">{"有効期限: "}</dt><dd class="inline text-fg">{expires_at}</dd></div>
+                                                                        </dl>
+                                                                    </div>
+                                                                }
+                                                            }).collect_view()}
+                                                        </div>
+                                                    }.into_view(),
+                                                    Some(Err(error)) => view! {
+                                                        <div class="rounded-lg border border-status-error-border bg-status-error-bg px-3 py-3 text-sm text-status-error-text">
+                                                            {error.to_string()}
+                                                        </div>
+                                                    }.into_view(),
+                                                    None => view! {
+                                                        <div class="rounded-lg border border-dashed border-border px-3 py-4 text-sm text-fg-muted">
+                                                            {"セッションを読み込んでいます..."}
+                                                        </div>
+                                                    }.into_view(),
+                                                }
+                                            }}
+                                        </div>
 
                                         // Delete buttons (hidden for self)
                                         <Show when=move || !is_self>
@@ -173,14 +254,14 @@ pub fn UserDetailDrawer(
                                                 <button
                                                     class="w-full px-4 py-2 rounded bg-status-warning-text text-text-inverse disabled:opacity-50"
                                                     disabled=move || delete_pending.get()
-                                                    on:click=soft_delete_click.clone()
+                                                    on:click=soft_delete_click
                                                 >
                                                     {"退職処理（アーカイブ）"}
                                                 </button>
                                                 <button
                                                     class="w-full px-4 py-2 rounded bg-action-danger-bg text-action-danger-text hover:bg-action-danger-bg-hover disabled:opacity-50"
                                                     disabled=move || delete_pending.get()
-                                                    on:click=hard_delete_click.clone()
+                                                    on:click=hard_delete_click
                                                 >
                                                     {"完全削除"}
                                                 </button>
@@ -234,17 +315,24 @@ mod host_tests {
     fn user_detail_drawer_renders() {
         let html = render_to_string(move || {
             let selected = create_rw_signal(Some(user()));
+            let user_sessions = create_resource(
+                move || (true, Some("u1".to_string())),
+                move |_| async move { Ok::<_, ApiError>(Vec::<AdminSessionResponse>::new()) },
+            );
             let messages = MessageState::default();
             let reset_action = create_action(|_: &String| async move { Ok(()) });
             let unlock_action = create_action(|_: &String| async move { Ok(()) });
+            let revoke_session_action = create_action(|_: &String| async move { Ok(()) });
             let delete_action = create_action(|_: &(String, bool)| async move { Ok(()) });
             let current_user_id = Signal::derive(|| None::<String>);
             view! {
                 <UserDetailDrawer
                     selected_user=selected
+                    user_sessions_resource=user_sessions
                     messages=messages
                     reset_mfa_action=reset_action
                     unlock_user_action=unlock_action
+                    revoke_session_action=revoke_session_action
                     delete_user_action=delete_action
                     current_user_id=current_user_id
                 />
@@ -252,6 +340,7 @@ mod host_tests {
         });
         assert!(html.contains("Alice Example"));
         assert!(html.contains("MFA"));
+        assert!(html.contains("アクティブセッション"));
     }
 
     #[test]
@@ -268,23 +357,37 @@ mod host_tests {
             delete_confirm_message(false),
             "このユーザーを退職処理（アーカイブ）しますか？"
         );
+        let dt = chrono::DateTime::parse_from_rfc3339("2026-03-10T10:00:00Z")
+            .expect("valid datetime")
+            .with_timezone(&chrono::Utc);
+        assert_eq!(session_device_label(Some("Chrome")), "Chrome");
+        assert_eq!(session_device_label(None), "不明なデバイス");
+        assert_eq!(format_session_datetime(dt), "2026-03-10 10:00");
+        assert_eq!(format_optional_session_datetime(None), "未記録");
     }
 
     #[test]
     fn user_detail_drawer_hides_delete_actions_for_self_user() {
         let html = render_to_string(move || {
             let selected = create_rw_signal(Some(user()));
+            let user_sessions = create_resource(
+                move || (true, Some("u1".to_string())),
+                move |_| async move { Ok::<_, ApiError>(Vec::<AdminSessionResponse>::new()) },
+            );
             let messages = MessageState::default();
             let reset_action = create_action(|_: &String| async move { Ok(()) });
             let unlock_action = create_action(|_: &String| async move { Ok(()) });
+            let revoke_session_action = create_action(|_: &String| async move { Ok(()) });
             let delete_action = create_action(|_: &(String, bool)| async move { Ok(()) });
             let current_user_id = Signal::derive(|| Some("u1".to_string()));
             view! {
                 <UserDetailDrawer
                     selected_user=selected
+                    user_sessions_resource=user_sessions
                     messages=messages
                     reset_mfa_action=reset_action
                     unlock_user_action=unlock_action
+                    revoke_session_action=revoke_session_action
                     delete_user_action=delete_action
                     current_user_id=current_user_id
                 />

--- a/frontend/src/pages/admin_users/panel.rs
+++ b/frontend/src/pages/admin_users/panel.rs
@@ -119,9 +119,11 @@ pub fn AdminUsersPage() -> impl IntoView {
                 // Active user detail drawer
                 <UserDetailDrawer
                     selected_user=vm.selected_user
+                    user_sessions_resource=vm.user_sessions_resource
                     messages=vm.drawer_messages
                     reset_mfa_action=vm.reset_mfa_action
                     unlock_user_action=vm.unlock_user_action
+                    revoke_session_action=vm.revoke_user_session_action
                     delete_user_action=vm.delete_user_action
                     current_user_id=current_user_id
                 />
@@ -143,12 +145,16 @@ mod host_tests {
     use super::*;
     use crate::test_support::helpers::{admin_user, provide_auth};
     use crate::test_support::ssr::render_to_string;
+    use leptos_router::{Router, RouterIntegrationContext, ServerIntegration};
 
     #[test]
     fn admin_users_page_renders_for_system_admin() {
         let html = render_to_string(move || {
+            provide_context(RouterIntegrationContext::new(ServerIntegration {
+                path: "http://localhost/admin/users".to_string(),
+            }));
             provide_auth(Some(admin_user(true)));
-            view! { <AdminUsersPage /> }
+            view! { <Router><AdminUsersPage /></Router> }
         });
         assert!(html.contains("ユーザー管理"));
         assert!(html.contains("アクティブユーザー"));

--- a/frontend/src/pages/admin_users/repository.rs
+++ b/frontend/src/pages/admin_users/repository.rs
@@ -1,5 +1,6 @@
 use crate::api::{
-    ApiClient, ApiError, ArchivedUserResponse, CreateUser, PiiProtectedResponse, UserResponse,
+    AdminSessionResponse, ApiClient, ApiError, ArchivedUserResponse, CreateUser,
+    PiiProtectedResponse, UserResponse,
 };
 use std::rc::Rc;
 
@@ -44,6 +45,17 @@ impl AdminUsersRepository {
 
     pub async fn unlock_user(&self, user_id: String) -> Result<(), ApiError> {
         self.client.admin_unlock_user(&user_id).await
+    }
+
+    pub async fn fetch_user_sessions(
+        &self,
+        user_id: String,
+    ) -> Result<Vec<AdminSessionResponse>, ApiError> {
+        self.client.admin_list_user_sessions(&user_id).await
+    }
+
+    pub async fn revoke_user_session(&self, session_id: String) -> Result<(), ApiError> {
+        self.client.admin_revoke_session(&session_id).await
     }
 
     // ========================================================================
@@ -125,6 +137,23 @@ mod host_tests {
                 .json_body(serde_json::json!({ "status": "unlocked" }));
         });
         server.mock(|when, then| {
+            when.method(GET).path("/api/admin/users/u1/sessions");
+            then.status(200).json_body(serde_json::json!([{
+                "id": "session-1",
+                "user_id": "u1",
+                "device_label": "Chrome on macOS",
+                "created_at": "2026-03-10T10:00:00Z",
+                "last_seen_at": "2026-03-10T10:30:00Z",
+                "expires_at": "2026-03-17T10:00:00Z",
+                "is_current": false
+            }]));
+        });
+        server.mock(|when, then| {
+            when.method(DELETE).path("/api/admin/sessions/session-1");
+            then.status(200)
+                .json_body(serde_json::json!({ "status": "revoked" }));
+        });
+        server.mock(|when, then| {
             when.method(GET).path("/api/admin/archived-users");
             then.status(200)
                 .json_body(serde_json::json!([archived_user_json("a1")]));
@@ -163,6 +192,9 @@ mod host_tests {
         repo.reset_user_mfa("u1".into()).await.unwrap();
         repo.delete_user("u1".into(), false).await.unwrap();
         repo.unlock_user("u1".into()).await.unwrap();
+        let sessions = repo.fetch_user_sessions("u1".into()).await.unwrap();
+        assert_eq!(sessions.len(), 1);
+        repo.revoke_user_session("session-1".into()).await.unwrap();
         let archived = repo.fetch_archived_users().await.unwrap();
         assert_eq!(archived.len(), 1);
         repo.restore_archived_user("a1".into()).await.unwrap();

--- a/frontend/src/pages/admin_users/view_model.rs
+++ b/frontend/src/pages/admin_users/view_model.rs
@@ -3,7 +3,8 @@ use super::{
     utils::{InviteFormState, MessageState},
 };
 use crate::api::{
-    ApiClient, ApiError, ArchivedUserResponse, CreateUser, PiiProtectedResponse, UserResponse,
+    AdminSessionResponse, ApiClient, ApiError, ArchivedUserResponse, CreateUser,
+    PiiProtectedResponse, UserResponse,
 };
 use crate::state::auth::use_auth;
 use leptos::*;
@@ -24,6 +25,8 @@ pub struct AdminUsersViewModel {
     pub drawer_messages: MessageState,
     pub selected_user: RwSignal<Option<UserResponse>>,
     pub selected_archived_user: RwSignal<Option<ArchivedUserResponse>>,
+    pub user_sessions_resource:
+        Resource<(bool, Option<String>), Result<Vec<AdminSessionResponse>, ApiError>>,
     pub pii_masked: RwSignal<bool>,
     pub active_tab: RwSignal<UserTab>,
     pub users_resource:
@@ -32,6 +35,7 @@ pub struct AdminUsersViewModel {
     pub invite_action: Action<CreateUser, Result<UserResponse, ApiError>>,
     pub reset_mfa_action: Action<String, Result<(), ApiError>>,
     pub unlock_user_action: Action<String, Result<(), ApiError>>,
+    pub revoke_user_session_action: Action<String, Result<(), ApiError>>,
     /// Delete a user: (user_id, hard_delete)
     pub delete_user_action: Action<(String, bool), Result<(), ApiError>>,
     /// Restore an archived user
@@ -61,6 +65,28 @@ pub fn use_admin_users_view_model() -> AdminUsersViewModel {
     let selected_archived_user = create_rw_signal(None::<ArchivedUserResponse>);
     let pii_masked = create_rw_signal(false);
     let active_tab = create_rw_signal(UserTab::Active);
+
+    let repo_sessions = repo.clone();
+    let user_sessions_resource = create_resource(
+        move || {
+            (
+                is_system_admin.get(),
+                selected_user.get().map(|user| user.id.clone()),
+            )
+        },
+        move |(allowed, maybe_user_id)| {
+            let repo = repo_sessions.clone();
+            async move {
+                if !allowed {
+                    Err(ApiError::validation("システム管理者のみ利用できます。"))
+                } else if let Some(user_id) = maybe_user_id {
+                    repo.fetch_user_sessions(user_id).await
+                } else {
+                    Ok(Vec::new())
+                }
+            }
+        },
+    );
 
     // Active users resource
     let repo_resource = repo.clone();
@@ -123,6 +149,13 @@ pub fn use_admin_users_view_model() -> AdminUsersViewModel {
         let repo = repo_unlock.clone();
         let user_id = user_id.clone();
         async move { repo.unlock_user(user_id).await }
+    });
+
+    let repo_revoke_session = repo.clone();
+    let revoke_user_session_action = create_action(move |session_id: &String| {
+        let repo = repo_revoke_session.clone();
+        let session_id = session_id.clone();
+        async move { repo.revoke_user_session(session_id).await }
     });
 
     let repo_restore = repo.clone();
@@ -200,6 +233,20 @@ pub fn use_admin_users_view_model() -> AdminUsersViewModel {
     });
 
     create_effect(move |_| {
+        if let Some(result) = revoke_user_session_action.value().get() {
+            match result {
+                Ok(_) => {
+                    drawer_messages.set_success("セッションをログアウトしました。");
+                    user_sessions_resource.refetch();
+                }
+                Err(err) => {
+                    drawer_messages.set_error(err);
+                }
+            }
+        }
+    });
+
+    create_effect(move |_| {
         if let Some(result) = restore_archived_action.value().get() {
             match result {
                 Ok(_) => {
@@ -236,6 +283,7 @@ pub fn use_admin_users_view_model() -> AdminUsersViewModel {
         drawer_messages,
         selected_user,
         selected_archived_user,
+        user_sessions_resource,
         pii_masked,
         active_tab,
         users_resource,
@@ -243,6 +291,7 @@ pub fn use_admin_users_view_model() -> AdminUsersViewModel {
         invite_action,
         reset_mfa_action,
         unlock_user_action,
+        revoke_user_session_action,
         delete_user_action,
         restore_archived_action,
         delete_archived_action,
@@ -274,6 +323,18 @@ mod host_tests {
         server.mock(|when, then| {
             when.method(GET).path("/api/admin/archived-users");
             then.status(200).json_body(serde_json::json!([]));
+        });
+        server.mock(|when, then| {
+            when.method(GET).path("/api/admin/users/u1/sessions");
+            then.status(200).json_body(serde_json::json!([{
+                "id": "session-1",
+                "user_id": "u1",
+                "device_label": "Chrome on macOS",
+                "created_at": "2026-03-10T10:00:00Z",
+                "last_seen_at": "2026-03-10T10:30:00Z",
+                "expires_at": "2026-03-17T10:00:00Z",
+                "is_current": false
+            }]));
         });
 
         let server = server.clone();
@@ -332,6 +393,22 @@ mod host_tests {
             then.status(200).json_body(serde_json::json!({}));
         });
         server.mock(|when, then| {
+            when.method(GET).path("/api/admin/users/u1/sessions");
+            then.status(200).json_body(serde_json::json!([{
+                "id": "session-1",
+                "user_id": "u1",
+                "device_label": "Chrome on macOS",
+                "created_at": "2026-03-10T10:00:00Z",
+                "last_seen_at": "2026-03-10T10:30:00Z",
+                "expires_at": "2026-03-17T10:00:00Z",
+                "is_current": false
+            }]));
+        });
+        server.mock(|when, then| {
+            when.method(DELETE).path("/api/admin/sessions/session-1");
+            then.status(200).json_body(serde_json::json!({}));
+        });
+        server.mock(|when, then| {
             when.method(POST)
                 .path("/api/admin/archived-users/a1/restore");
             then.status(200).json_body(serde_json::json!({}));
@@ -381,6 +458,38 @@ mod host_tests {
             }
             let reset_result = vm.reset_mfa_action.value().get();
             assert!(matches!(reset_result, Some(Ok(()))));
+
+            vm.selected_user.set(Some(UserResponse {
+                id: "u1".into(),
+                username: "alice".into(),
+                full_name: "Alice Example".into(),
+                role: "member".into(),
+                is_system_admin: false,
+                mfa_enabled: false,
+                is_locked: false,
+                locked_until: None,
+                failed_login_attempts: 0,
+            }));
+            vm.user_sessions_resource.refetch();
+            for _ in 0..10 {
+                if matches!(vm.user_sessions_resource.get(), Some(Ok(ref list)) if list.len() == 1)
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            let sessions = vm.user_sessions_resource.get();
+            assert!(matches!(sessions, Some(Ok(list)) if list.len() == 1));
+
+            vm.revoke_user_session_action.dispatch("session-1".into());
+            for _ in 0..10 {
+                if vm.revoke_user_session_action.value().get().is_some() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            let revoke_session_result = vm.revoke_user_session_action.value().get();
+            assert!(matches!(revoke_session_result, Some(Ok(()))));
 
             vm.delete_user_action.dispatch(("u1".into(), false));
             for _ in 0..10 {

--- a/frontend/src/pages/settings/panel.rs
+++ b/frontend/src/pages/settings/panel.rs
@@ -1,5 +1,8 @@
 use crate::{
-    api::{ApiError, CreateDataSubjectRequest, DataSubjectRequestResponse, DataSubjectRequestType},
+    api::{
+        ApiError, CreateDataSubjectRequest, DataSubjectRequestResponse, DataSubjectRequestType,
+        SessionResponse,
+    },
     components::{
         error::InlineErrorMessage,
         layout::{ErrorMessage, Layout, SuccessMessage},
@@ -19,6 +22,7 @@ use leptos::{ev::SubmitEvent, Callback, *};
 enum SettingsTab {
     Password,
     Mfa,
+    Sessions,
     SubjectRequest,
 }
 
@@ -562,6 +566,25 @@ pub fn SettingsPage() -> impl IntoView {
         );
     };
 
+    // --- Session Management State ---
+    let session_vm = vm.session_management_view_model;
+    let session_loading = session_vm.revoke_action.pending();
+    let sessions_resource = session_vm.sessions_resource;
+    let sessions_error =
+        Signal::derive(move || sessions_error_from_resource(sessions_resource.get()));
+    let sessions = Signal::derive(move || sessions_from_resource(sessions_resource.get()));
+    let (session_success_msg, set_session_success_msg) = create_signal(Option::<String>::None);
+    let (session_error_msg, set_session_error_msg) = create_signal(Option::<String>::None);
+
+    create_effect(move |_| {
+        apply_optional_session_revoke_effect_result(
+            session_vm.revoke_action.value().get(),
+            set_session_success_msg,
+            set_session_error_msg,
+            session_vm.reload,
+        );
+    });
+
     view! {
         <Layout>
             <div class="mx-auto max-w-3xl space-y-8">
@@ -591,6 +614,19 @@ pub fn SettingsPage() -> impl IntoView {
                         on:click=move |_| active_tab.set(SettingsTab::Mfa)
                     >
                         {"MFA 設定"}
+                    </button>
+                    <button
+                        class=move || {
+                            let base = "flex-1 px-4 py-2.5 rounded-xl text-sm font-display font-bold transition-all duration-200";
+                            if active_tab.get() == SettingsTab::Sessions {
+                                format!("{base} bg-surface-elevated text-fg shadow-sm transition-all duration-300")
+                            } else {
+                                format!("{base} text-fg-muted hover:text-fg")
+                            }
+                        }
+                        on:click=move |_| active_tab.set(SettingsTab::Sessions)
+                    >
+                        {"アクティブセッション"}
                     </button>
                     <button
                         class=move || {
@@ -685,6 +721,86 @@ pub fn SettingsPage() -> impl IntoView {
                             on_submit=handle_activate_cb
                             on_input=mfa_vm.totp_code.write_only()
                         />
+                    </div>
+                </Show>
+
+                // --- Session Management Section ---
+                <Show when=move || active_tab.get() == SettingsTab::Sessions>
+                    <div class="bg-surface-elevated rounded-2xl shadow-sm border border-border p-6 space-y-4">
+                        <div class="space-y-1">
+                            <h2 class="text-xl font-display font-bold text-fg border-b border-border pb-2">"アクティブセッション"</h2>
+                            <p class="text-sm text-fg-muted">
+                                {"現在ログイン中のデバイスを確認し、他のデバイスをログアウトできます。"}
+                            </p>
+                        </div>
+                        <Show when=move || session_success_msg.get().is_some() fallback=|| ()>
+                            <SuccessMessage message={session_success_msg.get().unwrap_or_default()} />
+                        </Show>
+                        <Show when=move || session_error_msg.get().is_some() fallback=|| ()>
+                            <ErrorMessage message={session_error_msg.get().unwrap_or_default()} />
+                        </Show>
+                        <Show when=move || sessions_error.get().is_some()>
+                            <ErrorMessage message={sessions_error.get().unwrap_or_default()} />
+                        </Show>
+                        <div class="space-y-3">
+                            {move || {
+                                let items = sessions.get();
+                                if items.is_empty() {
+                                    view! {
+                                        <div class="rounded-xl border border-dashed border-border px-4 py-6 text-sm text-fg-muted">
+                                            {"アクティブなセッションはありません。"}
+                                        </div>
+                                    }
+                                        .into_view()
+                                } else {
+                                    view! {
+                                        <div class="space-y-3">
+                                            {items.into_iter().map(|session| {
+                                                let session_id = session.id.clone();
+                                                let is_current = session.is_current;
+                                                let device_label = session_device_label(session.device_label.as_deref()).to_string();
+                                                let created_at = format_session_datetime(session.created_at);
+                                                let last_seen_at = format_optional_session_datetime(session.last_seen_at);
+                                                let expires_at = format_session_datetime(session.expires_at);
+                                                let status_label = session_status_label(is_current);
+                                                view! {
+                                                    <div class="rounded-xl border border-border bg-surface-muted px-4 py-4 space-y-3">
+                                                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                                            <div>
+                                                                <div class="text-sm font-semibold text-fg">{device_label}</div>
+                                                                <div class="text-xs text-fg-muted">{status_label}</div>
+                                                            </div>
+                                                            <button
+                                                                class="px-3 py-2 rounded bg-action-danger-bg text-action-danger-text hover:bg-action-danger-bg-hover disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+                                                                disabled=move || is_session_revoke_disabled(is_current, session_loading.get())
+                                                                on:click=move |_| session_vm.revoke_action.dispatch(session_id.clone())
+                                                            >
+                                                                {if is_current { "このセッションです" } else { "ログアウト" }}
+                                                            </button>
+                                                        </div>
+                                                        <dl class="grid grid-cols-1 gap-2 text-sm text-fg-muted sm:grid-cols-3">
+                                                            <div>
+                                                                <dt class="font-medium">{"開始"}</dt>
+                                                                <dd class="text-fg">{created_at}</dd>
+                                                            </div>
+                                                            <div>
+                                                                <dt class="font-medium">{"最終利用"}</dt>
+                                                                <dd class="text-fg">{last_seen_at}</dd>
+                                                            </div>
+                                                            <div>
+                                                                <dt class="font-medium">{"有効期限"}</dt>
+                                                                <dd class="text-fg">{expires_at}</dd>
+                                                            </div>
+                                                        </dl>
+                                                    </div>
+                                                }
+                                            }).collect_view()}
+                                        </div>
+                                    }
+                                        .into_view()
+                                }
+                            }}
+                        </div>
                     </div>
                 </Show>
 
@@ -801,6 +917,71 @@ fn subject_request_status_label(value: &str) -> String {
 
 fn format_subject_datetime(value: DateTime<Utc>) -> String {
     value.format("%Y-%m-%d %H:%M").to_string()
+}
+
+fn session_device_label(label: Option<&str>) -> &str {
+    label.unwrap_or("不明なデバイス")
+}
+
+fn format_session_datetime(value: DateTime<Utc>) -> String {
+    value.format("%Y-%m-%d %H:%M").to_string()
+}
+
+fn format_optional_session_datetime(value: Option<DateTime<Utc>>) -> String {
+    value
+        .map(format_session_datetime)
+        .unwrap_or_else(|| "未記録".to_string())
+}
+
+fn session_status_label(is_current: bool) -> &'static str {
+    if is_current {
+        "現在のセッション"
+    } else {
+        "他のデバイス"
+    }
+}
+
+fn session_revoke_feedback(result: Result<(), ApiError>) -> (Option<String>, Option<String>, bool) {
+    match result {
+        Ok(_) => (
+            Some("他のデバイスのセッションをログアウトしました。".into()),
+            None,
+            true,
+        ),
+        Err(err) => (None, Some(err.to_string()), false),
+    }
+}
+
+fn apply_optional_session_revoke_effect_result(
+    result: Option<Result<(), ApiError>>,
+    set_success: WriteSignal<Option<String>>,
+    set_error: WriteSignal<Option<String>>,
+    reload: RwSignal<u32>,
+) {
+    if let Some(result) = result {
+        let (success, error, should_reload) = session_revoke_feedback(result);
+        set_success.set(success);
+        set_error.set(error);
+        if should_reload {
+            reload.update(|value| *value = value.wrapping_add(1));
+        }
+    }
+}
+
+fn sessions_from_resource(
+    value: Option<Result<Vec<SessionResponse>, ApiError>>,
+) -> Vec<SessionResponse> {
+    value.and_then(Result::ok).unwrap_or_default()
+}
+
+fn sessions_error_from_resource(
+    value: Option<Result<Vec<SessionResponse>, ApiError>>,
+) -> Option<String> {
+    value.and_then(Result::err).map(|err| err.to_string())
+}
+
+fn is_session_revoke_disabled(is_current: bool, pending: bool) -> bool {
+    is_current || pending
 }
 
 #[cfg(all(test, target_arch = "wasm32"))]
@@ -938,6 +1119,7 @@ mod host_tests {
             assert!(html.contains("パスワード変更"));
             assert!(html.contains("本人対応申請"));
             assert!(html.contains("MFA 設定"));
+            assert!(html.contains("アクティブセッション"));
             assert!(html.contains("現在のパスワード"));
             assert!(!html.contains("申請履歴"));
 
@@ -993,6 +1175,19 @@ mod host_tests {
             .expect("valid datetime")
             .with_timezone(&Utc);
         assert_eq!(format_subject_datetime(dt), "2026-01-16 12:34");
+        assert_eq!(session_device_label(Some("Chrome")), "Chrome");
+        assert_eq!(session_device_label(None), "不明なデバイス");
+        assert_eq!(format_session_datetime(dt), "2026-01-16 12:34");
+        assert_eq!(
+            format_optional_session_datetime(Some(dt)),
+            "2026-01-16 12:34"
+        );
+        assert_eq!(format_optional_session_datetime(None), "未記録");
+        assert_eq!(session_status_label(true), "現在のセッション");
+        assert_eq!(session_status_label(false), "他のデバイス");
+        assert!(is_session_revoke_disabled(true, false));
+        assert!(is_session_revoke_disabled(false, true));
+        assert!(!is_session_revoke_disabled(false, false));
     }
 
     #[test]
@@ -1118,6 +1313,14 @@ mod host_tests {
             Some("本人対応申請を取消しました。")
         );
         assert!(cancel_ok_err.is_none());
+
+        let (session_ok_msg, session_ok_err, session_reload) = session_revoke_feedback(Ok(()));
+        assert_eq!(
+            session_ok_msg.as_deref(),
+            Some("他のデバイスのセッションをログアウトしました。")
+        );
+        assert!(session_ok_err.is_none());
+        assert!(session_reload);
 
         let (cancel_fail_msg, cancel_fail_err) =
             subject_cancel_feedback(Err(ApiError::unknown("cancel failed")));

--- a/frontend/src/pages/settings/repository.rs
+++ b/frontend/src/pages/settings/repository.rs
@@ -1,4 +1,4 @@
-use crate::api::{ApiClient, ApiError};
+use crate::api::{ApiClient, ApiError, SessionResponse};
 
 pub async fn change_password(
     client: ApiClient,
@@ -8,9 +8,17 @@ pub async fn change_password(
     client.change_password(current, new).await
 }
 
+pub async fn list_sessions(client: ApiClient) -> Result<Vec<SessionResponse>, ApiError> {
+    client.list_sessions().await
+}
+
+pub async fn revoke_session(client: ApiClient, session_id: String) -> Result<(), ApiError> {
+    client.revoke_session(&session_id).await
+}
+
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod host_tests {
-    use super::change_password;
+    use super::{change_password, list_sessions, revoke_session};
     use crate::api::test_support::mock::*;
     use crate::api::ApiClient;
 
@@ -26,5 +34,32 @@ mod host_tests {
         change_password(client, "current".into(), "newpass".into())
             .await
             .expect("change password");
+    }
+
+    #[tokio::test]
+    async fn session_repository_calls_api() {
+        let server = MockServer::start_async().await;
+        server.mock(|when, then| {
+            when.method(GET).path("/api/auth/sessions");
+            then.status(200).json_body(serde_json::json!([{
+                "id": "session-1",
+                "device_label": "Chrome on macOS",
+                "created_at": "2026-03-10T10:00:00Z",
+                "last_seen_at": "2026-03-10T10:30:00Z",
+                "expires_at": "2026-03-17T10:00:00Z",
+                "is_current": true
+            }]));
+        });
+        server.mock(|when, then| {
+            when.method(DELETE).path("/api/auth/sessions/session-1");
+            then.status(200).json_body(serde_json::json!({}));
+        });
+
+        let client = ApiClient::new_with_base_url(&server.url("/api"));
+        let sessions = list_sessions(client.clone()).await.expect("list sessions");
+        assert_eq!(sessions.len(), 1);
+        revoke_session(client, "session-1".into())
+            .await
+            .expect("revoke session");
     }
 }

--- a/frontend/src/pages/settings/view_model.rs
+++ b/frontend/src/pages/settings/view_model.rs
@@ -1,5 +1,7 @@
 use super::repository;
-use crate::api::{ApiClient, ApiError, CreateDataSubjectRequest, DataSubjectRequestResponse};
+use crate::api::{
+    ApiClient, ApiError, CreateDataSubjectRequest, DataSubjectRequestResponse, SessionResponse,
+};
 use crate::pages::mfa::view_model::MfaViewModel;
 use leptos::*;
 
@@ -8,6 +10,7 @@ pub struct SettingsViewModel {
     pub change_password_action: Action<(String, String), Result<(), ApiError>>,
     pub mfa_view_model: MfaViewModel, // Reuse existing MFA logic
     pub subject_request_view_model: SubjectRequestViewModel,
+    pub session_management_view_model: SessionManagementViewModel,
 }
 
 #[derive(Clone)]
@@ -17,6 +20,13 @@ pub struct SubjectRequestViewModel {
     pub create_action:
         Action<CreateDataSubjectRequest, Result<DataSubjectRequestResponse, ApiError>>,
     pub cancel_action: Action<String, Result<(), ApiError>>,
+}
+
+#[derive(Clone)]
+pub struct SessionManagementViewModel {
+    pub sessions_resource: Resource<u32, Result<Vec<SessionResponse>, ApiError>>,
+    pub reload: RwSignal<u32>,
+    pub revoke_action: Action<String, Result<(), ApiError>>,
 }
 
 pub fn use_settings_view_model() -> SettingsViewModel {
@@ -60,12 +70,36 @@ pub fn use_settings_view_model() -> SettingsViewModel {
         cancel_action: cancel_subject_action,
     };
 
+    let session_reload = create_rw_signal(0u32);
+    let session_list_api = api.clone();
+    let sessions_resource = create_resource(
+        move || session_reload.get(),
+        move |_| {
+            let api = session_list_api.clone();
+            async move { repository::list_sessions(api).await }
+        },
+    );
+
+    let session_revoke_api = api.clone();
+    let revoke_session_action = create_action(move |session_id: &String| {
+        let api = session_revoke_api.clone();
+        let session_id = session_id.clone();
+        async move { repository::revoke_session(api, session_id).await }
+    });
+
+    let session_management_view_model = SessionManagementViewModel {
+        sessions_resource,
+        reload: session_reload,
+        revoke_action: revoke_session_action,
+    };
+
     let mfa_view_model = crate::pages::mfa::view_model::use_mfa_view_model();
 
     SettingsViewModel {
         change_password_action,
         mfa_view_model,
         subject_request_view_model,
+        session_management_view_model,
     }
 }
 
@@ -114,11 +148,26 @@ mod host_tests {
                 .json_body(json!([subject_request_json("sr-1")]));
         });
         server.mock(|when, then| {
+            when.method(GET).path("/api/auth/sessions");
+            then.status(200).json_body(json!([{
+                "id": "session-1",
+                "device_label": "Chrome on macOS",
+                "created_at": "2026-03-10T10:00:00Z",
+                "last_seen_at": "2026-03-10T10:30:00Z",
+                "expires_at": "2026-03-17T10:00:00Z",
+                "is_current": true
+            }]));
+        });
+        server.mock(|when, then| {
             when.method(POST).path("/api/subject-requests");
             then.status(200).json_body(subject_request_json("sr-2"));
         });
         server.mock(|when, then| {
             when.method(DELETE).path("/api/subject-requests/sr-1");
+            then.status(200).json_body(json!({}));
+        });
+        server.mock(|when, then| {
+            when.method(DELETE).path("/api/auth/sessions/session-1");
             then.status(200).json_body(json!({}));
         });
         server
@@ -180,6 +229,23 @@ mod host_tests {
             }
             let _ = vm.subject_request_view_model.cancel_action.value().get();
 
+            vm.session_management_view_model
+                .revoke_action
+                .dispatch("session-1".into());
+            for _ in 0..10 {
+                if vm
+                    .session_management_view_model
+                    .revoke_action
+                    .value()
+                    .get()
+                    .is_some()
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            let _ = vm.session_management_view_model.revoke_action.value().get();
+
             for _ in 0..10 {
                 if vm
                     .subject_request_view_model
@@ -192,6 +258,20 @@ mod host_tests {
                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             }
             let _ = vm.subject_request_view_model.requests_resource.get();
+
+            for _ in 0..10 {
+                if vm
+                    .session_management_view_model
+                    .sessions_resource
+                    .get()
+                    .is_some()
+                {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+            let sessions = vm.session_management_view_model.sessions_resource.get();
+            assert!(matches!(sessions, Some(Ok(list)) if list.len() == 1));
 
             runtime.dispose();
         });


### PR DESCRIPTION
## Summary
- add frontend session API/types for user and admin session listing and revocation
- add a settings tab for active sessions so users can review and revoke other device sessions
- add admin user drawer session management with list and forced logout actions

Closes #149

## Validation
- cargo test -p timekeeper-frontend --lib settings -- --nocapture
- cargo test -p timekeeper-frontend --lib admin_users -- --nocapture
- cargo test -p timekeeper-frontend --lib api_client_admin_and_auth_endpoints_succeed -- --nocapture
- cargo fmt --all
- cargo clippy -p timekeeper-frontend --all-targets -- -D warnings (fails on pre-existing frontend clippy violations)