### PR TITLE
fix(frontend): treat missing active breaks as empty state

### DIFF
--- a/frontend/src/api/attendance.rs
+++ b/frontend/src/api/attendance.rs
@@ -314,6 +314,9 @@ impl ApiClient {
                 .json()
                 .await
                 .map_err(|e| ApiError::unknown(format!("Failed to parse response: {}", e)))
+        } else if status == reqwest::StatusCode::NOT_FOUND {
+            // The backend uses 404 when there are no active breaks to force-end.
+            Ok(Vec::new())
         } else {
             let error: ApiError = response
                 .json()

--- a/frontend/src/api/tests.rs
+++ b/frontend/src/api/tests.rs
@@ -909,6 +909,26 @@ async fn api_client_get_me_masks_parse_error_details() {
 }
 
 #[tokio::test]
+async fn api_client_admin_list_active_breaks_returns_empty_list_on_not_found() {
+    let server = MockServer::start_async().await;
+
+    server.mock(|when, then| {
+        when.method(GET).path("/api/admin/breaks/active");
+        then.status(404).json_body(serde_json::json!({
+            "error": "進行中の休憩はありません",
+            "code": "NOT_FOUND"
+        }));
+    });
+
+    let client = api_client(&server);
+    let active_breaks = client
+        .admin_list_active_breaks()
+        .await
+        .expect("404 active breaks should be treated as empty");
+    assert!(active_breaks.is_empty());
+}
+
+#[tokio::test]
 async fn api_client_refresh_override_can_return_error() {
     let client = ApiClient::new_with_base_url("http://127.0.0.1:9/api");
     super::auth::queue_refresh_override(

--- a/frontend/src/pages/admin/repository.rs
+++ b/frontend/src/pages/admin/repository.rs
@@ -411,6 +411,25 @@ mod host_tests {
         repo.delete_holiday("h1").await.unwrap();
         assert_eq!(repo.fetch_users().await.unwrap().len(), 1);
     }
+
+    #[tokio::test]
+    async fn admin_repository_list_active_breaks_returns_empty_list_on_not_found() {
+        let server = MockServer::start_async().await;
+        server.mock(|when, then| {
+            when.method(GET).path("/api/admin/breaks/active");
+            then.status(404).json_body(serde_json::json!({
+                "error": "進行中の休憩はありません",
+                "code": "NOT_FOUND"
+            }));
+        });
+
+        let repo = repo(&server);
+        let active_breaks = repo
+            .list_active_breaks()
+            .await
+            .expect("404 active breaks should be treated as empty");
+        assert!(active_breaks.is_empty());
+    }
 }
 
 fn convert_admin_holiday_item(item: AdminHolidayListItem) -> Option<HolidayResponse> {


### PR DESCRIPTION
## Summary
- treat `GET /api/admin/breaks/active` returning `404 Not Found` as a normal empty state
- keep the admin break force-end UI on the existing empty-state message instead of surfacing an error
- add regression tests at the API and repository seams for the 404 case

## Validation
- `cargo fmt --all --check`
- `cargo test -p timekeeper-frontend api_client_admin_list_active_breaks_returns_empty_list_on_not_found`
- `cargo test -p timekeeper-frontend admin_repository_list_active_breaks_returns_empty_list_on_not_found`

Closes #438
