### PR TITLE
chore(test): strengthen concurrent session coverage

### DIFF
--- a/backend/tests/auth_flow_api.rs
+++ b/backend/tests/auth_flow_api.rs
@@ -449,6 +449,68 @@ async fn login_enforces_session_limit() {
 }
 
 #[tokio::test]
+async fn login_enforces_session_limit_revokes_oldest_session() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    migrate_db(&pool).await;
+
+    let password = "Password123!";
+    let user = support::seed_user_with_password(&pool, UserRole::Employee, false, password).await;
+
+    let oldest_refresh_id = Uuid::new_v4().to_string();
+    let newer_refresh_id = Uuid::new_v4().to_string();
+    support::seed_active_session(&pool, user.id, &oldest_refresh_id, None).await;
+    support::seed_active_session(&pool, user.id, &newer_refresh_id, None).await;
+
+    let now = chrono::Utc::now();
+    sqlx::query("UPDATE active_sessions SET last_seen_at = $2 WHERE refresh_token_id = $1")
+        .bind(&oldest_refresh_id)
+        .bind(now - chrono::Duration::hours(6))
+        .execute(&pool)
+        .await
+        .expect("age oldest session");
+    sqlx::query("UPDATE active_sessions SET last_seen_at = $2 WHERE refresh_token_id = $1")
+        .bind(&newer_refresh_id)
+        .bind(now - chrono::Duration::hours(1))
+        .execute(&pool)
+        .await
+        .expect("age newer session");
+
+    let mut config = support::test_config();
+    config.max_concurrent_sessions = 2;
+
+    let response = auth_router_with_config(pool.clone(), config)
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/auth/login")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "username": user.username.clone(),
+                        "password": password,
+                    })
+                    .to_string(),
+                ))
+                .expect("build login request"),
+        )
+        .await
+        .expect("login request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let refresh_token =
+        extract_set_cookie_value(response.headers(), REFRESH_COOKIE_NAME).expect("refresh cookie");
+    let (new_refresh_id, _) =
+        decode_refresh_token(&refresh_token).expect("decode new refresh token");
+
+    assert_eq!(count_active_sessions(&pool, &user.id.to_string()).await, 2);
+    assert_eq!(count_refresh_tokens(&pool, &user.id.to_string()).await, 2);
+    assert!(!refresh_token_exists(&pool, &oldest_refresh_id).await);
+    assert!(refresh_token_exists(&pool, &newer_refresh_id).await);
+    assert!(refresh_token_exists(&pool, &new_refresh_id).await);
+}
+
+#[tokio::test]
 async fn me_returns_current_user() {
     let _guard = integration_guard().await;
     let pool = support::test_pool().await;

--- a/backend/tests/session_api.rs
+++ b/backend/tests/session_api.rs
@@ -20,6 +20,22 @@ mod support;
 
 use support::{create_test_token, seed_active_session, seed_user, test_config, test_pool};
 
+async fn count_active_sessions(pool: &PgPool, user_id: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM active_sessions WHERE user_id = $1")
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .expect("count active sessions")
+}
+
+async fn refresh_token_exists(pool: &PgPool, token_id: &str) -> bool {
+    sqlx::query_scalar::<_, bool>("SELECT EXISTS (SELECT 1 FROM refresh_tokens WHERE id = $1)")
+        .bind(token_id)
+        .fetch_one(pool)
+        .await
+        .expect("refresh token exists")
+}
+
 async fn integration_guard() -> tokio::sync::MutexGuard<'static, ()> {
     static GUARD: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
     GUARD
@@ -115,6 +131,47 @@ async fn test_list_sessions_returns_user_sessions() {
 }
 
 #[tokio::test]
+async fn test_list_sessions_marks_current_session() {
+    let _guard = integration_guard().await;
+    let pool = test_pool().await;
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("run migrations");
+
+    let employee = seed_user(&pool, UserRole::Employee, false).await;
+    let refresh_token_id = uuid::Uuid::new_v4().to_string();
+    let access_jti = uuid::Uuid::new_v4().to_string();
+    let _session_id =
+        seed_active_session(&pool, employee.id, &refresh_token_id, Some(&access_jti)).await;
+
+    let claims = create_test_claims(employee.id, &access_jti);
+    let app = test_router_user_sessions(pool.clone(), employee.clone(), claims);
+
+    let request = Request::builder()
+        .uri("/api/sessions")
+        .header(
+            "Authorization",
+            format!(
+                "Bearer {}",
+                create_test_token(employee.id, employee.role.clone())
+            ),
+        )
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json.as_array().unwrap().len(), 1);
+    assert_eq!(json[0]["is_current"].as_bool(), Some(true));
+}
+
+#[tokio::test]
 async fn test_revoke_other_session_succeeds() {
     let _guard = integration_guard().await;
     let pool = test_pool().await;
@@ -148,6 +205,11 @@ async fn test_revoke_other_session_succeeds() {
 
     let response = app.oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        count_active_sessions(&pool, &employee.id.to_string()).await,
+        0
+    );
+    assert!(!refresh_token_exists(&pool, &refresh_token_id).await);
 }
 
 #[tokio::test]

