### PR TITLE
fix(security): preserve lockout history and classify login results

### DIFF
--- a/backend/src/handlers/admin/subject_requests.rs
+++ b/backend/src/handlers/admin/subject_requests.rs
@@ -222,7 +222,8 @@ fn parse_request_type(value: &str) -> Result<DataSubjectRequestType, AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{TimeZone, Timelike};
+    use crate::handlers::admin::common::parse_filter_datetime;
+    use chrono::{NaiveDate, TimeZone, Timelike, Utc};
 
     fn app_error_message(err: AppError) -> String {
         match err {

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -103,7 +103,7 @@ pub async fn login(
         record_login_audit_event(
             Some(audit_log_service.clone()),
             audit_context.clone(),
-            "login_failure",
+            "account_lockout",
             user.id,
             Some(json!({ "reason": "account_locked" })),
         );
@@ -1444,10 +1444,10 @@ fn record_login_audit_event(
 }
 
 fn login_audit_result(event_type: &str) -> &'static str {
-    if event_type == "login_failure" {
-        "failure"
-    } else {
-        "success"
+    match event_type {
+        "login_failure" => "denied",
+        "account_lockout" => "blocked",
+        _ => "success",
     }
 }
 
@@ -1763,8 +1763,9 @@ mod tests {
     }
 
     #[test]
-    fn login_audit_result_is_failure_for_login_failure_event() {
-        assert_eq!(login_audit_result("login_failure"), "failure");
+    fn login_audit_result_maps_denied_and_blocked_events() {
+        assert_eq!(login_audit_result("login_failure"), "denied");
+        assert_eq!(login_audit_result("account_lockout"), "blocked");
         assert_eq!(login_audit_result("login_success"), "success");
     }
 

--- a/backend/src/repositories/auth.rs
+++ b/backend/src/repositories/auth.rs
@@ -502,12 +502,12 @@ pub async fn record_login_failure(
 }
 
 pub async fn clear_login_failures(pool: &PgPool, user_id: UserId) -> Result<(), sqlx::Error> {
+    // Preserve lockout_count so repeated attacks continue to inherit stronger backoff.
     sqlx::query(
         "UPDATE users \
          SET failed_login_attempts = 0, \
              locked_until = NULL, \
              lock_reason = NULL, \
-             lockout_count = 0, \
              updated_at = NOW() \
          WHERE id = $1",
     )

--- a/backend/tests/auth_flow_api.rs
+++ b/backend/tests/auth_flow_api.rs
@@ -337,7 +337,7 @@ async fn login_locks_account_after_reaching_failure_threshold() {
 }
 
 #[tokio::test]
-async fn login_success_clears_login_failure_state() {
+async fn login_success_preserves_lockout_history_while_clearing_active_failures() {
     let _guard = integration_guard().await;
     let pool = support::test_pool().await;
     migrate_db(&pool).await;
@@ -346,25 +346,19 @@ async fn login_success_clears_login_failure_state() {
     let user = support::seed_user_with_password(&pool, UserRole::Employee, false, password).await;
     let app = auth_router(pool.clone());
 
-    let failed_response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/api/auth/login")
-                .header(header::CONTENT_TYPE, "application/json")
-                .body(Body::from(
-                    json!({
-                        "username": user.username.clone(),
-                        "password": "Wrong123!",
-                    })
-                    .to_string(),
-                ))
-                .expect("build login request"),
-        )
-        .await
-        .expect("login request");
-    assert_eq!(failed_response.status(), StatusCode::UNAUTHORIZED);
+    // Seed lockout history directly so this test stays focused on successful-login cleanup
+    // without depending on the failure-counting path.
+    sqlx::query(
+        "UPDATE users \
+         SET failed_login_attempts = 2, \
+             lockout_count = 1, \
+             updated_at = NOW() \
+         WHERE id = $1",
+    )
+    .bind(user.id.to_string())
+    .execute(&pool)
+    .await
+    .expect("seed lockout history");
 
     let success_response = app
         .oneshot(
@@ -389,7 +383,7 @@ async fn login_success_clears_login_failure_state() {
         fetch_lock_state(&pool, &user.id.to_string()).await;
     assert_eq!(failed_attempts, 0);
     assert!(locked_until.is_none());
-    assert_eq!(lockout_count, 0);
+    assert_eq!(lockout_count, 1);
 }
 
 #[tokio::test]

--- a/docs/generated/exec-plans/active/EP-20260310-issue-288-login-hardening-phase1.md
+++ b/docs/generated/exec-plans/active/EP-20260310-issue-288-login-hardening-phase1.md
@@ -1,0 +1,40 @@
+# EP-20260310-issue-288-login-hardening-phase1
+
+## Goal
+- issue #288 のうち、即時に適用できる login hardening を先行実装する
+
+## Scope
+- In: `backend/src/handlers/auth.rs`, `backend/src/repositories/auth.rs`, `backend/tests/auth_flow_api.rs`
+- Out: Redis 集約、MQ/worker 追加、通知ジョブ化、ランダムジッター導入
+
+## Done Criteria (Observable)
+- [x] 成功ログイン後も `lockout_count` が保持される
+- [x] 監査ログ result が `login_failure => denied`, `account_lockout => blocked` になる
+- [x] backend の対象テストが成功する
+
+## Constraints / Non-goals
+- issue #288 を一度に閉じ切らず、独立して安全に出せる改善だけを先行する
+- 既存 API shape やログイン成功/失敗の外向きレスポンスは変えない
+
+## Task Breakdown
+1. [x] `clear_login_failures` の reset 対象から `lockout_count` を外す
+2. [x] locked account / threshold 到達時の audit result を `blocked` / `denied` に修正する
+3. [x] focused test / fmt / jj snapshot / PR 作成まで行う
+
+## Validation Plan
+- [x] `cargo test -p timekeeper-backend --lib handlers::auth::tests -- --nocapture`
+- [x] `cargo test -p timekeeper-backend --test auth_flow_api login_locks_account_after_reaching_failure_threshold -- --exact`
+- [x] `cargo test -p timekeeper-backend --test auth_flow_api login_success_preserves_lockout_history_while_clearing_active_failures -- --exact`
+- [x] `cargo fmt --all`
+- [ ] `cargo clippy -p timekeeper-backend --all-targets -- -D warnings`
+
+## JJ Snapshot Log
+- [ ] `jj status`
+- [x] backend 対象テスト pass
+- [ ] `jj commit -m "fix(security): preserve lockout history and classify login audit results"`
+
+## Progress Notes
+- 2026-03-10: issue #288 の current main との差分を確認。ダミーハッシュ検証と通知 async spawn は既に入っているため、未解消の実害である `lockout_count` reset と audit result を phase 1 として切り出す方針に決定。
+- 2026-03-10: `clear_login_failures` から `lockout_count` reset を除去し、成功ログイン後もバックオフ履歴を保持するよう変更。
+- 2026-03-10: locked account の監査イベントを `account_lockout` に寄せ、`login_failure => denied`, `account_lockout => blocked` へ result を修正。
+- 2026-03-10: `handlers::auth` unit test と `auth_flow_api` の focused integration test は成功。`cargo clippy -p timekeeper-backend --all-targets -- -D warnings` は `attendance_correction_requests` 系の既存違反で失敗。


### PR DESCRIPTION
## Summary
- preserve `lockout_count` on successful login while still clearing active failure state
- classify login audit results as `denied` and `blocked` to match the real login outcome
- repair the admin subject request test imports so the focused auth unit target compiles on current `main`

## Testing
- cargo test -p timekeeper-backend --lib handlers::auth::tests -- --nocapture
- cargo test -p timekeeper-backend --test auth_flow_api login_locks_account_after_reaching_failure_threshold -- --exact
- cargo test -p timekeeper-backend --test auth_flow_api login_success_preserves_lockout_history_while_clearing_active_failures -- --exact
- cargo fmt --all

`cargo clippy -p timekeeper-backend --all-targets -- -D warnings` still fails on pre-existing `attendance_correction_requests` issues outside this change.

Partially addresses #288