### PR TITLE
feat(i18n): localize admin frontend pages

### DIFF
--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -518,13 +518,28 @@ pages:
   home: {}
 
 admin_components:
-  attendance: {}
-  holidays: {}
+  attendance:
+    fields:
+      target_date: "Target Date"
+  holidays:
+    fields:
+      date: "Date"
+    filters:
+      from: "Start Date"
+      to: "End Date"
   requests: {}
   subject_requests: {}
   system_tools: {}
-  user_select: {}
-  weekly_holidays: {}
+  user_select:
+    placeholder: "Select a user"
+    loading: "Loading users..."
+    fetch_failed: "Failed to load users"
+    empty: "No users found"
+  weekly_holidays:
+    fields:
+      starts_on: "Effective Start Date"
+      ends_on: "Effective End Date (Optional)"
+    title: "Weekly Holidays"
 
 api:
   errors: {}

--- a/frontend/locales/ja.yml
+++ b/frontend/locales/ja.yml
@@ -518,13 +518,28 @@ pages:
   home: {}
 
 admin_components:
-  attendance: {}
-  holidays: {}
+  attendance:
+    fields:
+      target_date: "対象日"
+  holidays:
+    fields:
+      date: "日付"
+    filters:
+      from: "開始日"
+      to: "終了日"
   requests: {}
   subject_requests: {}
   system_tools: {}
-  user_select: {}
-  weekly_holidays: {}
+  user_select:
+    placeholder: "ユーザーを選択"
+    loading: "ユーザーを読み込み中..."
+    fetch_failed: "ユーザーの取得に失敗しました"
+    empty: "ユーザーが0件です"
+  weekly_holidays:
+    fields:
+      starts_on: "稼働開始日"
+      ends_on: "稼働終了日（任意）"
+    title: "週次休日"
 
 api:
   errors: {}

--- a/frontend/src/pages/admin/components/attendance.rs
+++ b/frontend/src/pages/admin/components/attendance.rs
@@ -423,7 +423,7 @@ pub fn AdminAttendanceToolsSection(
                         placeholder="ユーザーを選択してください".into()
                     />
                     <DatePicker
-                        label=Some("対象日")
+                        label=Some("admin_components.attendance.fields.target_date")
                         value=att_date
                     />
                     <input type="datetime-local" class="w-full border border-form-control-border bg-form-control-bg text-form-control-text rounded px-2 py-1" on:input=move |ev| set_input_signal(att_in, event_target_value(&ev)) />

--- a/frontend/src/pages/admin/components/holidays.rs
+++ b/frontend/src/pages/admin/components/holidays.rs
@@ -689,7 +689,7 @@ pub fn HolidayManagementSection(
             <h3 class="text-lg font-medium text-fg">{"祝日管理"}</h3>
             <form class="grid gap-3 lg:grid-cols-3" on:submit=on_create_holiday>
                 <DatePicker
-                    label=Some("日付")
+                    label=Some("admin_components.holidays.fields.date")
                     value=holiday_date_input
                 />
                 <div>
@@ -741,11 +741,11 @@ pub fn HolidayManagementSection(
                 </div>
                 <div class="grid gap-3 lg:grid-cols-4 align-bottom">
                     <DatePicker
-                        label=Some("開始日")
+                        label=Some("admin_components.holidays.filters.from")
                         value=filter_from_input
                     />
                     <DatePicker
-                        label=Some("終了日")
+                        label=Some("admin_components.holidays.filters.to")
                         value=filter_to_input
                     />
                     <div class="lg:col-span-2 flex items-end gap-2 mb-0.5">

--- a/frontend/src/pages/admin/components/weekly_holidays.rs
+++ b/frontend/src/pages/admin/components/weekly_holidays.rs
@@ -120,7 +120,9 @@ pub fn WeeklyHolidaySection(
         <div class="bg-surface-elevated shadow rounded-lg p-6 space-y-4">
             <div class="flex flex-col gap-1 lg:flex-row lg:items-center lg:justify-between">
                 <div>
-                    <h2 class="text-lg font-semibold text-fg">{"週次休日"}</h2>
+                    <h2 class="text-lg font-semibold text-fg">
+                        {rust_i18n::t!("admin_components.weekly_holidays.title")}
+                    </h2>
                     <p class="text-sm text-fg-muted">
                         {"週単位の休日を登録します。システム管理者は即日開始も設定できます。"}
                     </p>
@@ -157,7 +159,7 @@ pub fn WeeklyHolidaySection(
                 </div>
                 <div class="lg:col-span-1">
                     <DatePicker
-                        label=Some("稼働開始日")
+                        label=Some("admin_components.weekly_holidays.fields.starts_on")
                         value=starts_on_signal
                     />
                     <p class="text-xs text-fg-muted mt-1">
@@ -166,7 +168,7 @@ pub fn WeeklyHolidaySection(
                 </div>
                 <div class="lg:col-span-1">
                     <DatePicker
-                        label=Some("稼働終了日（任意）")
+                        label=Some("admin_components.weekly_holidays.fields.ends_on")
                         value=ends_on_signal
                     />
                 </div>
@@ -319,14 +321,14 @@ mod host_tests {
     #[test]
     fn weekly_holiday_section_renders_empty_state() {
         let html = render_with_resource(Vec::new(), true, false);
-        assert!(html.contains("週次休日"));
+        assert!(html.contains(rust_i18n::t!("admin_components.weekly_holidays.title").as_ref()));
         assert!(html.contains("登録済みの週次休日はありません。"));
     }
 
     #[test]
     fn weekly_holiday_section_renders_table() {
         let html = render_with_resource(vec![sample_item()], true, true);
-        assert!(html.contains("週次休日"));
+        assert!(html.contains(rust_i18n::t!("admin_components.weekly_holidays.title").as_ref()));
         assert!(html.contains("月"));
     }
 

--- a/frontend/src/pages/admin/panel.rs
+++ b/frontend/src/pages/admin/panel.rs
@@ -82,16 +82,17 @@ pub fn AdminPanel() -> impl IntoView {
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod host_tests {
     use super::*;
-    use crate::test_support::helpers::{admin_user, provide_auth};
+    use crate::test_support::helpers::{admin_user, provide_auth, set_test_locale};
     use crate::test_support::ssr::render_with_router_to_string;
 
     #[test]
     fn admin_panel_renders_sections_for_admin() {
+        let _locale = set_test_locale("ja");
         let html = render_with_router_to_string("http://localhost/", move || {
             provide_auth(Some(admin_user(true)));
             view! { <AdminPanel /> }
         });
-        assert!(html.contains("管理者ツール"));
-        assert!(html.contains("週次休日"));
+        assert!(html.contains(rust_i18n::t!("pages.admin.title").as_ref()));
+        assert!(html.contains(rust_i18n::t!("admin_components.weekly_holidays.title").as_ref()));
     }
 }


### PR DESCRIPTION
## Summary
- localize admin tools, admin export, audit logs, and admin users pages
- add admin-focused locale keys in `frontend/locales/en.yml` and `frontend/locales/ja.yml`
- update admin UI tests to assert translated copy through fixed locales

## Validation
- cargo fmt --all --check
- cargo clippy -p timekeeper-frontend --all-targets -- -D warnings
- cargo test -p timekeeper-frontend admin_view_model -- --nocapture --test-threads=1
- cargo test -p timekeeper-frontend admin_export -- --nocapture --test-threads=1
- cargo test -p timekeeper-frontend admin_audit_logs -- --nocapture --test-threads=1
- cargo test -p timekeeper-frontend admin_users -- --nocapture --test-threads=1

Stacked on #431
Refs #429