### PR TITLE
feat(security): aggregate login failures in redis

### DIFF
--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -3,6 +3,7 @@ use axum::{
     http::{header, header::USER_AGENT, HeaderMap},
     Json,
 };
+use bb8_redis::redis;
 use chrono::{DateTime, Utc};
 use rand::Rng;
 use serde_json::{json, Value};
@@ -62,7 +63,23 @@ const DUMMY_LOGIN_PASSWORD_HASH: &str =
     "$argon2id$v=19$m=19456,t=2,p=1$SHjkBewYpN0AqfNJtz4BCQ$Q6EKet0GGAKSbQ5hQFsXf+6WG+AX8Z91wi5hlimtYew";
 const LOGIN_FAILURE_JITTER_MIN_MS: u64 = 15;
 const LOGIN_FAILURE_JITTER_MAX_MS: u64 = 35;
+const LOGIN_FAILURE_REDIS_KEY_PREFIX: &str = "auth:login-failures:";
 const PASSWORD_EXPIRY_WARNING_WINDOW_DAYS: i64 = 7;
+const LOGIN_FAILURE_REDIS_SCRIPT: &str = r#"
+local key = KEYS[1]
+local threshold = tonumber(ARGV[1])
+local ttl_ms = tonumber(ARGV[2])
+local count = redis.call('INCR', key)
+-- TTL is set only on the first failure, so the pre-threshold window is fixed.
+if count == 1 then
+  redis.call('PEXPIRE', key, ttl_ms)
+end
+if count >= threshold then
+  redis.call('DEL', key)
+  return {1, count}
+end
+return {0, count}
+"#;
 
 #[derive(Debug)]
 pub struct AuthSession {
@@ -171,28 +188,21 @@ pub async fn login(
             auth_repo::clear_login_failures(&state.write_pool, session.user.id)
                 .await
                 .map_err(|_| internal_error("Failed to clear login failure count"))?;
+            clear_login_failure_cache(&state, session.user.id).await;
             session
         }
         Err(err) => {
             if should_track_login_failure(&err) {
-                let failure_state = auth_repo::record_login_failure(
-                    &state.write_pool,
-                    audit_actor_id,
-                    now,
-                    lockout_policy(&state.config),
-                )
-                .await
-                .map_err(|_| internal_error("Failed to update login failure state"))?;
+                let failure_state = record_login_failure_state(&state, audit_actor_id, now)
+                    .await
+                    .map_err(|_| internal_error("Failed to update login failure state"))?;
 
                 record_login_audit_event(
                     Some(audit_log_service.clone()),
                     audit_context.clone(),
                     "login_failure",
                     audit_actor_id,
-                    Some(json!({
-                        "failed_login_attempts": failure_state.failed_login_attempts,
-                        "lockout_count": failure_state.lockout_count,
-                    })),
+                    Some(login_failure_audit_metadata(&failure_state)),
                 );
 
                 if failure_state.became_locked {
@@ -1504,6 +1514,118 @@ fn enqueue_lockout_notification(
     });
 }
 
+async fn record_login_failure_state(
+    state: &AppState,
+    user_id: UserId,
+    now: DateTime<Utc>,
+) -> Result<auth_repo::LoginFailureState, anyhow::Error> {
+    let policy = lockout_policy(&state.config);
+    match try_record_login_failure_with_redis(state, user_id, now, policy).await {
+        Ok(Some(failure_state)) => Ok(failure_state),
+        Ok(None) => auth_repo::record_login_failure(&state.write_pool, user_id, now, policy)
+            .await
+            .map_err(Into::into),
+        Err(err) => {
+            tracing::warn!(
+                error = ?err,
+                user_id = %user_id,
+                "Failed to record login failure in Redis, falling back to database"
+            );
+            auth_repo::record_login_failure(&state.write_pool, user_id, now, policy)
+                .await
+                .map_err(Into::into)
+        }
+    }
+}
+
+async fn try_record_login_failure_with_redis(
+    state: &AppState,
+    user_id: UserId,
+    now: DateTime<Utc>,
+    policy: LockoutPolicy,
+) -> Result<Option<auth_repo::LoginFailureState>, anyhow::Error> {
+    let Some(pool) = state.redis() else {
+        return Ok(None);
+    };
+
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|err| anyhow::anyhow!("acquire redis connection: {err}"))?;
+    let key = login_failure_cache_key(user_id);
+    let ttl_ms = login_failure_cache_ttl_millis(policy);
+    let (threshold_reached, cached_count): (i32, i32) = redis::cmd("EVAL")
+        .arg(LOGIN_FAILURE_REDIS_SCRIPT)
+        .arg(1)
+        .arg(&key)
+        .arg(policy.threshold.max(1))
+        .arg(ttl_ms)
+        .query_async(&mut *conn)
+        .await
+        .map_err(|err| anyhow::anyhow!("increment login failure cache: {err}"))?;
+    drop(conn);
+
+    if threshold_reached != 0 {
+        let failure_state =
+            auth_repo::persist_lockout_state(&state.write_pool, user_id, now, policy).await?;
+        Ok(Some(failure_state))
+    } else {
+        Ok(Some(auth_repo::LoginFailureState {
+            failed_login_attempts: cached_count.max(0),
+            locked_until: None,
+            lockout_count: 0,
+            became_locked: false,
+        }))
+    }
+}
+
+async fn clear_login_failure_cache(state: &AppState, user_id: UserId) {
+    let Some(pool) = state.redis() else {
+        return;
+    };
+
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(err) => {
+            tracing::warn!(
+                error = ?err,
+                user_id = %user_id,
+                "Failed to acquire Redis connection to clear login failure cache"
+            );
+            return;
+        }
+    };
+
+    let delete_result: Result<i32, _> = redis::cmd("DEL")
+        .arg(login_failure_cache_key(user_id))
+        .query_async(&mut *conn)
+        .await;
+    if let Err(err) = delete_result {
+        tracing::warn!(
+            error = ?err,
+            user_id = %user_id,
+            "Failed to clear login failure cache from Redis"
+        );
+    }
+}
+
+fn login_failure_cache_key(user_id: UserId) -> String {
+    format!("{LOGIN_FAILURE_REDIS_KEY_PREFIX}{user_id}")
+}
+
+fn login_failure_cache_ttl_millis(policy: LockoutPolicy) -> i64 {
+    (policy.max_duration_hours.max(1) * 60 * 60 * 1000).max(60_000)
+}
+
+fn login_failure_audit_metadata(failure_state: &auth_repo::LoginFailureState) -> Value {
+    let mut metadata = json!({
+        "failed_login_attempts": failure_state.failed_login_attempts,
+    });
+    if failure_state.became_locked {
+        metadata["lockout_count"] = json!(failure_state.lockout_count);
+    }
+    metadata
+}
 async fn ensure_password_not_reused(
     pool: &sqlx::PgPool,
     user_id: UserId,
@@ -1704,6 +1826,21 @@ mod tests {
         assert_eq!(password_expiry_warning_days(&user, &config).unwrap(), None);
     }
 
+    #[test]
+    fn login_failure_jitter_stays_in_configured_range() {
+        for _ in 0..32 {
+            let jitter = login_failure_jitter_millis();
+            assert!((LOGIN_FAILURE_JITTER_MIN_MS..=LOGIN_FAILURE_JITTER_MAX_MS).contains(&jitter));
+        }
+    }
+
+    #[test]
+    fn login_audit_result_maps_denied_and_blocked_events() {
+        assert_eq!(login_audit_result("login_failure"), "denied");
+        assert_eq!(login_audit_result("account_lockout"), "blocked");
+        assert_eq!(login_audit_result("login_success"), "success");
+    }
+
     #[tokio::test]
     async fn ensure_password_not_reused_allows_history_zero() {
         let pool = PgPoolOptions::new()
@@ -1792,17 +1929,7 @@ mod tests {
     }
 
     #[test]
-    fn login_failure_jitter_stays_in_configured_range() {
-        for _ in 0..32 {
-            let jitter = login_failure_jitter_millis();
-            assert!((LOGIN_FAILURE_JITTER_MIN_MS..=LOGIN_FAILURE_JITTER_MAX_MS).contains(&jitter));
-        }
-    }
-
-    #[test]
-    fn login_audit_result_maps_denied_and_blocked_events() {
-        assert_eq!(login_audit_result("login_failure"), "denied");
-        assert_eq!(login_audit_result("account_lockout"), "blocked");
+    fn login_audit_result_remains_success_for_non_failure_events() {
         assert_eq!(login_audit_result("login_success"), "success");
     }
 

--- a/backend/src/repositories/auth.rs
+++ b/backend/src/repositories/auth.rs
@@ -454,32 +454,11 @@ pub async fn record_login_failure(
     let threshold = policy.threshold.max(1);
     let next_failed_attempts = failed_attempts + 1;
     if next_failed_attempts >= threshold {
-        let next_lockout_count = lockout_count + 1;
-        let duration = lockout_duration_minutes(next_lockout_count, policy);
-        let next_locked_until = now + chrono::Duration::minutes(duration);
-        sqlx::query(
-            "UPDATE users \
-             SET failed_login_attempts = 0, \
-                 locked_until = $1, \
-                 lock_reason = $2, \
-                 lockout_count = $3, \
-                 updated_at = NOW() \
-             WHERE id = $4",
-        )
-        .bind(next_locked_until)
-        .bind("too_many_failed_attempts")
-        .bind(next_lockout_count)
-        .bind(user_id.to_string())
-        .execute(&mut *tx)
-        .await?;
-
+        let failure_state =
+            persist_lockout_state_with_executor(&mut *tx, user_id, now, policy, lockout_count)
+                .await?;
         tx.commit().await?;
-        Ok(LoginFailureState {
-            failed_login_attempts: 0,
-            locked_until: Some(next_locked_until),
-            lockout_count: next_lockout_count,
-            became_locked: true,
-        })
+        Ok(failure_state)
     } else {
         sqlx::query(
             "UPDATE users \
@@ -499,6 +478,85 @@ pub async fn record_login_failure(
             became_locked: false,
         })
     }
+}
+
+pub async fn persist_lockout_state(
+    pool: &PgPool,
+    user_id: UserId,
+    now: DateTime<Utc>,
+    policy: LockoutPolicy,
+) -> Result<LoginFailureState, sqlx::Error> {
+    let mut tx = pool.begin().await?;
+    let row = sqlx::query_as::<_, (Option<DateTime<Utc>>, i32)>(
+        "SELECT locked_until, lockout_count \
+         FROM users WHERE id = $1 FOR UPDATE",
+    )
+    .bind(user_id.to_string())
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let Some((locked_until, lockout_count)) = row else {
+        tx.rollback().await?;
+        return Ok(LoginFailureState {
+            failed_login_attempts: 0,
+            locked_until: None,
+            lockout_count: 0,
+            became_locked: false,
+        });
+    };
+
+    let is_still_locked = locked_until.map(|until| until > now).unwrap_or(false);
+    if is_still_locked {
+        tx.commit().await?;
+        return Ok(LoginFailureState {
+            failed_login_attempts: 0,
+            locked_until,
+            lockout_count,
+            became_locked: false,
+        });
+    }
+
+    let failure_state =
+        persist_lockout_state_with_executor(&mut *tx, user_id, now, policy, lockout_count).await?;
+    tx.commit().await?;
+    Ok(failure_state)
+}
+
+async fn persist_lockout_state_with_executor<'e, E>(
+    executor: E,
+    user_id: UserId,
+    now: DateTime<Utc>,
+    policy: LockoutPolicy,
+    current_lockout_count: i32,
+) -> Result<LoginFailureState, sqlx::Error>
+where
+    E: sqlx::Executor<'e, Database = Postgres>,
+{
+    let next_lockout_count = current_lockout_count + 1;
+    let duration = lockout_duration_minutes(next_lockout_count, policy);
+    let next_locked_until = now + chrono::Duration::minutes(duration);
+    sqlx::query(
+        "UPDATE users \
+         SET failed_login_attempts = 0, \
+             locked_until = $1, \
+             lock_reason = $2, \
+             lockout_count = $3, \
+             updated_at = NOW() \
+         WHERE id = $4",
+    )
+    .bind(next_locked_until)
+    .bind("too_many_failed_attempts")
+    .bind(next_lockout_count)
+    .bind(user_id.to_string())
+    .execute(executor)
+    .await?;
+
+    Ok(LoginFailureState {
+        failed_login_attempts: 0,
+        locked_until: Some(next_locked_until),
+        lockout_count: next_lockout_count,
+        became_locked: true,
+    })
 }
 
 pub async fn clear_login_failures(pool: &PgPool, user_id: UserId) -> Result<(), sqlx::Error> {

--- a/backend/tests/auth_lockout_redis_integration.rs
+++ b/backend/tests/auth_lockout_redis_integration.rs
@@ -1,0 +1,364 @@
+use axum::{
+    body::Body,
+    http::{header, Request, StatusCode},
+    routing::post,
+    Extension, Router,
+};
+use bb8_redis::redis;
+use sqlx::PgPool;
+use std::{
+    env, fs,
+    net::TcpListener,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::{Arc, OnceLock},
+};
+use testcontainers::{clients::Cli, core::WaitFor, GenericImage, RunnableImage};
+use timekeeper_backend::{
+    config::Config,
+    db::redis::create_redis_pool,
+    handlers::auth,
+    middleware::request_id::RequestId,
+    models::user::UserRole,
+    services::audit_log::{AuditLogService, AuditLogServiceTrait},
+    state::AppState,
+};
+use tower::ServiceExt;
+
+mod support;
+
+static DOCKER_WRAPPER_DIR: OnceLock<PathBuf> = OnceLock::new();
+
+fn allocate_ephemeral_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("read socket addr")
+        .port()
+}
+
+fn ensure_docker_cli() {
+    if env::var("DOCKER_HOST").is_err() {
+        let podman_socket = Path::new("/run/podman/podman.sock");
+        if podman_socket.exists() {
+            env::set_var("DOCKER_HOST", "unix:///run/podman/podman.sock");
+        } else if let Ok(runtime_dir) = env::var("XDG_RUNTIME_DIR") {
+            let path = Path::new(&runtime_dir).join("podman/podman.sock");
+            if path.exists() {
+                if let Some(path_str) = path.to_str() {
+                    env::set_var("DOCKER_HOST", format!("unix://{}", path_str));
+                }
+            }
+        }
+    }
+
+    if Command::new("docker").arg("--version").output().is_ok() {
+        return;
+    }
+    if Command::new("podman").arg("--version").output().is_err() {
+        return;
+    }
+
+    let dir = DOCKER_WRAPPER_DIR.get_or_init(|| {
+        let dir = env::temp_dir().join("timekeeper-testcontainers-docker");
+        let _ = fs::create_dir_all(&dir);
+        dir
+    });
+    let docker_path = dir.join("docker");
+    if !docker_path.exists() {
+        let script = "#!/usr/bin/env sh\nexec podman \"$@\"\n";
+        let _ = fs::write(&docker_path, script);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(metadata) = fs::metadata(&docker_path) {
+                let mut perms = metadata.permissions();
+                perms.set_mode(0o755);
+                let _ = fs::set_permissions(&docker_path, perms);
+            }
+        }
+    }
+
+    let path = env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", dir.display(), path);
+    env::set_var("PATH", new_path);
+}
+
+async fn migrate_db(pool: &PgPool) {
+    sqlx::migrate!("./migrations")
+        .run(pool)
+        .await
+        .expect("run migrations");
+}
+
+async fn integration_guard() -> tokio::sync::MutexGuard<'static, ()> {
+    static GUARD: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    GUARD
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await
+}
+
+fn test_config(redis_url: String) -> Config {
+    let mut config = support::test_config();
+    config.redis_url = Some(redis_url);
+    config.feature_redis_cache_enabled = true;
+    config.account_lockout_threshold = 3;
+    config.account_lockout_duration_minutes = 15;
+    config.account_lockout_backoff_enabled = true;
+    config.account_lockout_max_duration_hours = 24;
+    config
+}
+
+async fn auth_router_with_redis(pool: PgPool, config: Config) -> Router {
+    let redis_pool = create_redis_pool(&config)
+        .await
+        .expect("create redis pool")
+        .expect("redis pool available");
+    let state = AppState::new(pool.clone(), None, Some(redis_pool), None, config);
+    let audit_log_service: Arc<dyn AuditLogServiceTrait> = Arc::new(AuditLogService::new(pool));
+    Router::new()
+        .route("/api/auth/login", post(auth::login))
+        .layer(Extension(RequestId("test-request-id".to_string())))
+        .layer(Extension(audit_log_service))
+        .with_state(state)
+}
+
+async fn fetch_lock_state(
+    pool: &PgPool,
+    user_id: &str,
+) -> (i32, Option<chrono::DateTime<chrono::Utc>>, i32) {
+    sqlx::query_as::<_, (i32, Option<chrono::DateTime<chrono::Utc>>, i32)>(
+        "SELECT failed_login_attempts, locked_until, lockout_count FROM users WHERE id = $1",
+    )
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("fetch lock state")
+}
+
+async fn redis_key_exists(redis_url: &str, user_id: &str) -> bool {
+    let client = redis::Client::open(redis_url).expect("open redis client");
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("connect redis");
+    let exists: i32 = redis::cmd("EXISTS")
+        .arg(format!("auth:login-failures:{user_id}"))
+        .query_async(&mut conn)
+        .await
+        .expect("check redis key");
+    exists != 0
+}
+
+async fn flush_redis(redis_url: &str) {
+    let client = redis::Client::open(redis_url).expect("open redis client");
+    let mut conn = client
+        .get_multiplexed_async_connection()
+        .await
+        .expect("connect redis");
+    let _: () = redis::cmd("FLUSHDB")
+        .query_async(&mut conn)
+        .await
+        .expect("flush redis");
+}
+
+#[tokio::test]
+async fn login_failures_stay_in_redis_until_threshold_is_reached() {
+    let _guard = integration_guard().await;
+    ensure_docker_cli();
+    let docker = Cli::default();
+    let host_port = allocate_ephemeral_port();
+    let image = GenericImage::new("redis", "7-alpine")
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"));
+    let image = RunnableImage::from(image).with_mapped_port((host_port, 6379));
+    let _container = docker.run(image);
+
+    let redis_url = format!("redis://127.0.0.1:{host_port}");
+    flush_redis(&redis_url).await;
+
+    let pool = support::test_pool().await;
+    migrate_db(&pool).await;
+    let user =
+        support::seed_user_with_password(&pool, UserRole::Employee, false, "Correct123!").await;
+    let app = auth_router_with_redis(pool.clone(), test_config(redis_url.clone())).await;
+
+    for attempt in 1..=2 {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "username": user.username.clone(),
+                            "password": "Wrong123!",
+                        })
+                        .to_string(),
+                    ))
+                    .expect("build login request"),
+            )
+            .await
+            .expect("login request");
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "attempt {attempt}"
+        );
+
+        let (failed_attempts, locked_until, lockout_count) =
+            fetch_lock_state(&pool, &user.id.to_string()).await;
+        assert_eq!(failed_attempts, 0, "attempt {attempt}");
+        assert!(locked_until.is_none(), "attempt {attempt}");
+        assert_eq!(lockout_count, 0, "attempt {attempt}");
+        assert!(redis_key_exists(&redis_url, &user.id.to_string()).await);
+    }
+
+    let threshold_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/auth/login")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "username": user.username.clone(),
+                        "password": "Wrong123!",
+                    })
+                    .to_string(),
+                ))
+                .expect("build login request"),
+        )
+        .await
+        .expect("login request");
+    assert_eq!(threshold_response.status(), StatusCode::UNAUTHORIZED);
+
+    let (failed_attempts, locked_until, lockout_count) =
+        fetch_lock_state(&pool, &user.id.to_string()).await;
+    assert_eq!(failed_attempts, 0);
+    assert!(locked_until.is_some());
+    assert_eq!(lockout_count, 1);
+    assert!(!redis_key_exists(&redis_url, &user.id.to_string()).await);
+}
+
+#[tokio::test]
+async fn successful_login_clears_redis_failure_counter() {
+    let _guard = integration_guard().await;
+    ensure_docker_cli();
+    let docker = Cli::default();
+    let host_port = allocate_ephemeral_port();
+    let image = GenericImage::new("redis", "7-alpine")
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"));
+    let image = RunnableImage::from(image).with_mapped_port((host_port, 6379));
+    let _container = docker.run(image);
+
+    let redis_url = format!("redis://127.0.0.1:{host_port}");
+    flush_redis(&redis_url).await;
+
+    let pool = support::test_pool().await;
+    migrate_db(&pool).await;
+    let password = "Correct123!";
+    let user = support::seed_user_with_password(&pool, UserRole::Employee, false, password).await;
+    let app = auth_router_with_redis(pool.clone(), test_config(redis_url.clone())).await;
+
+    let failed_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/auth/login")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "username": user.username.clone(),
+                        "password": "Wrong123!",
+                    })
+                    .to_string(),
+                ))
+                .expect("build failed login request"),
+        )
+        .await
+        .expect("failed login request");
+    assert_eq!(failed_response.status(), StatusCode::UNAUTHORIZED);
+    assert!(redis_key_exists(&redis_url, &user.id.to_string()).await);
+
+    let success_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/auth/login")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "username": user.username.clone(),
+                        "password": password,
+                    })
+                    .to_string(),
+                ))
+                .expect("build success login request"),
+        )
+        .await
+        .expect("success login request");
+    assert_eq!(success_response.status(), StatusCode::OK);
+
+    let (failed_attempts, locked_until, lockout_count) =
+        fetch_lock_state(&pool, &user.id.to_string()).await;
+    assert_eq!(failed_attempts, 0);
+    assert!(locked_until.is_none());
+    assert_eq!(lockout_count, 0);
+    assert!(!redis_key_exists(&redis_url, &user.id.to_string()).await);
+}
+
+#[tokio::test]
+async fn login_falls_back_to_database_when_redis_becomes_unavailable() {
+    let _guard = integration_guard().await;
+    ensure_docker_cli();
+    let docker = Cli::default();
+    let host_port = allocate_ephemeral_port();
+    let image = GenericImage::new("redis", "7-alpine")
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"));
+    let image = RunnableImage::from(image).with_mapped_port((host_port, 6379));
+    let container = docker.run(image);
+
+    let redis_url = format!("redis://127.0.0.1:{host_port}");
+    flush_redis(&redis_url).await;
+
+    let pool = support::test_pool().await;
+    migrate_db(&pool).await;
+    let user =
+        support::seed_user_with_password(&pool, UserRole::Employee, false, "Correct123!").await;
+    let app = auth_router_with_redis(pool.clone(), test_config(redis_url)).await;
+
+    drop(container);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+    for _ in 0..3 {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "username": user.username.clone(),
+                            "password": "Wrong123!",
+                        })
+                        .to_string(),
+                    ))
+                    .expect("build login request"),
+            )
+            .await
+            .expect("login request");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    let (failed_attempts, locked_until, lockout_count) =
+        fetch_lock_state(&pool, &user.id.to_string()).await;
+    assert_eq!(failed_attempts, 0);
+    assert!(locked_until.is_some());
+    assert_eq!(lockout_count, 1);
+}