--- a/backend/tests/token_cleanup_bin.rs
+++ b/backend/tests/token_cleanup_bin.rs
@@ -6,6 +6,14 @@ use uuid::Uuid;
 
 mod support;
 
+async fn integration_guard() -> tokio::sync::MutexGuard<'static, ()> {
+    static GUARD: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    GUARD
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await
+}
+
 async fn migrate_db(pool: &PgPool) {
     sqlx::migrate!("./migrations")
         .run(pool)
@@ -15,8 +23,15 @@ async fn migrate_db(pool: &PgPool) {
 
 #[tokio::test]
 async fn token_cleanup_binary_removes_expired_records() {
+    let _guard = integration_guard().await;
     let pool = support::test_pool().await;
     migrate_db(&pool).await;
+    sqlx::query(
+        "TRUNCATE active_access_tokens, active_sessions, refresh_tokens, password_resets RESTART IDENTITY CASCADE",
+    )
+    .execute(&pool)
+    .await
+    .expect("truncate cleanup tables");
 
     let user = support::seed_user(&pool, UserRole::Employee, false).await;
     let expired = Utc::now() - Duration::hours(2);
@@ -96,4 +111,96 @@ async fn token_cleanup_binary_removes_expired_records() {
     assert_eq!(access_tokens, 0);
     assert_eq!(sessions, 0);
     assert_eq!(resets, 0);
+}
+
+#[tokio::test]
+async fn token_cleanup_binary_preserves_non_expired_records() {
+    let _guard = integration_guard().await;
+    let pool = support::test_pool().await;
+    migrate_db(&pool).await;
+    sqlx::query(
+        "TRUNCATE active_access_tokens, active_sessions, refresh_tokens, password_resets RESTART IDENTITY CASCADE",
+    )
+    .execute(&pool)
+    .await
+    .expect("truncate cleanup tables");
+
+    let user = support::seed_user(&pool, UserRole::Employee, false).await;
+    let valid_until = Utc::now() + Duration::hours(2);
+
+    sqlx::query("INSERT INTO active_access_tokens (jti, user_id, expires_at) VALUES ($1, $2, $3)")
+        .bind(Uuid::new_v4().to_string())
+        .bind(user.id.to_string())
+        .bind(valid_until)
+        .execute(&pool)
+        .await
+        .expect("insert valid active access token");
+
+    let refresh_id = Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO refresh_tokens (id, user_id, token_hash, expires_at) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(&refresh_id)
+    .bind(user.id.to_string())
+    .bind("valid-token-hash")
+    .bind(valid_until)
+    .execute(&pool)
+    .await
+    .expect("insert valid refresh token");
+
+    sqlx::query(
+        "INSERT INTO active_sessions \
+         (id, user_id, refresh_token_id, access_jti, device_label, expires_at) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(user.id.to_string())
+    .bind(&refresh_id)
+    .bind(None::<String>)
+    .bind(Some("valid-device".to_string()))
+    .bind(valid_until)
+    .execute(&pool)
+    .await
+    .expect("insert valid active session");
+
+    sqlx::query(
+        "INSERT INTO password_resets (id, user_id, token_hash, expires_at) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(Uuid::new_v4().to_string())
+    .bind(user.id.to_string())
+    .bind("valid-reset-hash")
+    .bind(valid_until)
+    .execute(&pool)
+    .await
+    .expect("insert valid password reset");
+
+    let bin = env!("CARGO_BIN_EXE_token_cleanup");
+    let db_url = std::env::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL");
+
+    let status = Command::new(bin)
+        .env("DATABASE_URL", db_url)
+        .env(
+            "JWT_SECRET",
+            "0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .status()
+        .expect("run token_cleanup");
+    assert!(status.success());
+
+    let access_tokens: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM active_access_tokens")
+        .fetch_one(&pool)
+        .await
+        .expect("count active access tokens");
+    let sessions: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM active_sessions")
+        .fetch_one(&pool)
+        .await
+        .expect("count active sessions");
+    let resets: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM password_resets")
+        .fetch_one(&pool)
+        .await
+        .expect("count password resets");
+
+    assert_eq!(access_tokens, 1);
+    assert_eq!(sessions, 1);
+    assert_eq!(resets, 1);
 }

--- a/docs/generated/exec-plans/active/EP-20260310-open-issue-259.md
+++ b/docs/generated/exec-plans/active/EP-20260310-open-issue-259.md
@@ -1,0 +1,45 @@
+# ExecPlan: Open Issue Flow for #259
+
+## Goal
+
+concurrent session management まわりの backend 検証を補強し、最古セッションの自動 revoke、session list/revoke API の振る舞い、cleanup job の保持/削除条件を focused test で担保した状態で PR 作成まで完了する。
+
+## Steps
+
+- [completed] concurrent session limit の oldest-session revoke を検証する test を追加した
+- [completed] session list/revoke API の観測結果を強める test を追加した
+- [completed] token cleanup job が valid record を残す test を追加した
+- [completed] focused backend tests と format を実行した
+- [in_progress] `jj commit` を作成し、push と GitHub PR 作成まで完了する
+
+## Validation
+
+- `cargo test -p timekeeper-backend --test auth_flow_api -- --nocapture`
+- `cargo test -p timekeeper-backend --test session_api -- --nocapture`
+- `cargo test -p timekeeper-backend --test token_cleanup_bin -- --nocapture`
+- `cargo fmt --all`
+
+## Validation Log
+
+- `cargo test -p timekeeper-backend --test auth_flow_api login_enforces_session_limit_revokes_oldest_session -- --exact`
+  - passed
+- `cargo test -p timekeeper-backend --test session_api test_list_sessions_marks_current_session -- --exact`
+  - passed
+- `cargo test -p timekeeper-backend --test token_cleanup_bin token_cleanup_binary_preserves_non_expired_records -- --exact`
+  - passed
+- `cargo test -p timekeeper-backend --test auth_flow_api -- --nocapture`
+  - 21 passed
+- `cargo test -p timekeeper-backend --test session_api -- --nocapture`
+  - 13 passed
+- `cargo test -p timekeeper-backend --test token_cleanup_bin -- --nocapture`
+  - 4 passed
+- `cargo fmt --all`
+- `cargo clippy -p timekeeper-backend --all-targets -- -D warnings`
+  - `backend/src/handlers/*attendance_correction_requests.rs`, `backend/src/handlers/requests.rs`, `backend/src/repositories/attendance_correction_request.rs` の pre-existing clippy violations で失敗
+
+## Done Criteria
+
+- session limit 超過時に最古セッションが revoke されることを test が保証している
+- session list/revoke API の current-session 表示または revoke 後の DB 状態を test が保証している
+- cleanup binary が expired record を削除し、valid record は残すことを test が保証している
+- focused validation が成功し、issue `#259` の PR が作成されている


### PR DESCRIPTION
## Summary
- add a session-limit test that verifies the oldest active session is revoked first
- strengthen session API coverage for current-session marking and revoke persistence
- add cleanup binary coverage that preserves non-expired records while deleting expired ones

Closes #259

## Validation
- cargo test -p timekeeper-backend --test auth_flow_api login_enforces_session_limit_revokes_oldest_session -- --exact
- cargo test -p timekeeper-backend --test session_api test_list_sessions_marks_current_session -- --exact
- cargo test -p timekeeper-backend --test token_cleanup_bin token_cleanup_binary_preserves_non_expired_records -- --exact
- cargo test -p timekeeper-backend --test auth_flow_api -- --nocapture
- cargo test -p timekeeper-backend --test session_api -- --nocapture
- cargo test -p timekeeper-backend --test token_cleanup_bin -- --nocapture
- cargo fmt --all
- cargo clippy -p timekeeper-backend --all-targets -- -D warnings (fails on pre-existing handler/repository clippy violations)