### PR TITLE
fix(frontend): preserve locale in SSR tests

### DIFF
--- a/frontend/src/state/locale.rs
+++ b/frontend/src/state/locale.rs
@@ -23,10 +23,18 @@ impl Default for LocaleState {
 }
 
 fn create_locale_context() -> LocaleContext {
-    let initial = resolve_initial_locale(
-        load_persisted_locale().as_deref(),
-        browser_locale().as_deref(),
-    );
+    let persisted = load_persisted_locale();
+    let browser = browser_locale();
+    let current = current_global_locale();
+    let initial = if persisted.is_some() || browser.is_some() {
+        resolve_initial_locale(persisted.as_deref(), browser.as_deref())
+    } else {
+        current
+            .as_deref()
+            .map(normalize_locale)
+            .unwrap_or(DEFAULT_LOCALE)
+            .to_string()
+    };
     rust_i18n::set_locale(&initial);
     create_signal(LocaleState { current: initial })
 }
@@ -91,6 +99,11 @@ pub fn available_locales() -> Vec<String> {
         .collect()
 }
 
+fn current_global_locale() -> Option<String> {
+    let current = rust_i18n::locale().to_string();
+    (!current.trim().is_empty()).then_some(current)
+}
+
 fn load_persisted_locale() -> Option<String> {
     get_local_storage_item(LOCALE_STORAGE_KEY).ok().flatten()
 }
@@ -150,8 +163,8 @@ mod tests {
         let _locale = set_test_locale("ja");
         with_runtime(|| {
             let (read, _write) = create_locale_context();
-            assert_eq!(read.get().current, "en");
-            assert_eq!(rust_i18n::locale().to_string(), "en");
+            assert_eq!(read.get().current, "ja");
+            assert_eq!(rust_i18n::locale().to_string(), "ja");
         });
     }
 
@@ -160,6 +173,16 @@ mod tests {
         with_runtime(|| {
             let (read, _write) = use_locale();
             assert_eq!(read.get().current, "en");
+        });
+    }
+
+    #[test]
+    fn use_locale_without_context_preserves_existing_global_locale() {
+        let _locale = set_test_locale("ja");
+        with_runtime(|| {
+            let (read, _write) = use_locale();
+            assert_eq!(read.get().current, "ja");
+            assert_eq!(rust_i18n::locale().to_string(), "ja");
         });
     }
 

--- a/frontend/src/test_support/ssr.rs
+++ b/frontend/src/test_support/ssr.rs
@@ -1,6 +1,8 @@
 use leptos::*;
 use leptos_router::{Router, RouterIntegrationContext, ServerIntegration};
 
+use crate::state::locale::LocaleProvider;
+
 pub fn with_runtime<T>(f: impl FnOnce() -> T) -> T {
     let runtime = leptos::create_runtime();
     let result = f();
@@ -50,9 +52,11 @@ where
     render_to_string(move || {
         provide_context(RouterIntegrationContext::new(ServerIntegration { path }));
         view! {
-            <Router>
-                {view()}
-            </Router>
+            <LocaleProvider>
+                <Router>
+                    {view()}
+                </Router>
+            </LocaleProvider>
         }
     })
 }


### PR DESCRIPTION
## Summary
- keep the existing rust_i18n locale when locale context is created without persisted/browser state
- wrap SSR router test rendering with LocaleProvider so host tests match the real app tree
- add locale fallback coverage for the missing-provider path

## Testing
- cargo fmt --all --check
- cargo test -p timekeeper-frontend admin_panel_renders_sections_for_admin
- cargo test -p timekeeper-frontend use_locale_without_context_preserves_existing_global_locale
- cargo test -p timekeeper-frontend admin_dashboard_scaffold_switches_content
- cargo test -p timekeeper-frontend header_renders_locale_switcher_in_english