--- a/docs/generated/exec-plans/active/EP-20260310-issue-288-login-hardening-phase3-redis.md
+++ b/docs/generated/exec-plans/active/EP-20260310-issue-288-login-hardening-phase3-redis.md
@@ -1,0 +1,43 @@
+# EP-20260310-issue-288-login-hardening-phase3-redis
+
+## Goal
+- issue #288 の phase 3 として、ログイン失敗回数の Redis 集約を入れて DB 書き込みを閾値到達時に限定する
+
+## Scope
+- In: `backend/src/handlers/auth.rs`, `backend/src/repositories/auth.rs`, Redis 連携 integration test
+- Out: MQ/worker 導入、監査 result 追加拡張の残り、lockout history 減衰ポリシー
+
+## Done Criteria (Observable)
+- [x] Redis 有効時、閾値未満の login failure では `users.failed_login_attempts` が増えない
+- [x] Redis 有効時、閾値到達時のみ DB に lockout 状態が永続化される
+- [x] 成功ログイン時に Redis 側の失敗カウントが best-effort で消去される
+- [x] Redis 障害時に既存の DB-only path へフォールバックする
+- [x] focused backend test が成功する
+
+## Constraints / Non-goals
+- API レスポンス shape は変えない
+- Redis は pre-threshold の失敗回数だけを保持し、lockout state の source of truth は DB のままにする
+
+## Task Breakdown
+1. [x] `repositories/auth.rs` の lockout 永続化 helper を確定する
+2. [x] `handlers/auth.rs` に Redis failure counter と DB fallback を追加する
+3. [x] Redis integration test で threshold 未満/到達/成功時 clear を固定する
+4. [ ] focused test / fmt / snapshot / PR 作成まで進める
+
+## Validation Plan
+- [x] `cargo test -p timekeeper-backend --lib handlers::auth::tests -- --nocapture`
+- [x] `cargo test -p timekeeper-backend --test auth_flow_api login_locks_account_after_reaching_failure_threshold -- --exact`
+- [x] `cargo test -p timekeeper-backend --test auth_lockout_redis_integration -- --nocapture`
+- [x] `cargo fmt --all`
+- [ ] `cargo clippy -p timekeeper-backend --all-targets -- -D warnings`
+
+## JJ Snapshot Log
+- [x] `jj status`
+- [ ] backend 対象テスト pass
+- [ ] `jj commit -m "feat(security): aggregate login failures in redis"`
+
+## Progress Notes
+- 2026-03-10: phase 2 branch を親にして Redis 集約の実装に着手。`persist_lockout_state()` の下地がローカル差分に残っていることを確認。
+- 2026-03-10: `handlers/auth.rs` に Redis Lua script ベースの failure counter を追加。Redis 障害時は warn を出して既存 DB-only path にフォールバックする構成にした。
+- 2026-03-10: `auth_lockout_redis_integration` を追加し、threshold 未満は DB 非更新、threshold 到達時のみ DB lockout、成功ログイン時の Redis key clear を固定した。
+- 2026-03-10: `cargo clippy -p timekeeper-backend --all-targets -- -D warnings` は `attendance_correction_requests` 系の既存違反で失敗。


### PR DESCRIPTION
## Summary
- move pre-threshold login failure counting into Redis with atomic Lua-based increment/expire
- persist lockout state to Postgres only when the threshold is reached and clear Redis on successful login
- add Redis-backed integration coverage for threshold, lockout persistence, and successful-login cache clear

## Validation
- cargo test -p timekeeper-backend --lib handlers::auth::tests -- --nocapture
- cargo test -p timekeeper-backend --test auth_flow_api login_locks_account_after_reaching_failure_threshold -- --exact
- cargo test -p timekeeper-backend --test auth_lockout_redis_integration -- --nocapture
- cargo fmt --all

## Notes
- follow-up for issue #288
- cargo clippy -p timekeeper-backend --all-targets -- -D warnings still fails on pre-existing attendance_correction_requests warnings